### PR TITLE
Add copy to clipboard for aliases

### DIFF
--- a/_includes/themes/bootstrap/default.html
+++ b/_includes/themes/bootstrap/default.html
@@ -22,6 +22,8 @@ lantoniotrento@gmail.com
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
       <link href="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.css" rel="stylesheet">
       <link href="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/group-by-v2/bootstrap-table-group-by.css" rel="stylesheet">
+      <!-- https://primer.style/css/components/tooltips -->
+      <link href="https://unpkg.com/@primer/css@^16.0.0/dist/primer.css" rel="stylesheet" />
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
 

--- a/assets/css/appstore.css
+++ b/assets/css/appstore.css
@@ -6,3 +6,15 @@
 .table-appstore > tbody > tr > td {
     text-align: left;
 }
+
+/* button styling */
+.copyButton {
+    border: none;
+    cursor: pointer;
+    outline: none;
+    margin-left: 5px;
+    background-color: transparent;
+}
+.copyButton:hover {
+    opacity: 0.8;
+}

--- a/notappstore.html
+++ b/notappstore.html
@@ -62,8 +62,10 @@ function groupByFormatter(item,index,rows) {
         + " " + starFormatter(item, row, index);
 }
 function aliasFormatter(value, row, index) {
-  var output = "<code>" + row.command + "</code>";
-    output = output + "<button class='tooltipped tooltipped-sw copyButton' aria-label='Copy jbang command to clipboard'  data-clipboard-text='jbang " + row.command +"'><i class='fa fa-copy'></i></button>";
+  var output;
+
+  output = "<button class='tooltipped tooltipped-sw copyButton' aria-label='Copy jbang command to clipboard'  data-clipboard-text='jbang " + row.command +"'><i class='fa fa-clipboard'></i></button>";
+  output = output + " <code>" + row.command + "</code>";
   if(row.description) {
      output = output  + "<div style='white-space: pre-wrap'>" + row.description + "</div>";
   }

--- a/notappstore.html
+++ b/notappstore.html
@@ -45,6 +45,7 @@ files for Bootstrap -->
             src="https://code.jquery.com/jquery-3.6.0.min.js"
             crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js"></script>
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/group-by-v2/bootstrap-table-group-by.min.js"></script>
     <script>
@@ -61,8 +62,8 @@ function groupByFormatter(item,index,rows) {
         + " " + starFormatter(item, row, index);
 }
 function aliasFormatter(value, row, index) {
-  var output = "<code>jbang " + row.command + "</code>";
-  
+  var output = "<code>" + row.command + "</code>";
+    output = output + "<button class='tooltipped tooltipped-sw copyButton' aria-label='Copy jbang command to clipboard'  data-clipboard-text='jbang " + row.command +"'><i class='fa fa-copy'></i></button>";
   if(row.description) {
      output = output  + "<div style='white-space: pre-wrap'>" + row.description + "</div>";
   }
@@ -101,6 +102,9 @@ function starFormatter(value, row, index) {
         </thead>
     </table>
 
+        <script>
+            var clipboard = new ClipboardJS('.copyButton');
+        </script>
 </div>
 </div>
 


### PR DESCRIPTION
Removes `jbang` prefix and adds copy to clipboard button next to each aliases. It will copy `jbang <alias>` to clipboard.

![image](https://user-images.githubusercontent.com/877286/117588255-37d0c300-b0f0-11eb-9513-c2dbd284949e.png)
