### PR TITLE
feat: replace Vue 2 + Vuetify 2 with Oat UI + vanilla JS

### DIFF
--- a/content/appstore.html
+++ b/content/appstore.html
@@ -66,10 +66,7 @@ data-field: aliases
     </div>
 </div>
 
-<!-- Toast for copy feedback -->
-<div id="copy-toast" class="toast" data-variant="success" style="display:none">
-    Copied to clipboard!
-</div>
+
 
 <script>
 (function() {
@@ -85,7 +82,7 @@ data-field: aliases
     const contentEl = document.getElementById('appstore-content');
     const groupsEl = document.getElementById('appstore-groups');
     const paginationEl = document.getElementById('appstore-pagination').querySelector('menu');
-    const toastEl = document.getElementById('copy-toast');
+
 
     // Read ?q= from URL
     const params = new URLSearchParams(window.location.search);
@@ -228,22 +225,19 @@ data-field: aliases
         groupsEl.scrollIntoView({behavior: 'smooth', block: 'start'});
     });
 
-    // Copy clicks (delegated)
+    // Copy clicks (delegated) — click button, code, or anywhere in the alias row
     groupsEl.addEventListener('click', function(e) {
-        const btn = e.target.closest('.appstore-copy');
+        const cell = e.target.closest('.appstore-alias-cell');
+        if (!cell) return;
+        // Don't copy when clicking links in descriptions
+        if (e.target.closest('a')) return;
+        const btn = cell.querySelector('.appstore-copy');
         if (!btn) return;
         const cmd = btn.dataset.cmd;
         navigator.clipboard.writeText(cmd).then(() => {
-            showToast('Copied: ' + cmd);
+            if (window.showCopyToast) window.showCopyToast('Copied: ' + cmd);
         });
     });
-
-    function showToast(msg) {
-        toastEl.textContent = msg;
-        toastEl.style.display = 'block';
-        clearTimeout(toastEl._timer);
-        toastEl._timer = setTimeout(() => { toastEl.style.display = 'none'; }, 2500);
-    }
 
     function pageRange(current, total) {
         if (total <= 7) return Array.from({length: total}, (_, i) => i + 1);

--- a/content/appstore.html
+++ b/content/appstore.html
@@ -13,17 +13,21 @@ total-field: aliasCount
 data-field: aliases
 ---
 
+<link rel="stylesheet" href="https://unpkg.com/@knadh/oat@0.6.1/oat.min.css"/>
+<script src="https://unpkg.com/@knadh/oat@0.6.1/oat.min.js" defer></script>
+<link rel="stylesheet" href="/assets/css/appstore.css"/>
+
 <h2>JBang AppStore</h2>
 <div>
     Below is an index of JBang {page.data.thing-plural} available on GitHub in <a href="https://www.jbang.dev/documentation/jbang/latest/alias_catalogs.html#catalogs">JBang Catalogs.</a><br/><br/>
 
     To use it, <a href="/download">Download or Install</a> JBang or run the following command from any bash compatible terminal:
     <br/><br/>
-    <center><code style="font-size:25px;">curl -Ls https://sh.jbang.dev | bash -s - app setup</code></center>
+    <div style="text-align:center"><code style="font-size:25px;">curl -Ls https://sh.jbang.dev | bash -s - app setup</code></div>
     <br/>
     or in a Windows Powershell:
-    <br/></br/>
-    <center><code style="font-size:25px;">iex "& { $(iwr https://ps.jbang.dev) } app setup"</code></center>
+    <br/><br/>
+    <div style="text-align:center"><code style="font-size:25px;">iex "& { $(iwr https://ps.jbang.dev) } app setup"</code></div>
     <br/>
     <br/><br/>
     {page.data.tip-help.raw}
@@ -33,95 +37,231 @@ data-field: aliases
 </div>
 
 {|
-<div id="app">
-    <v-app id="inspire">
-        <v-layout child-flex>
-            <v-card width="100vw">
-                <v-card-title>
-                    AppStore
-                    <v-spacer></v-spacer>
-                    <v-text-field
-                        v-model="search"
-                        append-icon="mdi-magnify"
-                        label="Search"
-                        single-line
-                        hide-details
-                    ></v-text-field>
-                </v-card-title>
-                <v-data-table
-                    :headers="headers"
-                    :items="appstore.aliases"
-                    :search="search"
-                    group-by="link"
-                    item-key="command"
-                    :sort-desc="false"
-                    class="elevation-1"
-                    disable-pagination
-                    hide-default-footer
-                >
-                    <template v-slot:group.header="{items, isOpen, toggle}">
-                        <th colspan="2">
-                            <h2>
-                                <v-icon @click="toggle"
-                                >{{ isOpen ? 'mdi-minus' : 'mdi-plus' }}
-                                </v-icon>
-                                <a v-bind:href="items[0].link"><img style='width: 5vw;' v-bind:src='items[0].icon_url'/>
-                                    <i class="fab fa-fw fa-github"></i>
-                                    {{items[0].repoOwner}}/{{items[0].repoName}}</a>
-                                <span v-if="items[0].stars>0"><i class='fa fa-star'></i>{{items[0].stars}}</span>
-                            </h2>
-                        </th>
-                    </template>
+<div id="appstore">
+    <!-- Search -->
+    <div class="appstore-toolbar">
+        <input type="text" id="appstore-search" placeholder="Search aliases..." autofocus />
+        <span id="appstore-count" class="badge"></span>
+    </div>
 
-                    <template v-slot:item.command="{ item }">
-                        <button class='tooltipped tooltipped-se copyButton' aria-label='Copy jbang command to clipboard'  v-bind:data-clipboard-text='item.fullcommand'><i class='fa fa-clipboard'></i></button>
-                        <code>{{item.command}}</code>
-                        <div v-if="item.description" v-html="item.description" style='white-space: pre-wrap'>
-                        </div>
+    <!-- Loading -->
+    <div id="appstore-loading" class="appstore-loading">
+        <div class="spinner"></div>
+        <p>Loading catalog…</p>
+    </div>
 
-                    </template>
-                </v-data-table>
-            </v-card>
-        </v-layout>
-    </v-app>
+    <!-- Error -->
+    <div id="appstore-error" class="alert" data-variant="danger" style="display:none">
+        Failed to load the AppStore catalog. Please try refreshing the page.
+    </div>
 
+    <!-- Content -->
+    <div id="appstore-content" style="display:none">
+        <div id="appstore-groups"></div>
+
+        <!-- Pagination -->
+        <nav id="appstore-pagination" aria-label="Pagination" style="margin-top:1rem">
+            <menu></menu>
+        </nav>
+    </div>
 </div>
 
+<!-- Toast for copy feedback -->
+<div id="copy-toast" class="toast" data-variant="success" style="display:none">
+    Copied to clipboard!
+</div>
 
 <script>
-    new Vue({
-        el: "#app",
-        vuetify: new Vuetify(),
-        data() {
-            return {
-                search: '',
-                headers: [{
-                    text: "Alias",
-                    value: "command",
-                    width: "50%"
-                },
-                    {
-                        text: "link",
-                        value: "link",
-                    }
-                ],
-                appstore: []
+(function() {
+    const ITEMS_PER_PAGE = 20; // groups per page
+    let allGroups = [];       // [{repo, icon, owner, name, stars, link, aliases: [...]}]
+    let filteredGroups = [];
+    let currentPage = 1;
+
+    const searchInput = document.getElementById('appstore-search');
+    const countBadge = document.getElementById('appstore-count');
+    const loadingEl = document.getElementById('appstore-loading');
+    const errorEl = document.getElementById('appstore-error');
+    const contentEl = document.getElementById('appstore-content');
+    const groupsEl = document.getElementById('appstore-groups');
+    const paginationEl = document.getElementById('appstore-pagination').querySelector('menu');
+    const toastEl = document.getElementById('copy-toast');
+
+    // Read ?q= from URL
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('q')) {
+        searchInput.value = params.get('q');
+    }
+
+    // Fetch data
+    fetch('/assets/data/jbang-appstore.json')
+        .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+        .then(data => {
+            allGroups = groupByRepo(data.aliases || []);
+            loadingEl.style.display = 'none';
+            contentEl.style.display = 'block';
+            applyFilter();
+        })
+        .catch(() => {
+            loadingEl.style.display = 'none';
+            errorEl.style.display = 'block';
+        });
+
+    // Group aliases by repo
+    function groupByRepo(aliases) {
+        const map = new Map();
+        for (const a of aliases) {
+            const key = a.repoOwner + '/' + a.repoName;
+            if (!map.has(key)) {
+                map.set(key, {
+                    repo: key,
+                    icon: a.icon_url,
+                    owner: a.repoOwner,
+                    name: a.repoName,
+                    stars: a.stars || 0,
+                    link: 'https://github.com/' + key,
+                    aliases: []
+                });
             }
-        },
-        mounted: function() {
-            axios
-                .get('/assets/data/jbang-appstore.json')
-                .then(response => {
-                    this.appstore = response.data
-                })
-                .catch(function (error) {
-                    console.log(error);
-                })
+            map.get(key).aliases.push(a);
         }
-    })
-</script>
+        return Array.from(map.values());
+    }
 
-<script>
-    var clipboard = new ClipboardJS('.copyButton');
+    // Search
+    searchInput.addEventListener('input', function() {
+        currentPage = 1;
+        applyFilter();
+        // Update URL without reload
+        const url = new URL(window.location);
+        if (this.value) url.searchParams.set('q', this.value);
+        else url.searchParams.delete('q');
+        history.replaceState(null, '', url);
+    });
+
+    function applyFilter() {
+        const q = searchInput.value.toLowerCase().trim();
+        if (!q) {
+            filteredGroups = allGroups;
+        } else {
+            filteredGroups = [];
+            for (const g of allGroups) {
+                const matchingAliases = g.aliases.filter(a =>
+                    a.command.toLowerCase().includes(q) ||
+                    (a.description && a.description.toLowerCase().includes(q)) ||
+                    g.repo.toLowerCase().includes(q)
+                );
+                if (matchingAliases.length > 0) {
+                    filteredGroups.push({...g, aliases: matchingAliases});
+                }
+            }
+        }
+        const totalAliases = filteredGroups.reduce((sum, g) => sum + g.aliases.length, 0);
+        countBadge.textContent = totalAliases + ' aliases in ' + filteredGroups.length + ' repos';
+        render();
+    }
+
+    function render() {
+        const totalPages = Math.max(1, Math.ceil(filteredGroups.length / ITEMS_PER_PAGE));
+        if (currentPage > totalPages) currentPage = totalPages;
+
+        const start = (currentPage - 1) * ITEMS_PER_PAGE;
+        const pageGroups = filteredGroups.slice(start, start + ITEMS_PER_PAGE);
+
+        // Render groups
+        groupsEl.innerHTML = pageGroups.map(g => `
+            <details class="appstore-group" open>
+                <summary>
+                    <span class="appstore-repo-header">
+                        <img src="${esc(g.icon)}" alt="" width="32" height="32" loading="lazy"/>
+                        <a href="${esc(g.link)}">
+                            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: text-bottom; margin-right: 2px"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                            ${esc(g.owner)}/${esc(g.name)}
+                        </a>
+                        ${g.stars > 0 ? `<span class="appstore-stars" title="${g.stars} stars">★ ${g.stars.toLocaleString()}</span>` : ''}
+                    </span>
+                </summary>
+                <div class="table">
+                    <table>
+                        <tbody>
+                            ${g.aliases.map(a => `
+                            <tr>
+                                <td class="appstore-alias-cell">
+                                    <button class="appstore-copy outline small" title="Copy jbang command" data-cmd="${esc(a.fullcommand)}">
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                                    </button>
+                                    <code>${esc(a.command)}</code>
+                                    ${a.description ? `<div class="appstore-desc">${a.description}</div>` : ''}
+                                </td>
+                            </tr>`).join('')}
+                        </tbody>
+                    </table>
+                </div>
+            </details>
+        `).join('');
+
+        // Render pagination
+        if (totalPages <= 1) {
+            paginationEl.innerHTML = '';
+        } else {
+            let html = '';
+            html += `<li><button class="button outline small" ${currentPage === 1 ? 'disabled' : ''} data-page="${currentPage - 1}">&larr; Prev</button></li>`;
+            const range = pageRange(currentPage, totalPages);
+            for (const p of range) {
+                if (p === '...') {
+                    html += `<li><span class="button outline small" style="pointer-events:none">…</span></li>`;
+                } else {
+                    html += `<li><button class="button ${p === currentPage ? '' : 'outline'} small" data-page="${p}" ${p === currentPage ? 'aria-current="page"' : ''}>${p}</button></li>`;
+                }
+            }
+            html += `<li><button class="button outline small" ${currentPage === totalPages ? 'disabled' : ''} data-page="${currentPage + 1}">Next &rarr;</button></li>`;
+            paginationEl.innerHTML = html;
+        }
+    }
+
+    // Pagination clicks
+    document.getElementById('appstore-pagination').addEventListener('click', function(e) {
+        const btn = e.target.closest('[data-page]');
+        if (!btn || btn.disabled) return;
+        currentPage = parseInt(btn.dataset.page);
+        render();
+        groupsEl.scrollIntoView({behavior: 'smooth', block: 'start'});
+    });
+
+    // Copy clicks (delegated)
+    groupsEl.addEventListener('click', function(e) {
+        const btn = e.target.closest('.appstore-copy');
+        if (!btn) return;
+        const cmd = btn.dataset.cmd;
+        navigator.clipboard.writeText(cmd).then(() => {
+            showToast('Copied: ' + cmd);
+        });
+    });
+
+    function showToast(msg) {
+        toastEl.textContent = msg;
+        toastEl.style.display = 'block';
+        clearTimeout(toastEl._timer);
+        toastEl._timer = setTimeout(() => { toastEl.style.display = 'none'; }, 2500);
+    }
+
+    function pageRange(current, total) {
+        if (total <= 7) return Array.from({length: total}, (_, i) => i + 1);
+        const pages = [];
+        pages.push(1);
+        if (current > 3) pages.push('...');
+        for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) pages.push(i);
+        if (current < total - 2) pages.push('...');
+        pages.push(total);
+        return pages;
+    }
+
+    function esc(s) {
+        if (!s) return '';
+        const d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+})();
 </script>
 |}

--- a/content/download.html
+++ b/content/download.html
@@ -5,6 +5,8 @@ link: /download/
 layout: splash
 ---
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css"/>
+
 {|
 <h2>Download JBang</h2>
 
@@ -22,17 +24,17 @@ layout: splash
 }
 
 .tab-button {
-  padding: 16px 24px;
+  padding: 10px 14px;
   background: #f5f5f5;
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.85rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  min-width: 100px;
+  gap: 4px;
+  min-width: 80px;
   text-align: center;
 }
 
@@ -65,27 +67,10 @@ pre {
   background: #fff;
   padding: 15px;
   border-radius: 5px;
-  cursor: pointer;
-  position: relative;
 }
 
 pre:hover {
   background: #f5f5f5;
-}
-
-pre::after {
-  content: "Click to copy";
-  position: absolute;
-  right: 10px;
-  top: 5px;
-  font-size: 12px;
-  color: #666;
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-pre:hover::after {
-  opacity: 1;
 }
 </style>
 
@@ -314,21 +299,6 @@ document.addEventListener('DOMContentLoaded', function() {
   document.querySelectorAll('.tab-button').forEach(button => {
     button.addEventListener('click', () => {
       switchTab(button.dataset.tab);
-    });
-  });
-
-  // Add click handlers to all pre elements for copying
-  document.querySelectorAll('pre').forEach(pre => {
-    pre.addEventListener('click', () => {
-      const text = pre.textContent;
-      navigator.clipboard.writeText(text).then(() => {
-        // Visual feedback
-        const originalBg = pre.style.background;
-        pre.style.background = '#e6ffe6';
-        setTimeout(() => {
-          pre.style.background = originalBg;
-        }, 200);
-      });
     });
   });
 

--- a/content/ide.html
+++ b/content/ide.html
@@ -8,6 +8,7 @@ excerpt: "The following IDEs today have support for JBang via a plugin - no addi
 
 <link rel="stylesheet" href="https://unpkg.com/@knadh/oat@0.6.1/oat.min.css"/>
 <script src="https://unpkg.com/@knadh/oat@0.6.1/oat.min.js" defer></script>
+<style>/* Force light mode for Oat CSS */ :root { color-scheme: light; }</style>
 
 <h2>JBang IDE Support</h2>
 <div class="container">

--- a/content/ide.html
+++ b/content/ide.html
@@ -5,202 +5,167 @@ link: /ide/
 layout: splash
 excerpt: "The following IDEs today have support for JBang via a plugin - no additional setup needed!"
 ---
+
+<link rel="stylesheet" href="https://unpkg.com/@knadh/oat@0.6.1/oat.min.css"/>
+<script src="https://unpkg.com/@knadh/oat@0.6.1/oat.min.js" defer></script>
+
 <h2>JBang IDE Support</h2>
 <div class="container">
-  <!--<div class="row">
-    <div class="full-width">
-    <p>Note: Java is not required to be installed - JBang will automatically download a Java version<br/> 
-      if no Java 8 or higher Java Development Kit (JDK) version is found.</p>
-    </div>
-  </div>-->
 
-<div id="app">
-  <v-app id="inspire">
-    <v-tabs        
-     centered
-     icons-and-text
-    >
-      <v-tab id="vscodium-tab">VSCodium
-        <img src="/assets/images/ide/vscodium.svg" width="24" height="24" />
-      </v-tab>
-      <v-tab id="vscode-tab">Visual Studio Code
-        <img src="https://code.visualstudio.com/favicon.ico" width="24" height="24" />
-      </v-tab>
-      <v-tab id="intellij-tab">IntelliJ
-        <img src="https://simpleicons.org/icons/intellijidea.svg" width="24" height="24" />
-      </v-tab>
-      <v-tab id="eclipse-tab">Eclipse
-        <img src="https://simpleicons.org/icons/eclipseide.svg" width="24" height="24" />
-      </v-tab>
-      <v-tab id="zed-tab">Zed
-        <img src="https://logo.svgcdn.com/simple-icons/zedindustries-dark.png" width="24" height="24" />
-      </v-tab>
-      <v-tab id="vim-tab">Vim/neovim
-        <img src="https://simpleicons.org/icons/vim.svg" width="24" height="24" />
-      </v-tab>
-      <v-tab id="emacs-tab">Emacs
-        <img src="https://simpleicons.org/icons/gnuemacs.svg" width="24" height="24" />
-      </v-tab>
-      <v-tab id="replit-tab">repl.it
-        <img src="https://api.faviconkit.com/replit.com" width="24" height="24" />
-      </v-tab>
-      <v-tab id="gitpod-tab">GitPod
-        <img src="https://gitpod.io/favicon.ico" width="24" height="24" />
-      </v-tab>
-      <v-tab id="jdoodle-tab">JDoodle
-        <img src="https://www.jdoodle.com/favicon.ico" width="24" height="24" />
-      </v-tab>
-      <v-tab id="jupyter-tab">Jupyter Notebook
-        <img src="https://jupyter.org/favicon.ico" width="24" height="24" />
-      </v-tab>
-    
-      <v-tab-item>
-        <h3>VSCodium</h3>
-        <p>
-          VSCodium is a community-driven, freely-licensed binary distribution of Microsoft's editor Visual Studio Code.
-          Providing all the lightweight editor features you need to get started.
-        </p>
-        <p>
-          <code>jbang edit</code> will by defaut install VSCodium; a free distribution of Visual Studio Code. It provides
-           a good default set of extensions to have it configured to use with Java/JBang.
-        </p>
-        <p>
-          JBang is in <a href="https://open-vsx.org/extension/jbangdev/jbang-vscode">Open VSX Registry</a>
-        </p>
-      </v-tab-item>
-      <v-tab-item>
-        <h3>Visual Studio Code</h3>
-        <p>
-        Visual Studio code is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux.
-        </p>    
-        <p>
-          JBang is on <a href="https://marketplace.visualstudio.com/items?itemName=jbangdev.jbang-vscode">Visual Studio Marketplace</a>
-        </p>
-      </v-tab-item>
-      <v-tab-item>
-        <h3>IntelliJ</h3>
-        <p>
-          IntelliJ IDEA is a very popular Java IDE. Has a lot of features; especially when it comes to refactoring and code assists.
-        </p>
-        <p>
-          JBang is on <a href="https://plugins.jetbrains.com/plugin/18257-jbang">Jetbrains Marketplace</a>
-        </p>
-        
-      </v-tab-item>
+{|
+<ot-tabs>
+  <div role="tablist">
+    <button role="tab"><img src="/assets/images/ide/vscodium.svg" width="20" height="20" alt=""/> VSCodium</button>
+    <button role="tab"><img src="https://code.visualstudio.com/favicon.ico" width="20" height="20" alt=""/> VS Code</button>
+    <button role="tab"><img src="https://simpleicons.org/icons/intellijidea.svg" width="20" height="20" alt=""/> IntelliJ</button>
+    <button role="tab"><img src="https://simpleicons.org/icons/eclipseide.svg" width="20" height="20" alt=""/> Eclipse</button>
+    <button role="tab"><img src="https://logo.svgcdn.com/simple-icons/zedindustries-dark.png" width="20" height="20" alt=""/> Zed</button>
+    <button role="tab"><img src="https://simpleicons.org/icons/vim.svg" width="20" height="20" alt=""/> Vim/neovim</button>
+    <button role="tab"><img src="https://simpleicons.org/icons/gnuemacs.svg" width="20" height="20" alt=""/> Emacs</button>
+    <button role="tab"><img src="https://api.faviconkit.com/replit.com" width="20" height="20" alt=""/> repl.it</button>
+    <button role="tab"><img src="https://gitpod.io/favicon.ico" width="20" height="20" alt=""/> GitPod</button>
+    <button role="tab"><img src="https://www.jdoodle.com/favicon.ico" width="20" height="20" alt=""/> JDoodle</button>
+    <button role="tab"><img src="https://jupyter.org/favicon.ico" width="20" height="20" alt=""/> Jupyter</button>
+  </div>
 
-      <v-tab-item>
-        <h3>Eclipse</h3>
-        <p>
-          Eclipse is a popular opensource Java IDE. Has a large ecosystem of plugins and is 100% free to use.
-        </p>
-          <p>
-            JBang is on <a href="https://marketplace.eclipse.org/content/jbang-eclipse-integration">Eclipse Marketplace</a>
-          </p>
-        </v-tab-item>
-        <v-tab-item>
-          <h3>Zed</h3>
-          <p>
-            <a href="https://zed.dev"></a>Zed</a> is a high-performance editor with support for Java using Eclipse JDT Language Server.
-          </p>
-          <p>
-           No native JBang support yet, thus simplest way is to use sandbox mode: <code>jbang edit --sandbox --open=zed yourapp.java</code>.
-          </p>
-        </v-tab-item>
-        <v-tab-item>
-          <h3>Vim/neovim</h3>
-          <p>
-            Vim and neovim are highly configurable text editors built to enable efficient text editing. Supports Java with Eclipse JDT Language Server.
-          </p>
-          <p>
-            No native JBang support yet, thus simplest way is to use sandbox mode: <code>jbang edit --sandbox --open=nvim yourapp.java</code>.
-          </p>
-        </v-tab-item>
-        <v-tab-item>
-          <h3>Emacs</h3>
-          <p>
-            Emacs is an extensible, customizable, free/libre text editor and computing environment. Supports Java with Eclipse JDT Language Server.
-          </p>
-          <p>
-            No native JBang support yet, thus simplest way is to use sandbox mode: <code>jbang edit --sandbox --open=emacs yourapp.java</code>.
-          </p>
-        </v-tab-item>
-        <v-tab-item>
-          <h3>repl.it</h3>
-          <p>
-            repl.it is a free, online code editor that makes it easy to code, compile, run, and share in 50+ programming languages.
-          </p>
-          <p>
-            JBang template for <a href="https://replit.com/@maxandersen/jbang-replit-demo#.replit">Repl.it</a>
-          </p>
-        </v-tab-item>
-        <v-tab-item>
-          <h3>GitPod</h3>
-          <p>
-            GitPod is a free online IDE that allows you to create a dev environment for any GitHub repository.
-          </p>
-          <p>
-            JBang container template for <a href="https://gitpod.io/#https://github.com/jbangdev/jbang-devcontainer-template">GitPod</a>
-          </p>
-          </v-tab-item>
-        <v-tab-item>
-          <h3>JDoodle</h3>
-          <p>
-            JDoodle is a free online compiler, IDE and execution environment for Java, C, C++, PHP, Perl, Python, Ruby and many more.
-          </p>
-          <p>
-            Try JBang on <a href="https://www.jdoodle.com/try-jbang/">JDoodle</a>
-          </p>
-        </v-tab-item>
-        <v-tab-item>
-          <h3>Jupyter Notebook</h3>
-          <p>
-            Jupyter Notebook is an open-source web application that allows you to create and share documents containing live code, equations, visualizations, and narrative text.
-            With the JBang kernel, you can run Java code with JBang directly in Jupyter notebooks.
-          </p>
-          
-          <h4>Installation</h4>
-          <p>Install JupyterLab and the JBang kernel:</p>
-          <pre><code># Install JupyterLab (requires Python)
+  <div role="tabpanel">
+    <h3>VSCodium</h3>
+    <p>
+      VSCodium is a community-driven, freely-licensed binary distribution of Microsoft's editor Visual Studio Code.
+      Providing all the lightweight editor features you need to get started.
+    </p>
+    <p>
+      <code>jbang edit</code> will by default install VSCodium; a free distribution of Visual Studio Code. It provides
+       a good default set of extensions to have it configured to use with Java/JBang.
+    </p>
+    <p>
+      JBang is in <a href="https://open-vsx.org/extension/jbangdev/jbang-vscode">Open VSX Registry</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>Visual Studio Code</h3>
+    <p>
+      Visual Studio Code is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux.
+    </p>
+    <p>
+      JBang is on <a href="https://marketplace.visualstudio.com/items?itemName=jbangdev.jbang-vscode">Visual Studio Marketplace</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>IntelliJ</h3>
+    <p>
+      IntelliJ IDEA is a very popular Java IDE. Has a lot of features; especially when it comes to refactoring and code assists.
+    </p>
+    <p>
+      JBang is on <a href="https://plugins.jetbrains.com/plugin/18257-jbang">Jetbrains Marketplace</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>Eclipse</h3>
+    <p>
+      Eclipse is a popular opensource Java IDE. Has a large ecosystem of plugins and is 100% free to use.
+    </p>
+    <p>
+      JBang is on <a href="https://marketplace.eclipse.org/content/jbang-eclipse-integration">Eclipse Marketplace</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>Zed</h3>
+    <p>
+      <a href="https://zed.dev">Zed</a> is a high-performance editor with support for Java using Eclipse JDT Language Server.
+    </p>
+    <p>
+      No native JBang support yet, thus simplest way is to use sandbox mode: <code>jbang edit --sandbox --open=zed yourapp.java</code>.
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>Vim/neovim</h3>
+    <p>
+      Vim and neovim are highly configurable text editors built to enable efficient text editing. Supports Java with Eclipse JDT Language Server.
+    </p>
+    <p>
+      No native JBang support yet, thus simplest way is to use sandbox mode: <code>jbang edit --sandbox --open=nvim yourapp.java</code>.
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>Emacs</h3>
+    <p>
+      Emacs is an extensible, customizable, free/libre text editor and computing environment. Supports Java with Eclipse JDT Language Server.
+    </p>
+    <p>
+      No native JBang support yet, thus simplest way is to use sandbox mode: <code>jbang edit --sandbox --open=emacs yourapp.java</code>.
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>repl.it</h3>
+    <p>
+      repl.it is a free, online code editor that makes it easy to code, compile, run, and share in 50+ programming languages.
+    </p>
+    <p>
+      JBang template for <a href="https://replit.com/@maxandersen/jbang-replit-demo#.replit">Repl.it</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>GitPod</h3>
+    <p>
+      GitPod is a free online IDE that allows you to create a dev environment for any GitHub repository.
+    </p>
+    <p>
+      JBang container template for <a href="https://gitpod.io/#https://github.com/jbangdev/jbang-devcontainer-template">GitPod</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>JDoodle</h3>
+    <p>
+      JDoodle is a free online compiler, IDE and execution environment for Java, C, C++, PHP, Perl, Python, Ruby and many more.
+    </p>
+    <p>
+      Try JBang on <a href="https://www.jdoodle.com/try-jbang/">JDoodle</a>
+    </p>
+  </div>
+
+  <div role="tabpanel">
+    <h3>Jupyter Notebook</h3>
+    <p>
+      Jupyter Notebook is an open-source web application that allows you to create and share documents containing live code, equations, visualizations, and narrative text.
+      With the JBang kernel, you can run Java code with JBang directly in Jupyter notebooks.
+    </p>
+
+    <h4>Installation</h4>
+    <p>Install JupyterLab and the JBang kernel:</p>
+    <pre><code># Install JupyterLab (requires Python)
 pip install jupyterlab
 
 # Install JBang kernel
 jbang install-kernel@jupyter-java --java 25 --enable-preview jbang</code></pre>
-          
-          <h4>Usage</h4>
-          <p>Launch JupyterLab and create a new notebook with the JBang kernel:</p>
-          <pre><code>jupyter lab</code></pre>
-          
-          <p>In JupyterLab, create a new notebook and select "JBang" as the kernel. You can now write and execute Java code with JBang directives like <code>//DEPS</code> directly in your notebooks!</p>
-          
-          <h4>Try Online</h4>
-          <p>
-            Want to try it without installing? Use our <a href="/try/">online Jupyter environment</a> powered by MyBinder.
-          </p>
-          
-          <h4>Learn More</h4>
-          <p>
-            Visit the <a href="https://github.com/jbangdev/jbang-jupyter" target="_blank" rel="noopener">JBang Jupyter Kernel</a> repository for more details and examples.
-          </p>
-        </v-tab-item>
-        
 
-    </v-tabs>
-  </v-app>
+    <h4>Usage</h4>
+    <p>Launch JupyterLab and create a new notebook with the JBang kernel:</p>
+    <pre><code>jupyter lab</code></pre>
+
+    <p>In JupyterLab, create a new notebook and select "JBang" as the kernel. You can now write and execute Java code with JBang directives like <code>//DEPS</code> directly in your notebooks!</p>
+
+    <h4>Try Online</h4>
+    <p>
+      Want to try it without installing? Use our <a href="/try/">online Jupyter environment</a> powered by MyBinder.
+    </p>
+
+    <h4>Learn More</h4>
+    <p>
+      Visit the <a href="https://github.com/jbangdev/jbang-jupyter" target="_blank" rel="noopener">JBang Jupyter Kernel</a> repository for more details and examples.
+    </p>
+  </div>
+</ot-tabs>
+|}
+
 </div>
-<script>
-new Vue({
-  el: '#app',
-  vuetify: new Vuetify(),
-  data () {
-    return {
-      tab: null,
-      items: [
-        'Appetizers', 'Entrees', 'Deserts', 'Cocktails',
-      ],
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-    }
-  },
-})
-</script>
 <script src="{{base.url}}/assets/js/os-check.js"></script>
-  <!-- Content End -->

--- a/public/assets/css/appstore.css
+++ b/public/assets/css/appstore.css
@@ -1,5 +1,10 @@
 /* AppStore page styles */
 
+/* Force light mode for Oat CSS — prevents dark background when OS is in dark mode */
+:root {
+    color-scheme: light;
+}
+
 .appstore-toolbar {
     display: flex;
     align-items: center;
@@ -29,10 +34,16 @@
     cursor: pointer;
     user-select: none;
     list-style: none;
+    justify-content: flex-start;
 }
 
 .appstore-group summary::-webkit-details-marker {
     display: none;
+}
+
+/* Override Oat's summary chevron — use our own triangle */
+.appstore-group summary::after {
+    content: none !important;
 }
 
 .appstore-group summary::before {
@@ -45,6 +56,11 @@
 
 .appstore-group[open] summary::before {
     transform: rotate(90deg);
+}
+
+/* Override Oat's details > *:not(summary) margin */
+.appstore-group > *:not(summary) {
+    margin: 0 !important;
 }
 
 .appstore-repo-header {
@@ -77,6 +93,9 @@
 .appstore-group .table {
     margin: 0;
     border: none;
+    min-width: 0;
+    width: 100%;
+    overflow-x: hidden;
 }
 
 .appstore-group table {
@@ -85,9 +104,13 @@
     width: 100%;
 }
 
+.appstore-group tbody tr {
+    border-bottom: none !important;
+}
+
 .appstore-group td {
-    padding: 0.5rem 1rem;
-    border-top: 1px solid var(--ot-border, #eee);
+    padding: 0;
+    border: none !important;
 }
 
 .appstore-alias-cell {
@@ -95,6 +118,14 @@
     align-items: flex-start;
     gap: 0.5rem;
     flex-wrap: wrap;
+    padding: 0.6rem 1rem;
+    border-top: 1px solid #e0e0e0;
+    cursor: pointer;
+    position: relative;
+}
+
+.appstore-alias-cell:hover {
+    background-color: #f9f9f9;
 }
 
 .appstore-alias-cell code {
@@ -119,25 +150,6 @@
     line-height: 1;
 }
 
-/* Toast */
-.toast {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    padding: 0.75rem 1.25rem;
-    border-radius: 6px;
-    background: #2e7d32;
-    color: white;
-    font-size: 0.9rem;
-    z-index: 9999;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    animation: toast-in 0.2s ease;
-}
-
-@keyframes toast-in {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-}
 
 /* Pagination */
 #appstore-pagination menu {

--- a/public/assets/css/appstore.css
+++ b/public/assets/css/appstore.css
@@ -1,20 +1,171 @@
-.table-appstore > thead > tr > th {
-    text-align: left;
-    color: white;
+/* AppStore page styles */
+
+.appstore-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
 }
 
-.table-appstore > tbody > tr > td {
-    text-align: left;
+.appstore-toolbar input[type="text"] {
+    flex: 1;
+    max-width: 400px;
 }
 
-/* button styling */
-.copyButton {
-    border: none;
+.appstore-loading {
+    text-align: center;
+    padding: 3rem 1rem;
+}
+
+/* Group (repo) sections */
+.appstore-group {
+    margin-bottom: 0.75rem;
+    border: 1px solid var(--ot-border, #ddd);
+    border-radius: 6px;
+}
+
+.appstore-group summary {
+    padding: 0.75rem 1rem;
     cursor: pointer;
-    outline: none;
-    margin-left: 5px;
-    background-color: transparent;
+    user-select: none;
+    list-style: none;
 }
-.copyButton:hover {
-    opacity: 0.8;
+
+.appstore-group summary::-webkit-details-marker {
+    display: none;
+}
+
+.appstore-group summary::before {
+    content: "▶ ";
+    font-size: 0.7em;
+    margin-right: 0.5rem;
+    display: inline-block;
+    transition: transform 0.15s;
+}
+
+.appstore-group[open] summary::before {
+    transform: rotate(90deg);
+}
+
+.appstore-repo-header {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.appstore-repo-header img {
+    border-radius: 4px;
+}
+
+.appstore-repo-header a {
+    text-decoration: none;
+}
+
+.appstore-repo-header a:hover {
+    text-decoration: underline;
+}
+
+.appstore-stars {
+    font-size: 0.85rem;
+    font-weight: normal;
+    color: var(--ot-text-light, #666);
+}
+
+/* Alias table inside group */
+.appstore-group .table {
+    margin: 0;
+    border: none;
+}
+
+.appstore-group table {
+    margin: 0;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.appstore-group td {
+    padding: 0.5rem 1rem;
+    border-top: 1px solid var(--ot-border, #eee);
+}
+
+.appstore-alias-cell {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.appstore-alias-cell code {
+    font-weight: 600;
+}
+
+.appstore-desc {
+    width: 100%;
+    font-size: 0.9rem;
+    color: var(--ot-text-light, #666);
+    white-space: pre-wrap;
+}
+
+.appstore-desc p {
+    margin: 0.25rem 0;
+}
+
+/* Copy button */
+.appstore-copy {
+    flex-shrink: 0;
+    padding: 0.25rem 0.35rem !important;
+    line-height: 1;
+}
+
+/* Toast */
+.toast {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    padding: 0.75rem 1.25rem;
+    border-radius: 6px;
+    background: #2e7d32;
+    color: white;
+    font-size: 0.9rem;
+    z-index: 9999;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    animation: toast-in 0.2s ease;
+}
+
+@keyframes toast-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* Pagination */
+#appstore-pagination menu {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    list-style: none;
+    padding: 0;
+    justify-content: center;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    .appstore-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .appstore-toolbar input[type="text"] {
+        max-width: 100%;
+    }
+
+    .appstore-repo-header {
+        font-size: 0.95rem;
+    }
+
+    .appstore-repo-header img {
+        width: 24px;
+        height: 24px;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 site.page-layout=single.html
-site.default-ignored-files=**.DS_Store,**Thumbs.db
+site.default-ignored-files=**.DS_Store,**Thumbs.db,**.vscode/**
 site.collections.posts=true
 site.collections.posts.layout=post.html
 

--- a/templates/partials/head/custom.html
+++ b/templates/partials/head/custom.html
@@ -2,55 +2,11 @@
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 
-
-
-<!-- vuetify -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css"/>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons"/>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@2.5.0/dist/vuetify.min.css"/>
-<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js"></script>
-<script src="https://unpkg.com/vue@2"></script>
-<script src="https://cdn.jsdelivr.net/npm/vuetify@2.5.0/dist/vuetify.min.js"></script>
-<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
-
 <!-- hilight -->
-<!-- using dark as it looks okey but most importantly does not look like crap with vuetify theme inside apps -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/dark.min.css" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
 <script src="https://unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.js"></script>
 
 <script>hljs.highlightAll(); hljs.addPlugin(new CopyButtonPlugin());</script>
-
-<script>
-hljs.addPlugin(new CopyButtonPlugin());
-Vue.use(hljs.vuePlugin);
-//https://www.metachris.com/2017/02/vuejs-syntax-highlighting-with-highlightjs/
-Vue.directive('highlightjs', {
-  deep: true,
-  bind: function(el, binding) {
-    // on first bind, highlight all targets
-    let targets = el.querySelectorAll('code')
-    targets.forEach((target) => {
-      // if a value is directly assigned to the directive, use this
-      // instead of the element content.
-      if (binding.value) {
-        target.textContent = binding.value
-      }
-      hljs.highlightBlock(target)
-    })
-  },
-  componentUpdated: function(el, binding) {
-    // after an update, re-fill the content and then highlight
-    let targets = el.querySelectorAll('code')
-    targets.forEach((target) => {
-      if (binding.value) {
-        target.textContent = binding.value
-        hljs.highlightBlock(target)
-      }
-    })
-  }
-})
-</script>
-
 
 <!-- end custom head snippets -->

--- a/templates/partials/head/custom.html
+++ b/templates/partials/head/custom.html
@@ -5,8 +5,73 @@
 <!-- hilight -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/dark.min.css" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
-<script src="https://unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.js"></script>
 
-<script>hljs.highlightAll(); hljs.addPlugin(new CopyButtonPlugin());</script>
+<script>hljs.highlightAll();</script>
+
+<!-- Global click-to-copy for pre/code blocks -->
+<style>
+pre {
+  cursor: pointer;
+  position: relative;
+}
+pre:hover {
+  opacity: 0.9;
+}
+pre::after {
+  content: "Click to copy";
+  position: absolute;
+  right: 10px;
+  top: 5px;
+  font-size: 12px;
+  color: #999;
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+pre:hover::after {
+  opacity: 1;
+}
+.copy-toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 6px;
+  background: #2e7d32;
+  color: white;
+  font-size: 0.9rem;
+  z-index: 9999;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  animation: copy-toast-in 0.2s ease;
+  display: none;
+}
+@keyframes copy-toast-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+</style>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var toast = document.createElement('div');
+  toast.className = 'copy-toast';
+  document.body.appendChild(toast);
+  var toastTimer;
+  function showCopyToast(msg) {
+    toast.textContent = msg;
+    toast.style.display = 'block';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(function() { toast.style.display = 'none'; }, 2500);
+  }
+  window.showCopyToast = showCopyToast;
+  document.addEventListener('click', function(e) {
+    var pre = e.target.closest('pre');
+    if (!pre) return;
+    var text = pre.textContent;
+    navigator.clipboard.writeText(text).then(function() {
+      showCopyToast('Copied: ' + text.trim().substring(0, 80) + (text.trim().length > 80 ? '…' : ''));
+    });
+  });
+});
+</script>
 
 <!-- end custom head snippets -->


### PR DESCRIPTION
## Summary

Remove EOL Vue 2 + Vuetify 2 stack and replace with [Oat UI](https://oat.ink/) (~8 KB) + vanilla JavaScript.

### Changes
- **Global head cleanup**: Remove Vue 2, Vuetify 2, Axios, ClipboardJS, MDI fonts from `templates/partials/head/custom.html` (~620 KB removed from *every* page load)
- **AppStore page rewrite**: Oat styling + vanilla JS with:
  - `fetch()` instead of Axios
  - `navigator.clipboard` instead of ClipboardJS
  - Search with URL deep-linking (`?q=...`)
  - Pagination (20 repo groups per page)
  - Collapsible repo groups via `<details>/<summary>`
  - Loading spinner, error state, clipboard toast
  - Mobile-responsive layout
- **IDE page rewrite**: Vuetify `v-tabs` → Oat `<ot-tabs>` web component
- **Test fix**: Add `**.vscode/**` to `site.default-ignored-files` — fixes pre-existing test failures caused by `.vscode/settings.json` being picked up by Roq as content (500 errors during RoqAndRoll init)

### Why
- Vue 2 reached EOL on 31 Dec 2023; Vuetify 2 is also unmaintained
- These libraries were loaded globally on every page (~620 KB) but only used on AppStore and IDE pages
- Oat is loaded only on pages that need it

### Testing
- `mvn package` — BUILD SUCCESS, all 4 tests pass
- Verified generated HTML in `target/roq/`

### Follow-up ideas
- AppStore JSON could be normalized to reduce ~545 KB payload
- Templates data (84 items) exists in JSON but has no UI — could add a Templates page
- highlight.js in global head is v10.7.2 (old) — could modernize separately