### PR TITLE
Fix: incorrect rendering of tabs

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons"/>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@2.5.0/dist/vuetify.min.css"/>
 <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js"></script>
-<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue@2"></script>
 <script src="https://cdn.jsdelivr.net/npm/vuetify@2.5.0/dist/vuetify.min.js"></script>
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 


### PR DESCRIPTION
The site seems to use Vue.js. The default version of Vue is 3.0 and there are a few features from Vue2 that we rely on. So, updating the CDN to pull from v2 of Vue. This is for issue #40 