### PR TITLE
fix: set copy tooltip to se direction

### DIFF
--- a/notappstore.html
+++ b/notappstore.html
@@ -64,7 +64,7 @@ function groupByFormatter(item,index,rows) {
 function aliasFormatter(value, row, index) {
   var output;
 
-  output = "<button class='tooltipped tooltipped-sw copyButton' aria-label='Copy jbang command to clipboard'  data-clipboard-text='jbang " + row.command +"'><i class='fa fa-clipboard'></i></button>";
+  output = "<button class='tooltipped tooltipped-se copyButton' aria-label='Copy jbang command to clipboard'  data-clipboard-text='jbang " + row.command +"'><i class='fa fa-clipboard'></i></button>";
   output = output + " <code>" + row.command + "</code>";
   if(row.description) {
      output = output  + "<div style='white-space: pre-wrap'>" + row.description + "</div>";


### PR DESCRIPTION
Tooltip is getting hidden. Moving it to right side.

![image](https://user-images.githubusercontent.com/877286/117588670-fa216980-b0f2-11eb-919c-d1696a48aebe.png)
