### PR TITLE
refactor: normalize appstore JSON with catalog-centric structure

### DIFF
--- a/.github/appstore.java
+++ b/.github/appstore.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.commonmark.Extension;
 import org.commonmark.ext.autolink.AutolinkExtension;
@@ -335,16 +337,59 @@ class Template {
 
 class Cataloger {
   public final int aliasCount;
-  public final List<CatalogItem> aliases;
-  private List<CatalogItem> templates;
-  private int templateCount;
+  public final int templateCount;
+  public final List<CatalogEntry> catalogs;
 
-  public Cataloger(List<CatalogItem> items, List<CatalogItem> sortedTemplates) {
-    this.aliases = items;
-    aliasCount = items.size();
+  public Cataloger(List<CatalogItem> aliasItems, List<CatalogItem> templateItems) {
+    // Group by repo
+    Map<String, CatalogEntry> entries = new LinkedHashMap<>();
 
-    this.templates = sortedTemplates;
-    this.templateCount = sortedTemplates.size();
+    for (CatalogItem item : aliasItems) {
+      entries.computeIfAbsent(item.repoOwner + "/" + item.repoName,
+          k -> new CatalogEntry(item.repoOwner, item.repoName, item.stars, item.icon_url, item.link))
+          .aliases.add(new CompactItem(item));
+    }
+    for (CatalogItem item : templateItems) {
+      entries.computeIfAbsent(item.repoOwner + "/" + item.repoName,
+          k -> new CatalogEntry(item.repoOwner, item.repoName, item.stars, item.icon_url, item.link))
+          .templates.add(new CompactItem(item));
+    }
+
+    this.catalogs = new ArrayList<>(entries.values());
+    this.aliasCount = aliasItems.size();
+    this.templateCount = templateItems.size();
+  }
+}
+
+class CatalogEntry {
+  public final String owner;
+  public final String name;
+  public final int stars;
+  public final String icon;
+  public final String link;
+  public final List<CompactItem> aliases = new ArrayList<>();
+  public final List<CompactItem> templates = new ArrayList<>();
+
+  public CatalogEntry(String owner, String name, int stars, String icon, String link) {
+    this.owner = owner;
+    this.name = name;
+    this.stars = stars;
+    this.icon = icon;
+    this.link = link;
+  }
+}
+
+class CompactItem {
+  public final String a; // alias
+  public final String d; // description (nullable)
+  public final String s; // scriptRef (nullable)
+  public final String c; // command
+
+  public CompactItem(CatalogItem item) {
+    this.a = item.alias;
+    this.d = item.description;
+    this.s = item.scriptRef;
+    this.c = item.command;
   }
 }
 

--- a/content/appstore.html
+++ b/content/appstore.html
@@ -94,7 +94,19 @@ data-field: aliases
     fetch('/assets/data/jbang-appstore.json')
         .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
         .then(data => {
-            allGroups = groupByRepo(data.aliases || []);
+            allGroups = (data.catalogs || []).map(function(cat) {
+                return {
+                    repo: cat.owner + '/' + cat.name,
+                    icon: cat.icon,
+                    owner: cat.owner,
+                    name: cat.name,
+                    stars: cat.stars || 0,
+                    link: cat.link || ('https://github.com/' + cat.owner + '/' + cat.name),
+                    aliases: (cat.aliases || []).map(function(a) {
+                        return { command: a.c, description: a.d || null };
+                    })
+                };
+            });
             loadingEl.style.display = 'none';
             contentEl.style.display = 'block';
             applyFilter();
@@ -103,27 +115,6 @@ data-field: aliases
             loadingEl.style.display = 'none';
             errorEl.style.display = 'block';
         });
-
-    // Group aliases by repo
-    function groupByRepo(aliases) {
-        const map = new Map();
-        for (const a of aliases) {
-            const key = a.repoOwner + '/' + a.repoName;
-            if (!map.has(key)) {
-                map.set(key, {
-                    repo: key,
-                    icon: a.icon_url,
-                    owner: a.repoOwner,
-                    name: a.repoName,
-                    stars: a.stars || 0,
-                    link: 'https://github.com/' + key,
-                    aliases: []
-                });
-            }
-            map.get(key).aliases.push(a);
-        }
-        return Array.from(map.values());
-    }
 
     // Search
     searchInput.addEventListener('input', function() {
@@ -144,7 +135,7 @@ data-field: aliases
             filteredGroups = [];
             for (const g of allGroups) {
                 const matchingAliases = g.aliases.filter(a =>
-                    a.command.toLowerCase().includes(q) ||
+                    (a.command && a.command.toLowerCase().includes(q)) ||
                     (a.description && a.description.toLowerCase().includes(q)) ||
                     g.repo.toLowerCase().includes(q)
                 );
@@ -184,7 +175,7 @@ data-field: aliases
                             ${g.aliases.map(a => `
                             <tr>
                                 <td class="appstore-alias-cell">
-                                    <button class="appstore-copy outline small" title="Copy jbang command" data-cmd="${esc(a.fullcommand)}">
+                                    <button class="appstore-copy outline small" title="Copy jbang command" data-cmd="jbang ${esc(a.command)}">
                                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
                                     </button>
                                     <code>${esc(a.command)}</code>

--- a/public/assets/data/jbang-appstore.json
+++ b/public/assets/data/jbang-appstore.json
@@ -1,11007 +1,7503 @@
 {
   "aliasCount": 876,
-  "aliases": [
+  "templateCount": 84,
+  "catalogs": [
     {
+      "owner": "apple",
+      "name": "pkl",
       "stars": 11335,
-      "icon_url": "https://avatars.githubusercontent.com/u/10639145?v\u003d4",
-      "repoOwner": "apple",
-      "repoName": "pkl",
-      "alias": "pkl",
-      "scriptRef": "org.pkl-lang:pkl-cli-java:0.31.1",
-      "command": "pkl@apple/pkl",
-      "fullcommand": "jbang pkl@apple/pkl",
-      "link": "https://github.com/apple/pkl/blob/713fbc5043d3692487786b6502cf182d3ce1e0ce/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/10639145?v=4",
+      "link": "https://github.com/apple/pkl/blob/713fbc5043d3692487786b6502cf182d3ce1e0ce/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pkl",
+          "c": "pkl@apple/pkl",
+          "s": "org.pkl-lang:pkl-cli-java:0.31.1"
+        },
+        {
+          "a": "pkl-codegen-java",
+          "c": "pkl-codegen-java@apple/pkl",
+          "s": "org.pkl-lang:pkl-codegen-java:0.31.1"
+        },
+        {
+          "a": "pkl-codegen-kotlin",
+          "c": "pkl-codegen-kotlin@apple/pkl",
+          "s": "org.pkl-lang:pkl-codegen-kotlin:0.31.1"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 11335,
-      "icon_url": "https://avatars.githubusercontent.com/u/10639145?v\u003d4",
-      "repoOwner": "apple",
-      "repoName": "pkl",
-      "alias": "pkl-codegen-java",
-      "scriptRef": "org.pkl-lang:pkl-codegen-java:0.31.1",
-      "command": "pkl-codegen-java@apple/pkl",
-      "fullcommand": "jbang pkl-codegen-java@apple/pkl",
-      "link": "https://github.com/apple/pkl/blob/713fbc5043d3692487786b6502cf182d3ce1e0ce/jbang-catalog.json"
-    },
-    {
-      "stars": 11335,
-      "icon_url": "https://avatars.githubusercontent.com/u/10639145?v\u003d4",
-      "repoOwner": "apple",
-      "repoName": "pkl",
-      "alias": "pkl-codegen-kotlin",
-      "scriptRef": "org.pkl-lang:pkl-codegen-kotlin:0.31.1",
-      "command": "pkl-codegen-kotlin@apple/pkl",
-      "fullcommand": "jbang pkl-codegen-kotlin@apple/pkl",
-      "link": "https://github.com/apple/pkl/blob/713fbc5043d3692487786b6502cf182d3ce1e0ce/jbang-catalog.json"
-    },
-    {
+      "owner": "oshi",
+      "name": "oshi",
       "stars": 5206,
-      "icon_url": "https://avatars.githubusercontent.com/u/21304425?v\u003d4",
-      "repoOwner": "oshi",
-      "repoName": "oshi",
-      "alias": "json",
-      "scriptRef": "com.github.oshi:oshi-demo:RELEASE",
-      "command": "json@oshi/oshi",
-      "fullcommand": "jbang json@oshi/oshi",
-      "link": "https://github.com/oshi/oshi/blob/24a2021ca7c006b11aaf0e027d90998b828e7e38/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/21304425?v=4",
+      "link": "https://github.com/oshi/oshi/blob/24a2021ca7c006b11aaf0e027d90998b828e7e38/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "json",
+          "c": "json@oshi/oshi",
+          "s": "com.github.oshi:oshi-demo:RELEASE"
+        },
+        {
+          "a": "gui",
+          "c": "gui@oshi/oshi",
+          "s": "com.github.oshi:oshi-demo:RELEASE"
+        },
+        {
+          "a": "detectvm",
+          "c": "detectvm@oshi/oshi",
+          "s": "com.github.oshi:oshi-demo:RELEASE"
+        },
+        {
+          "a": "id",
+          "c": "id@oshi/oshi",
+          "s": "com.github.oshi:oshi-demo:RELEASE"
+        },
+        {
+          "a": "diskstore",
+          "c": "diskstore@oshi/oshi",
+          "s": "com.github.oshi:oshi-demo:RELEASE"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 5206,
-      "icon_url": "https://avatars.githubusercontent.com/u/21304425?v\u003d4",
-      "repoOwner": "oshi",
-      "repoName": "oshi",
-      "alias": "gui",
-      "scriptRef": "com.github.oshi:oshi-demo:RELEASE",
-      "command": "gui@oshi/oshi",
-      "fullcommand": "jbang gui@oshi/oshi",
-      "link": "https://github.com/oshi/oshi/blob/24a2021ca7c006b11aaf0e027d90998b828e7e38/jbang-catalog.json"
-    },
-    {
-      "stars": 5206,
-      "icon_url": "https://avatars.githubusercontent.com/u/21304425?v\u003d4",
-      "repoOwner": "oshi",
-      "repoName": "oshi",
-      "alias": "detectvm",
-      "scriptRef": "com.github.oshi:oshi-demo:RELEASE",
-      "command": "detectvm@oshi/oshi",
-      "fullcommand": "jbang detectvm@oshi/oshi",
-      "link": "https://github.com/oshi/oshi/blob/24a2021ca7c006b11aaf0e027d90998b828e7e38/jbang-catalog.json"
-    },
-    {
-      "stars": 5206,
-      "icon_url": "https://avatars.githubusercontent.com/u/21304425?v\u003d4",
-      "repoOwner": "oshi",
-      "repoName": "oshi",
-      "alias": "id",
-      "scriptRef": "com.github.oshi:oshi-demo:RELEASE",
-      "command": "id@oshi/oshi",
-      "fullcommand": "jbang id@oshi/oshi",
-      "link": "https://github.com/oshi/oshi/blob/24a2021ca7c006b11aaf0e027d90998b828e7e38/jbang-catalog.json"
-    },
-    {
-      "stars": 5206,
-      "icon_url": "https://avatars.githubusercontent.com/u/21304425?v\u003d4",
-      "repoOwner": "oshi",
-      "repoName": "oshi",
-      "alias": "diskstore",
-      "scriptRef": "com.github.oshi:oshi-demo:RELEASE",
-      "command": "diskstore@oshi/oshi",
-      "fullcommand": "jbang diskstore@oshi/oshi",
-      "link": "https://github.com/oshi/oshi/blob/24a2021ca7c006b11aaf0e027d90998b828e7e38/jbang-catalog.json"
-    },
-    {
+      "owner": "NanowarOfSteel",
+      "name": "HelloWorld",
       "stars": 1991,
-      "icon_url": "https://avatars.githubusercontent.com/u/185941913?v\u003d4",
-      "repoOwner": "NanowarOfSteel",
-      "repoName": "HelloWorld",
-      "alias": "helloworld",
-      "scriptRef": "src/main/java/it/nanowar/ofsteel/helloworld/HelloWorldMainLauncherClass.java",
-      "command": "helloworld@NanowarOfSteel/HelloWorld",
-      "fullcommand": "jbang helloworld@NanowarOfSteel/HelloWorld",
-      "link": "https://github.com/NanowarOfSteel/HelloWorld/blob/eb1b4d63eeb4a6d4fdd8167cda67876344c5bfcb/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/185941913?v=4",
+      "link": "https://github.com/NanowarOfSteel/HelloWorld/blob/eb1b4d63eeb4a6d4fdd8167cda67876344c5bfcb/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "helloworld",
+          "c": "helloworld@NanowarOfSteel/HelloWorld",
+          "s": "src/main/java/it/nanowar/ofsteel/helloworld/HelloWorldMainLauncherClass.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "validator",
+      "name": "validator",
       "stars": 1934,
-      "icon_url": "https://avatars.githubusercontent.com/u/498971?v\u003d4",
-      "repoOwner": "validator",
-      "repoName": "validator",
-      "alias": "vnu",
-      "scriptRef": "https://github.com/validator/validator/releases/download/latest/vnu.jar",
-      "command": "vnu@validator/validator",
-      "fullcommand": "jbang vnu@validator/validator",
-      "link": "https://github.com/validator/validator/blob/19ff04d1f1b05c12ed725d29e3dd866e0ba169ee/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/498971?v=4",
+      "link": "https://github.com/validator/validator/blob/19ff04d1f1b05c12ed725d29e3dd866e0ba169ee/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "vnu",
+          "c": "vnu@validator/validator",
+          "s": "https://github.com/validator/validator/releases/download/latest/vnu.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "jbangdev",
+      "name": "jbang",
       "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "jbang-fmt",
-      "description": "\u003cp\u003eA script that formats JBang Java example files for use in the JBang documentation\u003c/p\u003e\n",
-      "scriptRef": "jbang-fmt@jbangdev/jbang-fmt",
-      "command": "jbang-fmt@jbangdev/jbang~docs/modules/ROOT/examples",
-      "fullcommand": "jbang jbang-fmt@jbangdev/jbang~docs/modules/ROOT/examples",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/docs/modules/ROOT/examples/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/docs/modules/ROOT/examples/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jbang-fmt",
+          "c": "jbang-fmt@jbangdev/jbang~docs/modules/ROOT/examples",
+          "d": "<p>A script that formats JBang Java example files for use in the JBang documentation</p>\n",
+          "s": "jbang-fmt@jbangdev/jbang-fmt"
+        }
+      ],
+      "templates": [
+        {
+          "a": "gpt",
+          "c": "gpt@jbangdev/jbang~src/main/resources",
+          "d": "<p>Template using ChatGPT (requires --preview and OPENAI_API_KEY)</p>\n"
+        },
+        {
+          "a": "gpt.kt",
+          "c": "gpt.kt@jbangdev/jbang~src/main/resources",
+          "d": "<p>Template using ChatGPT for kotlin (requires --preview and OPENAI_API_KEY)</p>\n"
+        },
+        {
+          "a": "gpt.groovy",
+          "c": "gpt.groovy@jbangdev/jbang~src/main/resources",
+          "d": "<p>Template using ChatGPT for groovy (requires --preview and OPENAI_API_KEY)</p>\n"
+        },
+        {
+          "a": "agent",
+          "c": "agent@jbangdev/jbang~src/main/resources",
+          "d": "<p>Agent template</p>\n"
+        },
+        {
+          "a": "cli",
+          "c": "cli@jbangdev/jbang~src/main/resources",
+          "d": "<p>CLI template</p>\n"
+        },
+        {
+          "a": "hello",
+          "c": "hello@jbangdev/jbang~src/main/resources",
+          "d": "<p>Basic Hello World template</p>\n"
+        },
+        {
+          "a": "hello.kt",
+          "c": "hello.kt@jbangdev/jbang~src/main/resources",
+          "d": "<p>Basic kotlin Hello World template</p>\n"
+        },
+        {
+          "a": "hello.groovy",
+          "c": "hello.groovy@jbangdev/jbang~src/main/resources",
+          "d": "<p>Basic groovy Hello World template</p>\n"
+        },
+        {
+          "a": "readme.md",
+          "c": "readme.md@jbangdev/jbang~src/main/resources",
+          "d": "<p>Basic markdown readme template</p>\n"
+        },
+        {
+          "a": "qcli",
+          "c": "qcli@jbangdev/jbang~src/main/resources",
+          "d": "<p>Quarkus CLI template</p>\n"
+        },
+        {
+          "a": "qmetrics",
+          "c": "qmetrics@jbangdev/jbang~src/main/resources",
+          "d": "<p>Quarkus Metrics template</p>\n"
+        },
+        {
+          "a": "qrest",
+          "c": "qrest@jbangdev/jbang~src/main/resources",
+          "d": "<p>Quarkus REST template</p>\n"
+        }
+      ]
     },
     {
+      "owner": "oracle",
+      "name": "graalpython",
       "stars": 1587,
-      "icon_url": "https://avatars.githubusercontent.com/u/4430336?v\u003d4",
-      "repoOwner": "oracle",
-      "repoName": "graalpython",
-      "alias": "hello",
-      "description": "\u003cp\u003eScript that says hello from Python started from Java or execute Python expression as parameter.\u003c/p\u003e\n",
-      "scriptRef": "./graalpython/graalpy-jbang/examples/hello.java",
-      "command": "hello@oracle/graalpython",
-      "fullcommand": "jbang hello@oracle/graalpython",
-      "link": "https://github.com/oracle/graalpython/blob/9ecf016b5dbfb237f7b8425664fbfc6dbaa84a7d/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/4430336?v=4",
+      "link": "https://github.com/oracle/graalpython/blob/9ecf016b5dbfb237f7b8425664fbfc6dbaa84a7d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@oracle/graalpython",
+          "d": "<p>Script that says hello from Python started from Java or execute Python expression as parameter.</p>\n",
+          "s": "./graalpython/graalpy-jbang/examples/hello.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "graalpy",
+          "c": "graalpy@oracle/graalpython",
+          "d": "<p>Basic template for Graal Python java file.</p>\n"
+        },
+        {
+          "a": "graalpy_local_repo",
+          "c": "graalpy_local_repo@oracle/graalpython",
+          "d": "<p>Basic template for Graal Python java file. Mainly for testing.</p>\n"
+        }
+      ]
     },
     {
+      "owner": "hawtio",
+      "name": "hawtio",
       "stars": 1457,
-      "icon_url": "https://avatars.githubusercontent.com/u/2943947?v\u003d4",
-      "repoOwner": "hawtio",
-      "repoName": "hawtio",
-      "alias": "hawtio",
-      "description": "\u003cp\u003eRun Hawtio easily\u003c/p\u003e\n",
-      "scriptRef": "hawtio-jbang/dist/HawtioJBang.java",
-      "command": "hawtio@hawtio/hawtio",
-      "fullcommand": "jbang hawtio@hawtio/hawtio",
-      "link": "https://github.com/hawtio/hawtio/blob/622964b10f98553ad4e804bfae9246431d38dce4/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/2943947?v=4",
+      "link": "https://github.com/hawtio/hawtio/blob/622964b10f98553ad4e804bfae9246431d38dce4/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hawtio",
+          "c": "hawtio@hawtio/hawtio",
+          "d": "<p>Run Hawtio easily</p>\n",
+          "s": "hawtio-jbang/dist/HawtioJBang.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "citrusframework",
+      "name": "citrus",
       "stars": 483,
-      "icon_url": "https://avatars.githubusercontent.com/u/27848811?v\u003d4",
-      "repoOwner": "citrusframework",
-      "repoName": "citrus",
-      "alias": "citrus",
-      "description": "\u003cp\u003eRun Citrus tests\u003c/p\u003e\n",
-      "scriptRef": "tools/jbang/dist/CitrusJBang.java",
-      "command": "citrus@citrusframework/citrus",
-      "fullcommand": "jbang citrus@citrusframework/citrus",
-      "link": "https://github.com/citrusframework/citrus/blob/6832d3322a0acf33db83f8ff3e3118a65545eac6/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/27848811?v=4",
+      "link": "https://github.com/citrusframework/citrus/blob/6832d3322a0acf33db83f8ff3e3118a65545eac6/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "citrus",
+          "c": "citrus@citrusframework/citrus",
+          "d": "<p>Run Citrus tests</p>\n",
+          "s": "tools/jbang/dist/CitrusJBang.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "hibernate",
+      "name": "hibernate-reactive",
       "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "example",
-      "description": "\u003cp\u003eAn application example. The database must be available before running it. See \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/hibernate/hibernate-reactive/blob/main/podman.md\"\u003ehttps://github.com/hibernate/hibernate-reactive/blob/main/podman.md\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "tooling/jbang/Example.java",
-      "command": "example@hibernate/hibernate-reactive",
-      "fullcommand": "jbang example@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/348262?v=4",
+      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "example",
+          "c": "example@hibernate/hibernate-reactive",
+          "d": "<p>An application example. The database must be available before running it. See <a rel=\"nofollow\" href=\"https://github.com/hibernate/hibernate-reactive/blob/main/podman.md\">https://github.com/hibernate/hibernate-reactive/blob/main/podman.md</a></p>\n",
+          "s": "tooling/jbang/Example.java"
+        },
+        {
+          "a": "testcase",
+          "c": "testcase@hibernate/hibernate-reactive",
+          "d": "<p>A Hibernate Reactive JUnit test using Docker, Testcontainers and Vert.x Unit</p>\n",
+          "s": "tooling/jbang/ReactiveTest.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "pg-reproducer",
+          "c": "pg-reproducer@hibernate/hibernate-reactive",
+          "d": "<p>Template for a test with PostgreSQL using Junit 4, Vert.x Unit and Testcontainers</p>\n"
+        },
+        {
+          "a": "mysql-reproducer",
+          "c": "mysql-reproducer@hibernate/hibernate-reactive",
+          "d": "<p>Template for a test with MySQL using Junit 4, Vert.x Unit and Testcontainers</p>\n"
+        },
+        {
+          "a": "mariadb-reproducer",
+          "c": "mariadb-reproducer@hibernate/hibernate-reactive",
+          "d": "<p>Template for a test with MariaDB using Junit 4, Vert.x Unit and Testcontainers</p>\n"
+        },
+        {
+          "a": "db2-reproducer",
+          "c": "db2-reproducer@hibernate/hibernate-reactive",
+          "d": "<p>Template for a test with Db2 using Junit 4, Vert.x Unit and Testcontainers</p>\n"
+        },
+        {
+          "a": "cockroachdb-reproducer",
+          "c": "cockroachdb-reproducer@hibernate/hibernate-reactive",
+          "d": "<p>Template for a test with CockroachDB using Junit 4, Vert.x Unit and Testcontainers</p>\n"
+        }
+      ]
     },
     {
-      "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "testcase",
-      "description": "\u003cp\u003eA Hibernate Reactive JUnit test using Docker, Testcontainers and Vert.x Unit\u003c/p\u003e\n",
-      "scriptRef": "tooling/jbang/ReactiveTest.java",
-      "command": "testcase@hibernate/hibernate-reactive",
-      "fullcommand": "jbang testcase@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
-    },
-    {
+      "owner": "tamboui",
+      "name": "tamboui",
       "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "run-demo",
-      "description": "\u003cp\u003eRun TamboUI demos interactively\u003c/p\u003e\n",
-      "scriptRef": ".jbang/tambouiDemos.java",
-      "command": "run-demo@tamboui/tamboui",
-      "fullcommand": "jbang run-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/251016663?v=4",
+      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "run-demo",
+          "c": "run-demo@tamboui/tamboui",
+          "d": "<p>Run TamboUI demos interactively</p>\n",
+          "s": ".jbang/tambouiDemos.java"
+        },
+        {
+          "a": "aesh-ssh-http-demo",
+          "c": "aesh-ssh-http-demo@tamboui/tamboui",
+          "s": "demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java"
+        },
+        {
+          "a": "error-handling-demo",
+          "c": "error-handling-demo@tamboui/tamboui",
+          "s": "demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java"
+        },
+        {
+          "a": "fakodex-demo",
+          "c": "fakodex-demo@tamboui/tamboui",
+          "s": "demos/fakodex-demo/src/main/java/dev/tamboui/demo/coding/CodingAssistantDemo.java"
+        },
+        {
+          "a": "filemanager-demo",
+          "c": "filemanager-demo@tamboui/tamboui",
+          "s": "demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerDemo.java"
+        },
+        {
+          "a": "flex-demo",
+          "c": "flex-demo@tamboui/tamboui",
+          "s": "demos/flex-demo/src/main/java/dev/tamboui/demo/flex/FlexDemo.java"
+        },
+        {
+          "a": "form-table-demo",
+          "c": "form-table-demo@tamboui/tamboui",
+          "s": "demos/form-table-demo/src/main/java/dev/tamboui/demo/layout/FormTableDemo.java"
+        },
+        {
+          "a": "inline-progress-demo",
+          "c": "inline-progress-demo@tamboui/tamboui",
+          "s": "demos/inline-progress-demo/src/main/java/dev/tamboui/demo/InlineProgressDemo.java"
+        },
+        {
+          "a": "listelement-demo",
+          "c": "listelement-demo@tamboui/tamboui",
+          "s": "demos/listelement-demo/src/main/java/dev/tamboui/demo/ListElementDemo.java"
+        },
+        {
+          "a": "modular-demo",
+          "c": "modular-demo@tamboui/tamboui",
+          "s": "demos/modular-demo/src/main/java/dev/tamboui/demo/modular/ModularDemo.java"
+        },
+        {
+          "a": "rflex-demo",
+          "c": "rflex-demo@tamboui/tamboui",
+          "s": "demos/rflex-demo/src/main/java/dev/tamboui/demo/flex/RFlexDemo.java"
+        },
+        {
+          "a": "toolkit-export-demo",
+          "c": "toolkit-export-demo@tamboui/tamboui",
+          "s": "demos/toolkit-export-demo/src/main/java/dev/tamboui/demo/ToolkitExportDemo.java"
+        },
+        {
+          "a": "unicode-demo",
+          "c": "unicode-demo@tamboui/tamboui",
+          "s": "demos/unicode-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java"
+        },
+        {
+          "a": "unicode-inline-demo",
+          "c": "unicode-inline-demo@tamboui/tamboui",
+          "s": "demos/unicode-inline-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java"
+        },
+        {
+          "a": "dock-demo",
+          "c": "dock-demo@tamboui/tamboui",
+          "s": "tamboui-core/demos/dock-demo/src/main/java/dev/tamboui/demo/DockDemo.java"
+        },
+        {
+          "a": "export-demo",
+          "c": "export-demo@tamboui/tamboui",
+          "s": "tamboui-core/demos/export-demo/src/main/java/dev/tamboui/demo/ExportDemo.java"
+        },
+        {
+          "a": "flow-demo",
+          "c": "flow-demo@tamboui/tamboui",
+          "s": "tamboui-core/demos/flow-demo/src/main/java/dev/tamboui/demo/FlowDemo.java"
+        },
+        {
+          "a": "grid-demo",
+          "c": "grid-demo@tamboui/tamboui",
+          "s": "tamboui-core/demos/grid-demo/src/main/java/dev/tamboui/demo/GridDemo.java"
+        },
+        {
+          "a": "stack-demo",
+          "c": "stack-demo@tamboui/tamboui",
+          "s": "tamboui-core/demos/stack-demo/src/main/java/dev/tamboui/demo/StackDemo.java"
+        },
+        {
+          "a": "css-demo",
+          "c": "css-demo@tamboui/tamboui",
+          "s": "tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java"
+        },
+        {
+          "a": "css-no-toolkit-demo",
+          "c": "css-no-toolkit-demo@tamboui/tamboui",
+          "s": "tamboui-css/demos/css-no-toolkit-demo/src/main/java/dev/tamboui/demo/CssNoToolkitDemo.java"
+        },
+        {
+          "a": "image-demo",
+          "c": "image-demo@tamboui/tamboui",
+          "s": "tamboui-image/demos/image-demo/src/main/java/dev/tamboui/demo/ImageDemo.java"
+        },
+        {
+          "a": "markdown-demo",
+          "c": "markdown-demo@tamboui/tamboui",
+          "s": "tamboui-markdown/demos/markdown-demo/src/main/java/dev/tamboui/demo/MarkdownDemo.java"
+        },
+        {
+          "a": "picocli-demo",
+          "c": "picocli-demo@tamboui/tamboui",
+          "s": "tamboui-picocli/demos/picocli-demo/src/main/java/dev/tamboui/demo/PicoCLIDemo.java"
+        },
+        {
+          "a": "tfx-basic-effects-demo",
+          "c": "tfx-basic-effects-demo@tamboui/tamboui",
+          "s": "tamboui-tfx/demos/tfx-basic-effects-demo/src/main/java/dev/tamboui/demo/BasicEffectsTFXDemo.java"
+        },
+        {
+          "a": "tfx-demo",
+          "c": "tfx-demo@tamboui/tamboui",
+          "s": "tamboui-tfx/demos/tfx-demo/src/main/java/dev/tamboui/demo/TFXEffectsDemo.java"
+        },
+        {
+          "a": "tfx-toolkit-demo",
+          "c": "tfx-toolkit-demo@tamboui/tamboui",
+          "s": "tamboui-tfx-toolkit/demos/tfx-toolkit-demo/src/main/java/dev/tamboui/demo/TfxToolkitDemo.java"
+        },
+        {
+          "a": "tfx-tui-demo",
+          "c": "tfx-tui-demo@tamboui/tamboui",
+          "s": "tamboui-tfx-tui/demos/tfx-tui-demo/src/main/java/dev/tamboui/demo/TfxTuiDemo.java"
+        },
+        {
+          "a": "action-handler-demo",
+          "c": "action-handler-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/action-handler-demo/src/main/java/dev/tamboui/demo/actionhandler/ActionHandlerDemo.java"
+        },
+        {
+          "a": "custom-component-demo",
+          "c": "custom-component-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java"
+        },
+        {
+          "a": "emoji-demo",
+          "c": "emoji-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/emoji-demo/src/main/java/dev/tamboui/demo/EmojiDemo.java"
+        },
+        {
+          "a": "inline-toolkit-demo",
+          "c": "inline-toolkit-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/inline-toolkit-demo/src/main/java/dev/tamboui/demo/InlineToolkitDemo.java"
+        },
+        {
+          "a": "jtop-demo",
+          "c": "jtop-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/jtop-demo/src/main/java/dev/tamboui/demo/JTopDemo.java"
+        },
+        {
+          "a": "layout-demo",
+          "c": "layout-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/layout-demo/src/main/java/dev/tamboui/demo/LayoutDemo.java"
+        },
+        {
+          "a": "newyear-demo",
+          "c": "newyear-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/newyear-demo/src/main/java/dev/tamboui/demo/NewYearDemo.java"
+        },
+        {
+          "a": "richtext-demo",
+          "c": "richtext-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java"
+        },
+        {
+          "a": "textarea-demo",
+          "c": "textarea-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java"
+        },
+        {
+          "a": "toolkit-demo",
+          "c": "toolkit-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/toolkit-demo/src/main/java/dev/tamboui/demo/ToolkitDemo.java"
+        },
+        {
+          "a": "tree-demo",
+          "c": "tree-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit/demos/tree-demo/src/main/java/dev/tamboui/demo/tree/TreeDemo.java"
+        },
+        {
+          "a": "markdown-toolkit-demo",
+          "c": "markdown-toolkit-demo@tamboui/tamboui",
+          "s": "tamboui-toolkit-markdown/demos/markdown-toolkit-demo/src/main/java/dev/tamboui/demo/MarkdownToolkitDemo.java"
+        },
+        {
+          "a": "helloworld-demo",
+          "c": "helloworld-demo@tamboui/tamboui",
+          "s": "tamboui-tui/demos/helloworld-demo/src/main/java/dev/tamboui/demo/HelloWorldDemo.java"
+        },
+        {
+          "a": "logo-demo",
+          "c": "logo-demo@tamboui/tamboui",
+          "s": "tamboui-tui/demos/logo-demo/src/main/java/dev/tamboui/demo/LogoDemo.java"
+        },
+        {
+          "a": "tui-demo",
+          "c": "tui-demo@tamboui/tamboui",
+          "s": "tamboui-tui/demos/tui-demo/src/main/java/dev/tamboui/demo/TuiDemo.java"
+        },
+        {
+          "a": "barchart-demo",
+          "c": "barchart-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/barchart-demo/src/main/java/dev/tamboui/demo/BarChartDemo.java"
+        },
+        {
+          "a": "basic-demo",
+          "c": "basic-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/basic-demo/src/main/java/dev/tamboui/demo/Demo.java"
+        },
+        {
+          "a": "block-demo",
+          "c": "block-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/block-demo/src/main/java/dev/tamboui/demo/BlockDemo.java"
+        },
+        {
+          "a": "calendar-demo",
+          "c": "calendar-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/calendar-demo/src/main/java/dev/tamboui/demo/CalendarDemo.java"
+        },
+        {
+          "a": "canvas-demo",
+          "c": "canvas-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/canvas-demo/src/main/java/dev/tamboui/demo/CanvasDemo.java"
+        },
+        {
+          "a": "chart-demo",
+          "c": "chart-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/chart-demo/src/main/java/dev/tamboui/demo/ChartDemo.java"
+        },
+        {
+          "a": "collapsed-borders-demo",
+          "c": "collapsed-borders-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/collapsed-borders-demo/src/main/java/dev/tamboui/demo/CollapsedBordersDemo.java"
+        },
+        {
+          "a": "colors-rgb-demo",
+          "c": "colors-rgb-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/colors-rgb-demo/src/main/java/dev/tamboui/demo/ColorsRgbDemo.java"
+        },
+        {
+          "a": "gauge-demo",
+          "c": "gauge-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/gauge-demo/src/main/java/dev/tamboui/demo/GaugeDemo.java"
+        },
+        {
+          "a": "input-form-demo",
+          "c": "input-form-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/input-form-demo/src/main/java/dev/tamboui/demo/InputFormDemo.java"
+        },
+        {
+          "a": "list-demo",
+          "c": "list-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/list-demo/src/main/java/dev/tamboui/demo/ListDemo.java"
+        },
+        {
+          "a": "paragraph-demo",
+          "c": "paragraph-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/paragraph-demo/src/main/java/dev/tamboui/demo/ParagraphDemo.java"
+        },
+        {
+          "a": "scrollbar-demo",
+          "c": "scrollbar-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/scrollbar-demo/src/main/java/dev/tamboui/demo/ScrollbarDemo.java"
+        },
+        {
+          "a": "sparkline-demo",
+          "c": "sparkline-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/sparkline-demo/src/main/java/dev/tamboui/demo/SparklineDemo.java"
+        },
+        {
+          "a": "spinner-demo",
+          "c": "spinner-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/spinner-demo/src/main/java/dev/tamboui/demo/SpinnerDemo.java"
+        },
+        {
+          "a": "table-demo",
+          "c": "table-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/table-demo/src/main/java/dev/tamboui/demo/TableDemo.java"
+        },
+        {
+          "a": "tabs-demo",
+          "c": "tabs-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/tabs-demo/src/main/java/dev/tamboui/demo/TabsDemo.java"
+        },
+        {
+          "a": "todo-list-demo",
+          "c": "todo-list-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/todo-list-demo/src/main/java/dev/tamboui/demo/TodoListDemo.java"
+        },
+        {
+          "a": "tree-widget-demo",
+          "c": "tree-widget-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/tree-widget-demo/src/main/java/dev/tamboui/demo/TreeWidgetDemo.java"
+        },
+        {
+          "a": "wavetext-demo",
+          "c": "wavetext-demo@tamboui/tamboui",
+          "s": "tamboui-widgets/demos/wavetext-demo/src/main/java/dev/tamboui/demo/WaveTextDemo.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "aesh-ssh-http-demo",
-      "scriptRef": "demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java",
-      "command": "aesh-ssh-http-demo@tamboui/tamboui",
-      "fullcommand": "jbang aesh-ssh-http-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "error-handling-demo",
-      "scriptRef": "demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java",
-      "command": "error-handling-demo@tamboui/tamboui",
-      "fullcommand": "jbang error-handling-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "fakodex-demo",
-      "scriptRef": "demos/fakodex-demo/src/main/java/dev/tamboui/demo/coding/CodingAssistantDemo.java",
-      "command": "fakodex-demo@tamboui/tamboui",
-      "fullcommand": "jbang fakodex-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "filemanager-demo",
-      "scriptRef": "demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerDemo.java",
-      "command": "filemanager-demo@tamboui/tamboui",
-      "fullcommand": "jbang filemanager-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "flex-demo",
-      "scriptRef": "demos/flex-demo/src/main/java/dev/tamboui/demo/flex/FlexDemo.java",
-      "command": "flex-demo@tamboui/tamboui",
-      "fullcommand": "jbang flex-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "form-table-demo",
-      "scriptRef": "demos/form-table-demo/src/main/java/dev/tamboui/demo/layout/FormTableDemo.java",
-      "command": "form-table-demo@tamboui/tamboui",
-      "fullcommand": "jbang form-table-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "inline-progress-demo",
-      "scriptRef": "demos/inline-progress-demo/src/main/java/dev/tamboui/demo/InlineProgressDemo.java",
-      "command": "inline-progress-demo@tamboui/tamboui",
-      "fullcommand": "jbang inline-progress-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "listelement-demo",
-      "scriptRef": "demos/listelement-demo/src/main/java/dev/tamboui/demo/ListElementDemo.java",
-      "command": "listelement-demo@tamboui/tamboui",
-      "fullcommand": "jbang listelement-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "modular-demo",
-      "scriptRef": "demos/modular-demo/src/main/java/dev/tamboui/demo/modular/ModularDemo.java",
-      "command": "modular-demo@tamboui/tamboui",
-      "fullcommand": "jbang modular-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "rflex-demo",
-      "scriptRef": "demos/rflex-demo/src/main/java/dev/tamboui/demo/flex/RFlexDemo.java",
-      "command": "rflex-demo@tamboui/tamboui",
-      "fullcommand": "jbang rflex-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "toolkit-export-demo",
-      "scriptRef": "demos/toolkit-export-demo/src/main/java/dev/tamboui/demo/ToolkitExportDemo.java",
-      "command": "toolkit-export-demo@tamboui/tamboui",
-      "fullcommand": "jbang toolkit-export-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "unicode-demo",
-      "scriptRef": "demos/unicode-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java",
-      "command": "unicode-demo@tamboui/tamboui",
-      "fullcommand": "jbang unicode-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "unicode-inline-demo",
-      "scriptRef": "demos/unicode-inline-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java",
-      "command": "unicode-inline-demo@tamboui/tamboui",
-      "fullcommand": "jbang unicode-inline-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "dock-demo",
-      "scriptRef": "tamboui-core/demos/dock-demo/src/main/java/dev/tamboui/demo/DockDemo.java",
-      "command": "dock-demo@tamboui/tamboui",
-      "fullcommand": "jbang dock-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "export-demo",
-      "scriptRef": "tamboui-core/demos/export-demo/src/main/java/dev/tamboui/demo/ExportDemo.java",
-      "command": "export-demo@tamboui/tamboui",
-      "fullcommand": "jbang export-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "flow-demo",
-      "scriptRef": "tamboui-core/demos/flow-demo/src/main/java/dev/tamboui/demo/FlowDemo.java",
-      "command": "flow-demo@tamboui/tamboui",
-      "fullcommand": "jbang flow-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "grid-demo",
-      "scriptRef": "tamboui-core/demos/grid-demo/src/main/java/dev/tamboui/demo/GridDemo.java",
-      "command": "grid-demo@tamboui/tamboui",
-      "fullcommand": "jbang grid-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "stack-demo",
-      "scriptRef": "tamboui-core/demos/stack-demo/src/main/java/dev/tamboui/demo/StackDemo.java",
-      "command": "stack-demo@tamboui/tamboui",
-      "fullcommand": "jbang stack-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "css-demo",
-      "scriptRef": "tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java",
-      "command": "css-demo@tamboui/tamboui",
-      "fullcommand": "jbang css-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "css-no-toolkit-demo",
-      "scriptRef": "tamboui-css/demos/css-no-toolkit-demo/src/main/java/dev/tamboui/demo/CssNoToolkitDemo.java",
-      "command": "css-no-toolkit-demo@tamboui/tamboui",
-      "fullcommand": "jbang css-no-toolkit-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "image-demo",
-      "scriptRef": "tamboui-image/demos/image-demo/src/main/java/dev/tamboui/demo/ImageDemo.java",
-      "command": "image-demo@tamboui/tamboui",
-      "fullcommand": "jbang image-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "markdown-demo",
-      "scriptRef": "tamboui-markdown/demos/markdown-demo/src/main/java/dev/tamboui/demo/MarkdownDemo.java",
-      "command": "markdown-demo@tamboui/tamboui",
-      "fullcommand": "jbang markdown-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "picocli-demo",
-      "scriptRef": "tamboui-picocli/demos/picocli-demo/src/main/java/dev/tamboui/demo/PicoCLIDemo.java",
-      "command": "picocli-demo@tamboui/tamboui",
-      "fullcommand": "jbang picocli-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tfx-basic-effects-demo",
-      "scriptRef": "tamboui-tfx/demos/tfx-basic-effects-demo/src/main/java/dev/tamboui/demo/BasicEffectsTFXDemo.java",
-      "command": "tfx-basic-effects-demo@tamboui/tamboui",
-      "fullcommand": "jbang tfx-basic-effects-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tfx-demo",
-      "scriptRef": "tamboui-tfx/demos/tfx-demo/src/main/java/dev/tamboui/demo/TFXEffectsDemo.java",
-      "command": "tfx-demo@tamboui/tamboui",
-      "fullcommand": "jbang tfx-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tfx-toolkit-demo",
-      "scriptRef": "tamboui-tfx-toolkit/demos/tfx-toolkit-demo/src/main/java/dev/tamboui/demo/TfxToolkitDemo.java",
-      "command": "tfx-toolkit-demo@tamboui/tamboui",
-      "fullcommand": "jbang tfx-toolkit-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tfx-tui-demo",
-      "scriptRef": "tamboui-tfx-tui/demos/tfx-tui-demo/src/main/java/dev/tamboui/demo/TfxTuiDemo.java",
-      "command": "tfx-tui-demo@tamboui/tamboui",
-      "fullcommand": "jbang tfx-tui-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "action-handler-demo",
-      "scriptRef": "tamboui-toolkit/demos/action-handler-demo/src/main/java/dev/tamboui/demo/actionhandler/ActionHandlerDemo.java",
-      "command": "action-handler-demo@tamboui/tamboui",
-      "fullcommand": "jbang action-handler-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "custom-component-demo",
-      "scriptRef": "tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java",
-      "command": "custom-component-demo@tamboui/tamboui",
-      "fullcommand": "jbang custom-component-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "emoji-demo",
-      "scriptRef": "tamboui-toolkit/demos/emoji-demo/src/main/java/dev/tamboui/demo/EmojiDemo.java",
-      "command": "emoji-demo@tamboui/tamboui",
-      "fullcommand": "jbang emoji-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "inline-toolkit-demo",
-      "scriptRef": "tamboui-toolkit/demos/inline-toolkit-demo/src/main/java/dev/tamboui/demo/InlineToolkitDemo.java",
-      "command": "inline-toolkit-demo@tamboui/tamboui",
-      "fullcommand": "jbang inline-toolkit-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "jtop-demo",
-      "scriptRef": "tamboui-toolkit/demos/jtop-demo/src/main/java/dev/tamboui/demo/JTopDemo.java",
-      "command": "jtop-demo@tamboui/tamboui",
-      "fullcommand": "jbang jtop-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "layout-demo",
-      "scriptRef": "tamboui-toolkit/demos/layout-demo/src/main/java/dev/tamboui/demo/LayoutDemo.java",
-      "command": "layout-demo@tamboui/tamboui",
-      "fullcommand": "jbang layout-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "newyear-demo",
-      "scriptRef": "tamboui-toolkit/demos/newyear-demo/src/main/java/dev/tamboui/demo/NewYearDemo.java",
-      "command": "newyear-demo@tamboui/tamboui",
-      "fullcommand": "jbang newyear-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "richtext-demo",
-      "scriptRef": "tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java",
-      "command": "richtext-demo@tamboui/tamboui",
-      "fullcommand": "jbang richtext-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "textarea-demo",
-      "scriptRef": "tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java",
-      "command": "textarea-demo@tamboui/tamboui",
-      "fullcommand": "jbang textarea-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "toolkit-demo",
-      "scriptRef": "tamboui-toolkit/demos/toolkit-demo/src/main/java/dev/tamboui/demo/ToolkitDemo.java",
-      "command": "toolkit-demo@tamboui/tamboui",
-      "fullcommand": "jbang toolkit-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tree-demo",
-      "scriptRef": "tamboui-toolkit/demos/tree-demo/src/main/java/dev/tamboui/demo/tree/TreeDemo.java",
-      "command": "tree-demo@tamboui/tamboui",
-      "fullcommand": "jbang tree-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "markdown-toolkit-demo",
-      "scriptRef": "tamboui-toolkit-markdown/demos/markdown-toolkit-demo/src/main/java/dev/tamboui/demo/MarkdownToolkitDemo.java",
-      "command": "markdown-toolkit-demo@tamboui/tamboui",
-      "fullcommand": "jbang markdown-toolkit-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "helloworld-demo",
-      "scriptRef": "tamboui-tui/demos/helloworld-demo/src/main/java/dev/tamboui/demo/HelloWorldDemo.java",
-      "command": "helloworld-demo@tamboui/tamboui",
-      "fullcommand": "jbang helloworld-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "logo-demo",
-      "scriptRef": "tamboui-tui/demos/logo-demo/src/main/java/dev/tamboui/demo/LogoDemo.java",
-      "command": "logo-demo@tamboui/tamboui",
-      "fullcommand": "jbang logo-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tui-demo",
-      "scriptRef": "tamboui-tui/demos/tui-demo/src/main/java/dev/tamboui/demo/TuiDemo.java",
-      "command": "tui-demo@tamboui/tamboui",
-      "fullcommand": "jbang tui-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "barchart-demo",
-      "scriptRef": "tamboui-widgets/demos/barchart-demo/src/main/java/dev/tamboui/demo/BarChartDemo.java",
-      "command": "barchart-demo@tamboui/tamboui",
-      "fullcommand": "jbang barchart-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "basic-demo",
-      "scriptRef": "tamboui-widgets/demos/basic-demo/src/main/java/dev/tamboui/demo/Demo.java",
-      "command": "basic-demo@tamboui/tamboui",
-      "fullcommand": "jbang basic-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "block-demo",
-      "scriptRef": "tamboui-widgets/demos/block-demo/src/main/java/dev/tamboui/demo/BlockDemo.java",
-      "command": "block-demo@tamboui/tamboui",
-      "fullcommand": "jbang block-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "calendar-demo",
-      "scriptRef": "tamboui-widgets/demos/calendar-demo/src/main/java/dev/tamboui/demo/CalendarDemo.java",
-      "command": "calendar-demo@tamboui/tamboui",
-      "fullcommand": "jbang calendar-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "canvas-demo",
-      "scriptRef": "tamboui-widgets/demos/canvas-demo/src/main/java/dev/tamboui/demo/CanvasDemo.java",
-      "command": "canvas-demo@tamboui/tamboui",
-      "fullcommand": "jbang canvas-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "chart-demo",
-      "scriptRef": "tamboui-widgets/demos/chart-demo/src/main/java/dev/tamboui/demo/ChartDemo.java",
-      "command": "chart-demo@tamboui/tamboui",
-      "fullcommand": "jbang chart-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "collapsed-borders-demo",
-      "scriptRef": "tamboui-widgets/demos/collapsed-borders-demo/src/main/java/dev/tamboui/demo/CollapsedBordersDemo.java",
-      "command": "collapsed-borders-demo@tamboui/tamboui",
-      "fullcommand": "jbang collapsed-borders-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "colors-rgb-demo",
-      "scriptRef": "tamboui-widgets/demos/colors-rgb-demo/src/main/java/dev/tamboui/demo/ColorsRgbDemo.java",
-      "command": "colors-rgb-demo@tamboui/tamboui",
-      "fullcommand": "jbang colors-rgb-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "gauge-demo",
-      "scriptRef": "tamboui-widgets/demos/gauge-demo/src/main/java/dev/tamboui/demo/GaugeDemo.java",
-      "command": "gauge-demo@tamboui/tamboui",
-      "fullcommand": "jbang gauge-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "input-form-demo",
-      "scriptRef": "tamboui-widgets/demos/input-form-demo/src/main/java/dev/tamboui/demo/InputFormDemo.java",
-      "command": "input-form-demo@tamboui/tamboui",
-      "fullcommand": "jbang input-form-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "list-demo",
-      "scriptRef": "tamboui-widgets/demos/list-demo/src/main/java/dev/tamboui/demo/ListDemo.java",
-      "command": "list-demo@tamboui/tamboui",
-      "fullcommand": "jbang list-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "paragraph-demo",
-      "scriptRef": "tamboui-widgets/demos/paragraph-demo/src/main/java/dev/tamboui/demo/ParagraphDemo.java",
-      "command": "paragraph-demo@tamboui/tamboui",
-      "fullcommand": "jbang paragraph-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "scrollbar-demo",
-      "scriptRef": "tamboui-widgets/demos/scrollbar-demo/src/main/java/dev/tamboui/demo/ScrollbarDemo.java",
-      "command": "scrollbar-demo@tamboui/tamboui",
-      "fullcommand": "jbang scrollbar-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "sparkline-demo",
-      "scriptRef": "tamboui-widgets/demos/sparkline-demo/src/main/java/dev/tamboui/demo/SparklineDemo.java",
-      "command": "sparkline-demo@tamboui/tamboui",
-      "fullcommand": "jbang sparkline-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "spinner-demo",
-      "scriptRef": "tamboui-widgets/demos/spinner-demo/src/main/java/dev/tamboui/demo/SpinnerDemo.java",
-      "command": "spinner-demo@tamboui/tamboui",
-      "fullcommand": "jbang spinner-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "table-demo",
-      "scriptRef": "tamboui-widgets/demos/table-demo/src/main/java/dev/tamboui/demo/TableDemo.java",
-      "command": "table-demo@tamboui/tamboui",
-      "fullcommand": "jbang table-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tabs-demo",
-      "scriptRef": "tamboui-widgets/demos/tabs-demo/src/main/java/dev/tamboui/demo/TabsDemo.java",
-      "command": "tabs-demo@tamboui/tamboui",
-      "fullcommand": "jbang tabs-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "todo-list-demo",
-      "scriptRef": "tamboui-widgets/demos/todo-list-demo/src/main/java/dev/tamboui/demo/TodoListDemo.java",
-      "command": "todo-list-demo@tamboui/tamboui",
-      "fullcommand": "jbang todo-list-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "tree-widget-demo",
-      "scriptRef": "tamboui-widgets/demos/tree-widget-demo/src/main/java/dev/tamboui/demo/TreeWidgetDemo.java",
-      "command": "tree-widget-demo@tamboui/tamboui",
-      "fullcommand": "jbang tree-widget-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
-      "stars": 437,
-      "icon_url": "https://avatars.githubusercontent.com/u/251016663?v\u003d4",
-      "repoOwner": "tamboui",
-      "repoName": "tamboui",
-      "alias": "wavetext-demo",
-      "scriptRef": "tamboui-widgets/demos/wavetext-demo/src/main/java/dev/tamboui/demo/WaveTextDemo.java",
-      "command": "wavetext-demo@tamboui/tamboui",
-      "fullcommand": "jbang wavetext-demo@tamboui/tamboui",
-      "link": "https://github.com/tamboui/tamboui/blob/c5d69c1d837abe4794763d5f205ecc2f7613982c/jbang-catalog.json"
-    },
-    {
+      "owner": "quarkiverse",
+      "name": "quarkus-mcp-servers",
       "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "filesystem",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-filesystem:RELEASE@fatjar",
-      "command": "filesystem@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang filesystem@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/69191779?v=4",
+      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "filesystem",
+          "c": "filesystem@quarkiverse/quarkus-mcp-servers",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-filesystem:RELEASE@fatjar"
+        },
+        {
+          "a": "jdbc",
+          "c": "jdbc@quarkiverse/quarkus-mcp-servers",
+          "s": "jdbc/.scripts/mcpjdbc.java"
+        },
+        {
+          "a": "jfx-script",
+          "c": "jfx-script@quarkiverse/quarkus-mcp-servers",
+          "s": "jfx/src/main/java/io/quarkiverse/mcp/servers/jfx/MCPServerJFX.java"
+        },
+        {
+          "a": "jfx",
+          "c": "jfx@quarkiverse/quarkus-mcp-servers",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-jfx:RELEASE@fatjar"
+        },
+        {
+          "a": "kubernetes",
+          "c": "kubernetes@quarkiverse/quarkus-mcp-servers",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-kubernetes:RELEASE@fatjar"
+        },
+        {
+          "a": "containers",
+          "c": "containers@quarkiverse/quarkus-mcp-servers",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-containers:RELEASE@fatjar"
+        },
+        {
+          "a": "jvminsight",
+          "c": "jvminsight@quarkiverse/quarkus-mcp-servers",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-jvminsight:RELEASE@fatjar"
+        }
+      ],
+      "templates": [
+        {
+          "a": "mcp",
+          "c": "mcp@quarkiverse/quarkus-mcp-servers"
+        }
+      ]
     },
     {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "jdbc",
-      "scriptRef": "jdbc/.scripts/mcpjdbc.java",
-      "command": "jdbc@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang jdbc@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "jfx-script",
-      "scriptRef": "jfx/src/main/java/io/quarkiverse/mcp/servers/jfx/MCPServerJFX.java",
-      "command": "jfx-script@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang jfx-script@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "jfx",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-jfx:RELEASE@fatjar",
-      "command": "jfx@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang jfx@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "kubernetes",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-kubernetes:RELEASE@fatjar",
-      "command": "kubernetes@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang kubernetes@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "containers",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-containers:RELEASE@fatjar",
-      "command": "containers@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang containers@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "jvminsight",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-jvminsight:RELEASE@fatjar",
-      "command": "jvminsight@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang jvminsight@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
+      "owner": "jvm-profiling-tools",
+      "name": "ap-loader",
       "stars": 159,
-      "icon_url": "https://avatars.githubusercontent.com/u/26695883?v\u003d4",
-      "repoOwner": "jvm-profiling-tools",
-      "repoName": "ap-loader",
-      "alias": "ap-loader",
-      "description": "\u003cp\u003easync profiler loader. Use directly with \u003ccode\u003ejbang ap-loader@jvm-profiling-tools/ap-loader\u003c/code\u003e or use as agent with \u003ccode\u003ejbang --javaagent\u003dap-loader@jvm-profile-tools/ap-loader ...\u003c/code\u003e.\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
-      "command": "ap-loader@jvm-profiling-tools/ap-loader",
-      "fullcommand": "jbang ap-loader@jvm-profiling-tools/ap-loader",
-      "link": "https://github.com/jvm-profiling-tools/ap-loader/blob/f2697892e2211e2a639f12ebfc479343cd6c75af/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/26695883?v=4",
+      "link": "https://github.com/jvm-profiling-tools/ap-loader/blob/f2697892e2211e2a639f12ebfc479343cd6c75af/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "ap-loader",
+          "c": "ap-loader@jvm-profiling-tools/ap-loader",
+          "d": "<p>async profiler loader. Use directly with <code>jbang ap-loader@jvm-profiling-tools/ap-loader</code> or use as agent with <code>jbang --javaagent=ap-loader@jvm-profile-tools/ap-loader ...</code>.</p>\n",
+          "s": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar"
+        },
+        {
+          "a": "converter",
+          "c": "converter@jvm-profiling-tools/ap-loader",
+          "s": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar"
+        },
+        {
+          "a": "profiler",
+          "c": "profiler@jvm-profiling-tools/ap-loader",
+          "s": "ap-loader@jvm-profiling-tools/ap-loader"
+        },
+        {
+          "a": "jattach",
+          "c": "jattach@jvm-profiling-tools/ap-loader",
+          "s": "ap-loader@jvm-profiling-tools/ap-loader"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 159,
-      "icon_url": "https://avatars.githubusercontent.com/u/26695883?v\u003d4",
-      "repoOwner": "jvm-profiling-tools",
-      "repoName": "ap-loader",
-      "alias": "converter",
-      "scriptRef": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
-      "command": "converter@jvm-profiling-tools/ap-loader",
-      "fullcommand": "jbang converter@jvm-profiling-tools/ap-loader",
-      "link": "https://github.com/jvm-profiling-tools/ap-loader/blob/f2697892e2211e2a639f12ebfc479343cd6c75af/jbang-catalog.json"
-    },
-    {
-      "stars": 159,
-      "icon_url": "https://avatars.githubusercontent.com/u/26695883?v\u003d4",
-      "repoOwner": "jvm-profiling-tools",
-      "repoName": "ap-loader",
-      "alias": "profiler",
-      "scriptRef": "ap-loader@jvm-profiling-tools/ap-loader",
-      "command": "profiler@jvm-profiling-tools/ap-loader",
-      "fullcommand": "jbang profiler@jvm-profiling-tools/ap-loader",
-      "link": "https://github.com/jvm-profiling-tools/ap-loader/blob/f2697892e2211e2a639f12ebfc479343cd6c75af/jbang-catalog.json"
-    },
-    {
-      "stars": 159,
-      "icon_url": "https://avatars.githubusercontent.com/u/26695883?v\u003d4",
-      "repoOwner": "jvm-profiling-tools",
-      "repoName": "ap-loader",
-      "alias": "jattach",
-      "scriptRef": "ap-loader@jvm-profiling-tools/ap-loader",
-      "command": "jattach@jvm-profiling-tools/ap-loader",
-      "fullcommand": "jbang jattach@jvm-profiling-tools/ap-loader",
-      "link": "https://github.com/jvm-profiling-tools/ap-loader/blob/f2697892e2211e2a639f12ebfc479343cd6c75af/jbang-catalog.json"
-    },
-    {
+      "owner": "gufranthakur",
+      "name": "FlowForge",
       "stars": 128,
-      "icon_url": "https://avatars.githubusercontent.com/u/151453120?v\u003d4",
-      "repoOwner": "gufranthakur",
-      "repoName": "FlowForge",
-      "alias": "flowforge",
-      "scriptRef": "https://github.com/gufranthakur/FlowForge/releases/latest/download/FlowForge.jar",
-      "command": "flowforge@gufranthakur/FlowForge",
-      "fullcommand": "jbang flowforge@gufranthakur/FlowForge",
-      "link": "https://github.com/gufranthakur/FlowForge/blob/6985af4fe8870e5f1b393730f27a707ca0d7c183/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/151453120?v=4",
+      "link": "https://github.com/gufranthakur/FlowForge/blob/6985af4fe8870e5f1b393730f27a707ca0d7c183/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "flowforge",
+          "c": "flowforge@gufranthakur/FlowForge",
+          "s": "https://github.com/gufranthakur/FlowForge/releases/latest/download/FlowForge.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "jbangdev",
+      "name": "jbang-jash",
       "stars": 123,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-jash",
-      "alias": "latest",
-      "scriptRef": "latest.jsh",
-      "command": "latest@jbangdev/jbang-jash",
-      "fullcommand": "jbang latest@jbangdev/jbang-jash",
-      "link": "https://github.com/jbangdev/jbang-jash/blob/dc9b1bf941527f03a41b30e0ad4450253cb01f4d/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang-jash/blob/dc9b1bf941527f03a41b30e0ad4450253cb01f4d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "latest",
+          "c": "latest@jbangdev/jbang-jash",
+          "s": "latest.jsh"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "wanaku-ai",
+      "name": "wanaku",
       "stars": 112,
-      "icon_url": "https://avatars.githubusercontent.com/u/200620763?v\u003d4",
-      "repoOwner": "wanaku-ai",
-      "repoName": "wanaku",
-      "alias": "wanaku",
-      "description": "\u003cp\u003eRun Wanaku easily with JBang\u003c/p\u003e\n",
-      "scriptRef": "apps/wanaku-jbang/src/main/java/ai/wanaku/jbang/WanakuJBang.java",
-      "command": "wanaku@wanaku-ai/wanaku",
-      "fullcommand": "jbang wanaku@wanaku-ai/wanaku",
-      "link": "https://github.com/wanaku-ai/wanaku/blob/eeccc941760ccf6dccbb84b6f74e77dd1e08ed6e/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/200620763?v=4",
+      "link": "https://github.com/wanaku-ai/wanaku/blob/eeccc941760ccf6dccbb84b6f74e77dd1e08ed6e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "wanaku",
+          "c": "wanaku@wanaku-ai/wanaku",
+          "d": "<p>Run Wanaku easily with JBang</p>\n",
+          "s": "apps/wanaku-jbang/src/main/java/ai/wanaku/jbang/WanakuJBang.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "quarkiverse",
+      "name": "quarkus-roq",
       "stars": 105,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-roq",
-      "alias": "roq",
-      "description": "\u003cp\u003eRoq CLI - static site generator\u003c/p\u003e\n",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.1/quarkus-roq-cli-2.1.1-runner.jar",
-      "command": "roq@quarkiverse/quarkus-roq",
-      "fullcommand": "jbang roq@quarkiverse/quarkus-roq",
-      "link": "https://github.com/quarkiverse/quarkus-roq/blob/ddae526a84c5d6b670c412667f7e200e79e44b4d/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/69191779?v=4",
+      "link": "https://github.com/quarkiverse/quarkus-roq/blob/ddae526a84c5d6b670c412667f7e200e79e44b4d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "roq",
+          "c": "roq@quarkiverse/quarkus-roq",
+          "d": "<p>Roq CLI - static site generator</p>\n",
+          "s": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.1/quarkus-roq-cli-2.1.1-runner.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "spring-ai-community",
+      "name": "agent-client",
       "stars": 96,
-      "icon_url": "https://avatars.githubusercontent.com/u/190035333?v\u003d4",
-      "repoOwner": "spring-ai-community",
-      "repoName": "agent-client",
-      "alias": "agents",
-      "description": "\u003cp\u003eSpring AI Agents launcher - run AI agents on your codebase\u003c/p\u003e\n",
-      "scriptRef": "https://raw.githubusercontent.com/spring-ai-community/agent-client/main/jbang/launcher.java",
-      "command": "agents@spring-ai-community/agent-client",
-      "fullcommand": "jbang agents@spring-ai-community/agent-client",
-      "link": "https://github.com/spring-ai-community/agent-client/blob/d086dde4251082db70fdd214f21d0c3e2f6910cb/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/190035333?v=4",
+      "link": "https://github.com/spring-ai-community/agent-client/blob/d086dde4251082db70fdd214f21d0c3e2f6910cb/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "agents",
+          "c": "agents@spring-ai-community/agent-client",
+          "d": "<p>Spring AI Agents launcher - run AI agents on your codebase</p>\n",
+          "s": "https://raw.githubusercontent.com/spring-ai-community/agent-client/main/jbang/launcher.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "citrusframework",
+      "name": "yaks",
       "stars": 90,
-      "icon_url": "https://avatars.githubusercontent.com/u/27848811?v\u003d4",
-      "repoOwner": "citrusframework",
-      "repoName": "yaks",
-      "alias": "yaks",
-      "description": "\u003cp\u003eRun YAKS tests locally\u003c/p\u003e\n",
-      "scriptRef": "java/tools/yaks-jbang/dist/YaksJBang.java",
-      "command": "yaks@citrusframework/yaks",
-      "fullcommand": "jbang yaks@citrusframework/yaks",
-      "link": "https://github.com/citrusframework/yaks/blob/0ab1d0691d448ce95f0265a91fafddd85809a534/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/27848811?v=4",
+      "link": "https://github.com/citrusframework/yaks/blob/0ab1d0691d448ce95f0265a91fafddd85809a534/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "yaks",
+          "c": "yaks@citrusframework/yaks",
+          "d": "<p>Run YAKS tests locally</p>\n",
+          "s": "java/tools/yaks-jbang/dist/YaksJBang.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "commonhaus",
+      "name": "foundation",
       "stars": 72,
-      "icon_url": "https://avatars.githubusercontent.com/u/144493209?v\u003d4",
-      "repoOwner": "commonhaus",
-      "repoName": "foundation",
-      "alias": "policypanda",
-      "scriptRef": "templates/panda/PolicyPanda.java",
-      "command": "policypanda@commonhaus/foundation",
-      "fullcommand": "jbang policypanda@commonhaus/foundation",
-      "link": "https://github.com/commonhaus/foundation/blob/6f668d5b6378833396bc9573768f10232f83cd66/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/144493209?v=4",
+      "link": "https://github.com/commonhaus/foundation/blob/6f668d5b6378833396bc9573768f10232f83cd66/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "policypanda",
+          "c": "policypanda@commonhaus/foundation",
+          "s": "templates/panda/PolicyPanda.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "jbangdev",
+      "name": "jbang-catalog",
       "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "hello",
-      "description": "\u003cp\u003eScript that says hello back for each argument\u003c/p\u003e\n",
-      "scriptRef": "hello.java",
-      "command": "hello@jbangdev",
-      "fullcommand": "jbang hello@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@jbangdev",
+          "d": "<p>Script that says hello back for each argument</p>\n",
+          "s": "hello.java"
+        },
+        {
+          "a": "properties",
+          "c": "properties@jbangdev",
+          "d": "<p>Dump table of System properties</p>\n",
+          "s": "properties.java"
+        },
+        {
+          "a": "deps",
+          "c": "deps@jbangdev",
+          "d": "<p>Analyze JBang script dependencies</p>\n",
+          "s": "deps.java"
+        },
+        {
+          "a": "env",
+          "c": "env@jbangdev",
+          "d": "<p>Dump table of Environment Variables</p>\n",
+          "s": "env.java"
+        },
+        {
+          "a": "gavsearch",
+          "c": "gavsearch@jbangdev",
+          "d": "<p><code>gavsearch</code> lets you use search.maven.org from command line.\nExample: <code>gavsearch hibernate</code> will search for artifacts with hibernate in its name.\nYou can use any of the search modifiers search.maven.org supports, i.e.:\n<code>gavsearch c:QuarkusTest</code> will search for artifacts with class <code>QuarkusTest</code></p>\n",
+          "s": "gavsearch.java"
+        },
+        {
+          "a": "git",
+          "c": "git@jbangdev",
+          "d": "<p>Git command line tool implemented with jgit. Lets you do basic git features without installing git!</p>\n",
+          "s": "jgit.java"
+        },
+        {
+          "a": "bouncinglogo",
+          "c": "bouncinglogo@jbangdev",
+          "s": "bouncinglogo.java"
+        },
+        {
+          "a": "h2",
+          "c": "h2@jbangdev",
+          "s": "com.h2database:h2:1.4.200"
+        },
+        {
+          "a": "catalog2readme",
+          "c": "catalog2readme@jbangdev",
+          "s": "catalog2readme.java"
+        },
+        {
+          "a": "httpd",
+          "c": "httpd@jbangdev",
+          "d": "<p><code>httpd</code> runs a webserver serving out the content of a directory.\nExample: <code>jbang httpd@jbangdev -d _site</code> will serve out the <code>_site</code> folder on localhost:8000.</p>\n",
+          "s": "httpd.java"
+        },
+        {
+          "a": "getjava",
+          "c": "getjava@jbangdev",
+          "d": "<p>Experimental utility to download Java distributions using api.foojay.io.</p>\n",
+          "s": "getjava.java"
+        },
+        {
+          "a": "ec",
+          "c": "ec@jbangdev",
+          "s": "ec.jsh"
+        },
+        {
+          "a": "faker",
+          "c": "faker@jbangdev",
+          "s": "faker.jsh"
+        },
+        {
+          "a": "dalle",
+          "c": "dalle@jbangdev",
+          "s": "dalle.java"
+        },
+        {
+          "a": "bootstrap",
+          "c": "bootstrap@jbangdev",
+          "d": "<p>Bootstrap a jbang script to make it self-contained.</p>\n",
+          "s": "bootstrap.java"
+        },
+        {
+          "a": "jmc",
+          "c": "jmc@jbangdev",
+          "s": "jmc.jsh"
+        },
+        {
+          "a": "mf",
+          "c": "mf@jbangdev",
+          "d": "<h1>mf.java - JAR Manifest Reader CLI</h1>\n<p><code>mf</code> is a command-line tool for extracting and displaying JAR manifest information.</p>\n<h2>Usage</h2>\n<pre><code class=\"language-sh\">mf &lt;jar-file&gt; [--json] [--yaml] [--structured|-s]\n</code></pre>\n<ul>\n<li><strong><code>&lt;jar-file&gt;</code></strong>: Path to the JAR file to analyze (required). Use '-' for stdin.</li>\n<li><strong><code>--json</code></strong>: Output manifest attributes as JSON.</li>\n<li><strong><code>--yaml</code></strong>: Output manifest attributes as YAML.</li>\n<li><strong><code>--structured</code>, <code>-s</code></strong>: Parse known attributes (e.g., Import-Package, Export-Package) into structured data (lists/maps).</li>\n</ul>\n<h2>Features</h2>\n<ul>\n<li>Reads the <code>META-INF/MANIFEST.MF</code> from the specified JAR file.</li>\n<li>By default, prints manifest attributes as manifest.mf.</li>\n<li>Supports machine-readable output with <code>--json</code> or <code>--yaml</code>.</li>\n<li>Structured parsing of known attributes with <code>--structured</code>.</li>\n<li>Returns a nonzero exit code if the manifest is missing or the JAR cannot be read.</li>\n</ul>\n<h2>Examples</h2>\n<pre><code class=\"language-sh\">mf mylib.jar\nmf mylib.jar --json\nmf `jbang info jar org.junit.jupiter:junit-jupiter:5.10.0` --yaml--structured\n</code></pre>\n",
+          "s": "mf/mf.java"
+        },
+        {
+          "a": "jbang-fmt",
+          "c": "jbang-fmt@jbangdev",
+          "d": "<p>Format Java code (without messing up JBang directives).</p>\n",
+          "s": "jbang-fmt@jbangdev/jbang-fmt"
+        },
+        {
+          "a": "jbang-jupyter",
+          "c": "jbang-jupyter@jbangdev",
+          "s": "https://github.com/jbangdev/jbang-jupyter/releases/download/early-access/jbang-jupyter-0.1.0-SNAPSHOT-fatjar.jar"
+        },
+        {
+          "a": "trylink",
+          "c": "trylink@jbangdev",
+          "s": "jupyter/trylink.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "github",
+          "c": "github@jbangdev",
+          "d": "<p>Simple cli to querying github</p>\n"
+        },
+        {
+          "a": "qmcp",
+          "c": "qmcp@jbangdev",
+          "d": "<p>Simple cli to querying github</p>\n"
+        },
+        {
+          "a": "jitpack",
+          "c": "jitpack@jbangdev",
+          "d": "<p>Initializes a bare-bone jitpack.yml to enable publishing a jbang script as a maven artifact via jitpack.</p>\n<p>Example: <code>jbang init -t jitpack@jbangdev myapp.java</code> and then commit this to github and visit jitpack.io to trigger its build.</p>\n"
+        },
+        {
+          "a": "renovate",
+          "c": "renovate@jbangdev",
+          "d": "<p>Initializes a renovate.json to enable automatic management of any .java file //DEPS section.</p>\n<p>Example: <code>jbang init -t renovate@jbangdev .github/renovate.json</code> and then commit this to github and if you installed <a rel=\"nofollow\" href=\"https://github.com/apps/renovate\">https://github.com/apps/renovate</a> renovate will make issues and PR's for dependency updates.</p>\n"
+        },
+        {
+          "a": "junit",
+          "c": "junit@jbangdev",
+          "d": "<p>Basic template for JUnit tests</p>\n"
+        }
+      ]
     },
     {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "properties",
-      "description": "\u003cp\u003eDump table of System properties\u003c/p\u003e\n",
-      "scriptRef": "properties.java",
-      "command": "properties@jbangdev",
-      "fullcommand": "jbang properties@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "deps",
-      "description": "\u003cp\u003eAnalyze JBang script dependencies\u003c/p\u003e\n",
-      "scriptRef": "deps.java",
-      "command": "deps@jbangdev",
-      "fullcommand": "jbang deps@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "env",
-      "description": "\u003cp\u003eDump table of Environment Variables\u003c/p\u003e\n",
-      "scriptRef": "env.java",
-      "command": "env@jbangdev",
-      "fullcommand": "jbang env@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "gavsearch",
-      "description": "\u003cp\u003e\u003ccode\u003egavsearch\u003c/code\u003e lets you use search.maven.org from command line.\nExample: \u003ccode\u003egavsearch hibernate\u003c/code\u003e will search for artifacts with hibernate in its name.\nYou can use any of the search modifiers search.maven.org supports, i.e.:\n\u003ccode\u003egavsearch c:QuarkusTest\u003c/code\u003e will search for artifacts with class \u003ccode\u003eQuarkusTest\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "gavsearch.java",
-      "command": "gavsearch@jbangdev",
-      "fullcommand": "jbang gavsearch@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "git",
-      "description": "\u003cp\u003eGit command line tool implemented with jgit. Lets you do basic git features without installing git!\u003c/p\u003e\n",
-      "scriptRef": "jgit.java",
-      "command": "git@jbangdev",
-      "fullcommand": "jbang git@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "bouncinglogo",
-      "scriptRef": "bouncinglogo.java",
-      "command": "bouncinglogo@jbangdev",
-      "fullcommand": "jbang bouncinglogo@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "h2",
-      "scriptRef": "com.h2database:h2:1.4.200",
-      "command": "h2@jbangdev",
-      "fullcommand": "jbang h2@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "catalog2readme",
-      "scriptRef": "catalog2readme.java",
-      "command": "catalog2readme@jbangdev",
-      "fullcommand": "jbang catalog2readme@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "httpd",
-      "description": "\u003cp\u003e\u003ccode\u003ehttpd\u003c/code\u003e runs a webserver serving out the content of a directory.\nExample: \u003ccode\u003ejbang httpd@jbangdev -d _site\u003c/code\u003e will serve out the \u003ccode\u003e_site\u003c/code\u003e folder on localhost:8000.\u003c/p\u003e\n",
-      "scriptRef": "httpd.java",
-      "command": "httpd@jbangdev",
-      "fullcommand": "jbang httpd@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "getjava",
-      "description": "\u003cp\u003eExperimental utility to download Java distributions using api.foojay.io.\u003c/p\u003e\n",
-      "scriptRef": "getjava.java",
-      "command": "getjava@jbangdev",
-      "fullcommand": "jbang getjava@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "ec",
-      "scriptRef": "ec.jsh",
-      "command": "ec@jbangdev",
-      "fullcommand": "jbang ec@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "faker",
-      "scriptRef": "faker.jsh",
-      "command": "faker@jbangdev",
-      "fullcommand": "jbang faker@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "dalle",
-      "scriptRef": "dalle.java",
-      "command": "dalle@jbangdev",
-      "fullcommand": "jbang dalle@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "bootstrap",
-      "description": "\u003cp\u003eBootstrap a jbang script to make it self-contained.\u003c/p\u003e\n",
-      "scriptRef": "bootstrap.java",
-      "command": "bootstrap@jbangdev",
-      "fullcommand": "jbang bootstrap@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "jmc",
-      "scriptRef": "jmc.jsh",
-      "command": "jmc@jbangdev",
-      "fullcommand": "jbang jmc@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "mf",
-      "description": "\u003ch1\u003emf.java - JAR Manifest Reader CLI\u003c/h1\u003e\n\u003cp\u003e\u003ccode\u003emf\u003c/code\u003e is a command-line tool for extracting and displaying JAR manifest information.\u003c/p\u003e\n\u003ch2\u003eUsage\u003c/h2\u003e\n\u003cpre\u003e\u003ccode class\u003d\"language-sh\"\u003emf \u0026lt;jar-file\u0026gt; [--json] [--yaml] [--structured|-s]\n\u003c/code\u003e\u003c/pre\u003e\n\u003cul\u003e\n\u003cli\u003e\u003cstrong\u003e\u003ccode\u003e\u0026lt;jar-file\u0026gt;\u003c/code\u003e\u003c/strong\u003e: Path to the JAR file to analyze (required). Use \u0027-\u0027 for stdin.\u003c/li\u003e\n\u003cli\u003e\u003cstrong\u003e\u003ccode\u003e--json\u003c/code\u003e\u003c/strong\u003e: Output manifest attributes as JSON.\u003c/li\u003e\n\u003cli\u003e\u003cstrong\u003e\u003ccode\u003e--yaml\u003c/code\u003e\u003c/strong\u003e: Output manifest attributes as YAML.\u003c/li\u003e\n\u003cli\u003e\u003cstrong\u003e\u003ccode\u003e--structured\u003c/code\u003e, \u003ccode\u003e-s\u003c/code\u003e\u003c/strong\u003e: Parse known attributes (e.g., Import-Package, Export-Package) into structured data (lists/maps).\u003c/li\u003e\n\u003c/ul\u003e\n\u003ch2\u003eFeatures\u003c/h2\u003e\n\u003cul\u003e\n\u003cli\u003eReads the \u003ccode\u003eMETA-INF/MANIFEST.MF\u003c/code\u003e from the specified JAR file.\u003c/li\u003e\n\u003cli\u003eBy default, prints manifest attributes as manifest.mf.\u003c/li\u003e\n\u003cli\u003eSupports machine-readable output with \u003ccode\u003e--json\u003c/code\u003e or \u003ccode\u003e--yaml\u003c/code\u003e.\u003c/li\u003e\n\u003cli\u003eStructured parsing of known attributes with \u003ccode\u003e--structured\u003c/code\u003e.\u003c/li\u003e\n\u003cli\u003eReturns a nonzero exit code if the manifest is missing or the JAR cannot be read.\u003c/li\u003e\n\u003c/ul\u003e\n\u003ch2\u003eExamples\u003c/h2\u003e\n\u003cpre\u003e\u003ccode class\u003d\"language-sh\"\u003emf mylib.jar\nmf mylib.jar --json\nmf `jbang info jar org.junit.jupiter:junit-jupiter:5.10.0` --yaml--structured\n\u003c/code\u003e\u003c/pre\u003e\n",
-      "scriptRef": "mf/mf.java",
-      "command": "mf@jbangdev",
-      "fullcommand": "jbang mf@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "jbang-fmt",
-      "description": "\u003cp\u003eFormat Java code (without messing up JBang directives).\u003c/p\u003e\n",
-      "scriptRef": "jbang-fmt@jbangdev/jbang-fmt",
-      "command": "jbang-fmt@jbangdev",
-      "fullcommand": "jbang jbang-fmt@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "jbang-jupyter",
-      "scriptRef": "https://github.com/jbangdev/jbang-jupyter/releases/download/early-access/jbang-jupyter-0.1.0-SNAPSHOT-fatjar.jar",
-      "command": "jbang-jupyter@jbangdev",
-      "fullcommand": "jbang jbang-jupyter@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "trylink",
-      "scriptRef": "jupyter/trylink.java",
-      "command": "trylink@jbangdev",
-      "fullcommand": "jbang trylink@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
+      "owner": "ZenWave360",
+      "name": "zenwave-sdk",
       "stars": 56,
-      "icon_url": "https://avatars.githubusercontent.com/u/93670347?v\u003d4",
-      "repoOwner": "ZenWave360",
-      "repoName": "zenwave-sdk",
-      "alias": "release",
-      "scriptRef": "io.zenwave360.sdk:zenwave-sdk-cli:RELEASE",
-      "command": "release@ZenWave360/zenwave-sdk",
-      "fullcommand": "jbang release@ZenWave360/zenwave-sdk",
-      "link": "https://github.com/ZenWave360/zenwave-sdk/blob/7a341146430f1980bc0b68477b02cfa7abfc6081/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/93670347?v=4",
+      "link": "https://github.com/ZenWave360/zenwave-sdk/blob/7a341146430f1980bc0b68477b02cfa7abfc6081/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "release",
+          "c": "release@ZenWave360/zenwave-sdk",
+          "s": "io.zenwave360.sdk:zenwave-sdk-cli:RELEASE"
+        },
+        {
+          "a": "snapshots",
+          "c": "snapshots@ZenWave360/zenwave-sdk",
+          "s": "io.zenwave360.sdk:zenwave-sdk-cli:2.6.0-SNAPSHOT"
+        },
+        {
+          "a": "v1_7_1",
+          "c": "v1_7_1@ZenWave360/zenwave-sdk",
+          "s": "io.github.zenwave360.zenwave-sdk:zenwave-sdk-cli:1.7.1"
+        },
+        {
+          "a": "zw",
+          "c": "zw@ZenWave360/zenwave-sdk~e2e/src/test/resources/projects/monolith-clinical-project",
+          "s": "io.zenwave360.sdk:zenwave-sdk-cli:2.1.0-SNAPSHOT"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 56,
-      "icon_url": "https://avatars.githubusercontent.com/u/93670347?v\u003d4",
-      "repoOwner": "ZenWave360",
-      "repoName": "zenwave-sdk",
-      "alias": "snapshots",
-      "scriptRef": "io.zenwave360.sdk:zenwave-sdk-cli:2.6.0-SNAPSHOT",
-      "command": "snapshots@ZenWave360/zenwave-sdk",
-      "fullcommand": "jbang snapshots@ZenWave360/zenwave-sdk",
-      "link": "https://github.com/ZenWave360/zenwave-sdk/blob/7a341146430f1980bc0b68477b02cfa7abfc6081/jbang-catalog.json"
-    },
-    {
-      "stars": 56,
-      "icon_url": "https://avatars.githubusercontent.com/u/93670347?v\u003d4",
-      "repoOwner": "ZenWave360",
-      "repoName": "zenwave-sdk",
-      "alias": "v1_7_1",
-      "scriptRef": "io.github.zenwave360.zenwave-sdk:zenwave-sdk-cli:1.7.1",
-      "command": "v1_7_1@ZenWave360/zenwave-sdk",
-      "fullcommand": "jbang v1_7_1@ZenWave360/zenwave-sdk",
-      "link": "https://github.com/ZenWave360/zenwave-sdk/blob/7a341146430f1980bc0b68477b02cfa7abfc6081/jbang-catalog.json"
-    },
-    {
-      "stars": 56,
-      "icon_url": "https://avatars.githubusercontent.com/u/93670347?v\u003d4",
-      "repoOwner": "ZenWave360",
-      "repoName": "zenwave-sdk",
-      "alias": "zw",
-      "scriptRef": "io.zenwave360.sdk:zenwave-sdk-cli:2.1.0-SNAPSHOT",
-      "command": "zw@ZenWave360/zenwave-sdk~e2e/src/test/resources/projects/monolith-clinical-project",
-      "fullcommand": "jbang zw@ZenWave360/zenwave-sdk~e2e/src/test/resources/projects/monolith-clinical-project",
-      "link": "https://github.com/ZenWave360/zenwave-sdk/blob/7a341146430f1980bc0b68477b02cfa7abfc6081/e2e/src/test/resources/projects/monolith-clinical-project/jbang-catalog.json"
-    },
-    {
+      "owner": "nikolassv",
+      "name": "md-serve",
       "stars": 54,
-      "icon_url": "https://avatars.githubusercontent.com/u/1006908?v\u003d4",
-      "repoOwner": "nikolassv",
-      "repoName": "md-serve",
-      "alias": "md-serve",
-      "description": "\u003cp\u003eServe a directory of Markdown files as rendered HTML\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/nikolassv/md-serve/releases/latest/download/md-serve.jar",
-      "command": "md-serve@nikolassv/md-serve",
-      "fullcommand": "jbang md-serve@nikolassv/md-serve",
-      "link": "https://github.com/nikolassv/md-serve/blob/53f6fbff2d24b92c64a67990da4ce3b6d892827f/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/1006908?v=4",
+      "link": "https://github.com/nikolassv/md-serve/blob/53f6fbff2d24b92c64a67990da4ce3b6d892827f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "md-serve",
+          "c": "md-serve@nikolassv/md-serve",
+          "d": "<p>Serve a directory of Markdown files as rendered HTML</p>\n",
+          "s": "https://github.com/nikolassv/md-serve/releases/latest/download/md-serve.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "apache",
+      "name": "sling-whiteboard",
       "stars": 48,
-      "icon_url": "https://avatars.githubusercontent.com/u/47359?v\u003d4",
-      "repoOwner": "apache",
-      "repoName": "sling-whiteboard",
-      "alias": "start",
-      "description": "\u003cp\u003eStart Apache Sling\u003c/p\u003e\n",
-      "scriptRef": "jbang/SlingStarter.java",
-      "command": "start@apache/sling-whiteboard",
-      "fullcommand": "jbang start@apache/sling-whiteboard",
-      "link": "https://github.com/apache/sling-whiteboard/blob/c2ad0487b498c2a30ba96f780ee3818bb421c3dc/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/47359?v=4",
+      "link": "https://github.com/apache/sling-whiteboard/blob/c2ad0487b498c2a30ba96f780ee3818bb421c3dc/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "start",
+          "c": "start@apache/sling-whiteboard",
+          "d": "<p>Start Apache Sling</p>\n",
+          "s": "jbang/SlingStarter.java"
+        },
+        {
+          "a": "repoinitValidator",
+          "c": "repoinitValidator@apache/sling-whiteboard",
+          "d": "<p>Validate a Repoinit script</p>\n",
+          "s": "jbang/RepoinitValidator.java"
+        },
+        {
+          "a": "jvmVersion",
+          "c": "jvmVersion@apache/sling-whiteboard",
+          "d": "<p>Run with a specific JVM version</p>\n",
+          "s": "jbang/jvmVersion.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 48,
-      "icon_url": "https://avatars.githubusercontent.com/u/47359?v\u003d4",
-      "repoOwner": "apache",
-      "repoName": "sling-whiteboard",
-      "alias": "repoinitValidator",
-      "description": "\u003cp\u003eValidate a Repoinit script\u003c/p\u003e\n",
-      "scriptRef": "jbang/RepoinitValidator.java",
-      "command": "repoinitValidator@apache/sling-whiteboard",
-      "fullcommand": "jbang repoinitValidator@apache/sling-whiteboard",
-      "link": "https://github.com/apache/sling-whiteboard/blob/c2ad0487b498c2a30ba96f780ee3818bb421c3dc/jbang-catalog.json"
-    },
-    {
-      "stars": 48,
-      "icon_url": "https://avatars.githubusercontent.com/u/47359?v\u003d4",
-      "repoOwner": "apache",
-      "repoName": "sling-whiteboard",
-      "alias": "jvmVersion",
-      "description": "\u003cp\u003eRun with a specific JVM version\u003c/p\u003e\n",
-      "scriptRef": "jbang/jvmVersion.java",
-      "command": "jvmVersion@apache/sling-whiteboard",
-      "fullcommand": "jbang jvmVersion@apache/sling-whiteboard",
-      "link": "https://github.com/apache/sling-whiteboard/blob/c2ad0487b498c2a30ba96f780ee3818bb421c3dc/jbang-catalog.json"
-    },
-    {
+      "owner": "manikmagar",
+      "name": "mulefd",
       "stars": 46,
-      "icon_url": "https://avatars.githubusercontent.com/u/877286?v\u003d4",
-      "repoOwner": "manikmagar",
-      "repoName": "mulefd",
-      "alias": "mulefd",
-      "description": "\u003cp\u003eRuns Mule Flow Diagrams\u003c/p\u003e\n",
-      "scriptRef": "jbang/mulefd.java",
-      "command": "mulefd@manikmagar/mulefd",
-      "fullcommand": "jbang mulefd@manikmagar/mulefd",
-      "link": "https://github.com/manikmagar/mulefd/blob/5a4e43a1638576110e3e17e44cb6df48a511e91c/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/877286?v=4",
+      "link": "https://github.com/manikmagar/mulefd/blob/5a4e43a1638576110e3e17e44cb6df48a511e91c/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mulefd",
+          "c": "mulefd@manikmagar/mulefd",
+          "d": "<p>Runs Mule Flow Diagrams</p>\n",
+          "s": "jbang/mulefd.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "parttimenerd",
+      "name": "jstall",
       "stars": 43,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "jstall",
-      "alias": "jstall",
-      "scriptRef": "https://github.com/parttimenerd/jstall/releases/download/v0.7.0/jstall.jar",
-      "command": "jstall@parttimenerd/jstall",
-      "fullcommand": "jbang jstall@parttimenerd/jstall",
-      "link": "https://github.com/parttimenerd/jstall/blob/ecb4486e9685682d857c20f3a20a170d0ff9b13c/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/jstall/blob/ecb4486e9685682d857c20f3a20a170d0ff9b13c/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jstall",
+          "c": "jstall@parttimenerd/jstall",
+          "s": "https://github.com/parttimenerd/jstall/releases/download/v0.7.0/jstall.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "linux-china",
+      "name": "task-keeper",
       "stars": 43,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "task-keeper",
-      "alias": "Hello",
-      "description": "\u003cp\u003eJava Hello World\u003c/p\u003e\n",
-      "scriptRef": "temp/Hello.java",
-      "command": "Hello@linux-china/task-keeper",
-      "fullcommand": "jbang Hello@linux-china/task-keeper",
-      "link": "https://github.com/linux-china/task-keeper/blob/c1155a9151e99b0a5413a50ee7374efe6386a54b/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/task-keeper/blob/c1155a9151e99b0a5413a50ee7374efe6386a54b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "Hello",
+          "c": "Hello@linux-china/task-keeper",
+          "d": "<p>Java Hello World</p>\n",
+          "s": "temp/Hello.java"
+        },
+        {
+          "a": "HelloWorld",
+          "c": "HelloWorld@linux-china/task-keeper",
+          "d": "<p>Java Hello World Clone</p>\n",
+          "s": "temp/Hello.java"
+        },
+        {
+          "a": "HelloWorld",
+          "c": "HelloWorld@linux-china/task-keeper~src/templates",
+          "d": "<p>Hello World</p>\n",
+          "s": "src/main/jbang/HelloWorld.java"
+        },
+        {
+          "a": "YourApp",
+          "c": "YourApp@linux-china/task-keeper~src/templates",
+          "d": "<p>Run your app</p>\n",
+          "s": "src/main/jbang/YourApp.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 43,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "task-keeper",
-      "alias": "HelloWorld",
-      "description": "\u003cp\u003eJava Hello World Clone\u003c/p\u003e\n",
-      "scriptRef": "temp/Hello.java",
-      "command": "HelloWorld@linux-china/task-keeper",
-      "fullcommand": "jbang HelloWorld@linux-china/task-keeper",
-      "link": "https://github.com/linux-china/task-keeper/blob/c1155a9151e99b0a5413a50ee7374efe6386a54b/jbang-catalog.json"
-    },
-    {
-      "stars": 43,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "task-keeper",
-      "alias": "HelloWorld",
-      "description": "\u003cp\u003eHello World\u003c/p\u003e\n",
-      "scriptRef": "src/main/jbang/HelloWorld.java",
-      "command": "HelloWorld@linux-china/task-keeper~src/templates",
-      "fullcommand": "jbang HelloWorld@linux-china/task-keeper~src/templates",
-      "link": "https://github.com/linux-china/task-keeper/blob/c1155a9151e99b0a5413a50ee7374efe6386a54b/src/templates/jbang-catalog.json"
-    },
-    {
-      "stars": 43,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "task-keeper",
-      "alias": "YourApp",
-      "description": "\u003cp\u003eRun your app\u003c/p\u003e\n",
-      "scriptRef": "src/main/jbang/YourApp.java",
-      "command": "YourApp@linux-china/task-keeper~src/templates",
-      "fullcommand": "jbang YourApp@linux-china/task-keeper~src/templates",
-      "link": "https://github.com/linux-china/task-keeper/blob/c1155a9151e99b0a5413a50ee7374efe6386a54b/src/templates/jbang-catalog.json"
-    },
-    {
+      "owner": "brunoborges",
+      "name": "jairosvg",
       "stars": 34,
-      "icon_url": "https://avatars.githubusercontent.com/u/129743?v\u003d4",
-      "repoOwner": "brunoborges",
-      "repoName": "jairosvg",
-      "alias": "jairosvg",
-      "description": "\u003cp\u003eSVG to PNG/PDF/PS converter powered by Java2D\u003c/p\u003e\n",
-      "scriptRef": "io.brunoborges:jairosvg:1.0.10",
-      "command": "jairosvg@brunoborges/jairosvg",
-      "fullcommand": "jbang jairosvg@brunoborges/jairosvg",
-      "link": "https://github.com/brunoborges/jairosvg/blob/fd1cbda8dcd088519e55c81f9c8cbbd4285b3cb7/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/129743?v=4",
+      "link": "https://github.com/brunoborges/jairosvg/blob/fd1cbda8dcd088519e55c81f9c8cbbd4285b3cb7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jairosvg",
+          "c": "jairosvg@brunoborges/jairosvg",
+          "d": "<p>SVG to PNG/PDF/PS converter powered by Java2D</p>\n",
+          "s": "io.brunoborges:jairosvg:1.0.10"
+        },
+        {
+          "a": "benchmark",
+          "c": "benchmark@brunoborges/jairosvg",
+          "d": "<p>SVG \u2192 PNG benchmark: JairoSVG vs EchoSVG vs JSVG vs CairoSVG</p>\n",
+          "s": "comparison/benchmark/benchmark.java"
+        },
+        {
+          "a": "update-readme",
+          "c": "update-readme@brunoborges/jairosvg",
+          "d": "<p>Regenerate benchmark README tables from benchmark-results.jsonl</p>\n",
+          "s": "comparison/benchmark/update_readme.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 34,
-      "icon_url": "https://avatars.githubusercontent.com/u/129743?v\u003d4",
-      "repoOwner": "brunoborges",
-      "repoName": "jairosvg",
-      "alias": "benchmark",
-      "description": "\u003cp\u003eSVG → PNG benchmark: JairoSVG vs EchoSVG vs JSVG vs CairoSVG\u003c/p\u003e\n",
-      "scriptRef": "comparison/benchmark/benchmark.java",
-      "command": "benchmark@brunoborges/jairosvg",
-      "fullcommand": "jbang benchmark@brunoborges/jairosvg",
-      "link": "https://github.com/brunoborges/jairosvg/blob/fd1cbda8dcd088519e55c81f9c8cbbd4285b3cb7/jbang-catalog.json"
-    },
-    {
-      "stars": 34,
-      "icon_url": "https://avatars.githubusercontent.com/u/129743?v\u003d4",
-      "repoOwner": "brunoborges",
-      "repoName": "jairosvg",
-      "alias": "update-readme",
-      "description": "\u003cp\u003eRegenerate benchmark README tables from benchmark-results.jsonl\u003c/p\u003e\n",
-      "scriptRef": "comparison/benchmark/update_readme.java",
-      "command": "update-readme@brunoborges/jairosvg",
-      "fullcommand": "jbang update-readme@brunoborges/jairosvg",
-      "link": "https://github.com/brunoborges/jairosvg/blob/fd1cbda8dcd088519e55c81f9c8cbbd4285b3cb7/jbang-catalog.json"
-    },
-    {
+      "owner": "parttimenerd",
+      "name": "meta-agent",
       "stars": 33,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "meta-agent",
-      "alias": "meta-agent",
-      "scriptRef": "http://github.com/parttimenerd/meta-agent/releases/latest/download/meta-agent.jar",
-      "command": "meta-agent@parttimenerd/meta-agent",
-      "fullcommand": "jbang meta-agent@parttimenerd/meta-agent",
-      "link": "https://github.com/parttimenerd/meta-agent/blob/a255e888a8d86c667375117c0decba4a34d25734/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/meta-agent/blob/a255e888a8d86c667375117c0decba4a34d25734/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "meta-agent",
+          "c": "meta-agent@parttimenerd/meta-agent",
+          "s": "http://github.com/parttimenerd/meta-agent/releases/latest/download/meta-agent.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "ricksbrown",
+      "name": "cowsay",
       "stars": 32,
-      "icon_url": "https://avatars.githubusercontent.com/u/4993735?v\u003d4",
-      "repoOwner": "ricksbrown",
-      "repoName": "cowsay",
-      "alias": "cowsay",
-      "scriptRef": "com.github.ricksbrown:cowsay:LATEST",
-      "command": "cowsay@ricksbrown/cowsay",
-      "fullcommand": "jbang cowsay@ricksbrown/cowsay",
-      "link": "https://github.com/ricksbrown/cowsay/blob/dd10fd483540780bef5a269356f059005ac5c6f0/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/4993735?v=4",
+      "link": "https://github.com/ricksbrown/cowsay/blob/dd10fd483540780bef5a269356f059005ac5c6f0/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "cowsay",
+          "c": "cowsay@ricksbrown/cowsay",
+          "s": "com.github.ricksbrown:cowsay:LATEST"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "maveniverse",
+      "name": "pilot",
       "stars": 31,
-      "icon_url": "https://avatars.githubusercontent.com/u/118349365?v\u003d4",
-      "repoOwner": "maveniverse",
-      "repoName": "pilot",
-      "alias": "pilot",
-      "description": "\u003cp\u003eInteractive TUI for Maven -- search, browse, and manage dependencies\u003c/p\u003e\n",
-      "scriptRef": "GAV:eu.maveniverse.maven.plugins:pilot-cli:RELEASE",
-      "command": "pilot@maveniverse/pilot",
-      "fullcommand": "jbang pilot@maveniverse/pilot",
-      "link": "https://github.com/maveniverse/pilot/blob/28115c530dca09455ae78d375960ee96e5447f90/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/118349365?v=4",
+      "link": "https://github.com/maveniverse/pilot/blob/28115c530dca09455ae78d375960ee96e5447f90/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pilot",
+          "c": "pilot@maveniverse/pilot",
+          "d": "<p>Interactive TUI for Maven -- search, browse, and manage dependencies</p>\n",
+          "s": "GAV:eu.maveniverse.maven.plugins:pilot-cli:RELEASE"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "worldline",
+      "name": "learning-kotlin",
       "stars": 30,
-      "icon_url": "https://avatars.githubusercontent.com/u/5173767?v\u003d4",
-      "repoOwner": "worldline",
-      "repoName": "learning-kotlin",
-      "alias": "jfxapp",
-      "description": "\u003cp\u003eSingle file JavaFX application that defined the UI with code (no fxml)\u003c/p\u003e\n",
-      "scriptRef": "material/scripting/jbang/jfxdemo.kt",
-      "command": "jfxapp@worldline/learning-kotlin",
-      "fullcommand": "jbang jfxapp@worldline/learning-kotlin",
-      "link": "https://github.com/worldline/learning-kotlin/blob/bffc395ae1426a7a0b822e7e9902ae00130b23c3/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/5173767?v=4",
+      "link": "https://github.com/worldline/learning-kotlin/blob/bffc395ae1426a7a0b822e7e9902ae00130b23c3/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfxapp",
+          "c": "jfxapp@worldline/learning-kotlin",
+          "d": "<p>Single file JavaFX application that defined the UI with code (no fxml)</p>\n",
+          "s": "material/scripting/jbang/jfxdemo.kt"
+        }
+      ],
+      "templates": [
+        {
+          "a": "jfxkt-legacy",
+          "c": "jfxkt-legacy@worldline/learning-kotlin",
+          "d": "<p>Single file JavaFX application</p>\n"
+        },
+        {
+          "a": "jfxkt",
+          "c": "jfxkt@worldline/learning-kotlin",
+          "d": "<p>Single file JavaFX application that defined the UI with code (no fxml)</p>\n"
+        }
+      ]
     },
     {
+      "owner": "mariofusco",
+      "name": "site-summarizer",
       "stars": 27,
-      "icon_url": "https://avatars.githubusercontent.com/u/372781?v\u003d4",
-      "repoOwner": "mariofusco",
-      "repoName": "site-summarizer",
-      "alias": "doit",
-      "scriptRef": "summarize.java",
-      "command": "doit@mariofusco/site-summarizer",
-      "fullcommand": "jbang doit@mariofusco/site-summarizer",
-      "link": "https://github.com/mariofusco/site-summarizer/blob/7c75b660fdee522313e2b8dd4cb3d02ae135f662/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/372781?v=4",
+      "link": "https://github.com/mariofusco/site-summarizer/blob/7c75b660fdee522313e2b8dd4cb3d02ae135f662/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "doit",
+          "c": "doit@mariofusco/site-summarizer",
+          "s": "summarize.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "jbangdev",
+      "name": "jbang-examples",
       "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "jfxtiles",
-      "scriptRef": "examples/jfxtiles.java",
-      "command": "jfxtiles@jbangdev/jbang-examples",
-      "fullcommand": "jbang jfxtiles@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfxtiles",
+          "c": "jfxtiles@jbangdev/jbang-examples",
+          "s": "examples/jfxtiles.java"
+        },
+        {
+          "a": "perftest",
+          "c": "perftest@jbangdev/jbang-examples",
+          "s": "examples/benchmark/perftest.java"
+        },
+        {
+          "a": "hibernate",
+          "c": "hibernate@jbangdev/jbang-examples",
+          "s": "examples/hibernate.java"
+        },
+        {
+          "a": "jfx",
+          "c": "jfx@jbangdev/jbang-examples",
+          "s": "examples/jfx.java"
+        },
+        {
+          "a": "junitrun",
+          "c": "junitrun@jbangdev/jbang-examples",
+          "s": "examples/junitrun.java"
+        },
+        {
+          "a": "findmodule",
+          "c": "findmodule@jbangdev/jbang-examples",
+          "s": "examples/findmodule.java"
+        },
+        {
+          "a": "records",
+          "c": "records@jbangdev/jbang-examples",
+          "s": "examples/records.java"
+        },
+        {
+          "a": "progress",
+          "c": "progress@jbangdev/jbang-examples",
+          "s": "examples/progress.java"
+        },
+        {
+          "a": "webdriver",
+          "c": "webdriver@jbangdev/jbang-examples",
+          "s": "examples/webdriver.java"
+        },
+        {
+          "a": "junit-run",
+          "c": "junit-run@jbangdev/jbang-examples",
+          "s": "examples/junit-run.java"
+        },
+        {
+          "a": "camel",
+          "c": "camel@jbangdev/jbang-examples",
+          "s": "examples/camel.java"
+        },
+        {
+          "a": "asciidoc",
+          "c": "asciidoc@jbangdev/jbang-examples",
+          "s": "examples/asciidoc.java"
+        },
+        {
+          "a": "gh_fetch_release_assets",
+          "c": "gh_fetch_release_assets@jbangdev/jbang-examples",
+          "s": "examples/gh_fetch_release_assets.java"
+        },
+        {
+          "a": "piping",
+          "c": "piping@jbangdev/jbang-examples",
+          "s": "examples/piping.java"
+        },
+        {
+          "a": "smee",
+          "c": "smee@jbangdev/jbang-examples",
+          "s": "examples/smee.java"
+        },
+        {
+          "a": "lang",
+          "c": "lang@jbangdev/jbang-examples",
+          "s": "examples/lang.java"
+        },
+        {
+          "a": "docker",
+          "c": "docker@jbangdev/jbang-examples",
+          "s": "examples/docker.java"
+        },
+        {
+          "a": "classpath_example",
+          "c": "classpath_example@jbangdev/jbang-examples",
+          "s": "examples/classpath_example.jsh"
+        },
+        {
+          "a": "tz",
+          "c": "tz@jbangdev/jbang-examples",
+          "s": "examples/tz.java"
+        },
+        {
+          "a": "vertx",
+          "c": "vertx@jbangdev/jbang-examples",
+          "s": "examples/vertx.java"
+        },
+        {
+          "a": "urldep",
+          "c": "urldep@jbangdev/jbang-examples",
+          "s": "examples/urldep.java"
+        },
+        {
+          "a": "helloworld",
+          "c": "helloworld@jbangdev/jbang-examples",
+          "s": "examples/helloworld.jsh"
+        },
+        {
+          "a": "undertow",
+          "c": "undertow@jbangdev/jbang-examples",
+          "s": "examples/undertow.java"
+        },
+        {
+          "a": "inetTest",
+          "c": "inetTest@jbangdev/jbang-examples",
+          "s": "examples/inetTest.java"
+        },
+        {
+          "a": "envdetector",
+          "c": "envdetector@jbangdev/jbang-examples",
+          "s": "examples/envdetector.java"
+        },
+        {
+          "a": "shrinkwrap",
+          "c": "shrinkwrap@jbangdev/jbang-examples",
+          "s": "examples/shrinkwrap.java"
+        },
+        {
+          "a": "resteasyclient",
+          "c": "resteasyclient@jbangdev/jbang-examples",
+          "s": "examples/resteasyclient.java"
+        },
+        {
+          "a": "adoptopenjdk",
+          "c": "adoptopenjdk@jbangdev/jbang-examples",
+          "s": "examples/adoptopenjdk.java"
+        },
+        {
+          "a": "analytics",
+          "c": "analytics@jbangdev/jbang-examples",
+          "s": "examples/analytics.java"
+        },
+        {
+          "a": "imap",
+          "c": "imap@jbangdev/jbang-examples",
+          "s": "examples/imap.java"
+        },
+        {
+          "a": "githubinfo",
+          "c": "githubinfo@jbangdev/jbang-examples",
+          "s": "examples/githubinfo.java"
+        },
+        {
+          "a": "script",
+          "c": "script@jbangdev/jbang-examples",
+          "s": "examples/script.java"
+        },
+        {
+          "a": "ratpack",
+          "c": "ratpack@jbangdev/jbang-examples",
+          "s": "examples/ratpack.java"
+        },
+        {
+          "a": "checksum",
+          "c": "checksum@jbangdev/jbang-examples",
+          "s": "examples/checksum.java"
+        },
+        {
+          "a": "s3upload",
+          "c": "s3upload@jbangdev/jbang-examples",
+          "s": "examples/s3upload.java"
+        },
+        {
+          "a": "sparkjava",
+          "c": "sparkjava@jbangdev/jbang-examples",
+          "s": "examples/sparkjava.java"
+        },
+        {
+          "a": "jetty",
+          "c": "jetty@jbangdev/jbang-examples",
+          "s": "examples/jetty.jsh"
+        },
+        {
+          "a": "NanoClock",
+          "c": "NanoClock@jbangdev/jbang-examples",
+          "s": "examples/NanoClock.java"
+        },
+        {
+          "a": "asciidoctor",
+          "c": "asciidoctor@jbangdev/jbang-examples",
+          "s": "examples/asciidoctor.java"
+        },
+        {
+          "a": "gh_release_stats",
+          "c": "gh_release_stats@jbangdev/jbang-examples",
+          "s": "examples/gh_release_stats.java"
+        },
+        {
+          "a": "grabavatars",
+          "c": "grabavatars@jbangdev/jbang-examples",
+          "s": "examples/grabavatars.java"
+        },
+        {
+          "a": "ilc",
+          "c": "ilc@jbangdev/jbang-examples",
+          "s": "examples/ilc.java"
+        },
+        {
+          "a": "mockneatSQL",
+          "c": "mockneatSQL@jbangdev/jbang-examples",
+          "s": "examples/mockneatSQL.java"
+        },
+        {
+          "a": "opencv_ball_tracker",
+          "c": "opencv_ball_tracker@jbangdev/jbang-examples",
+          "s": "examples/opencv_ball_tracker.java"
+        },
+        {
+          "a": "plantuml",
+          "c": "plantuml@jbangdev/jbang-examples",
+          "s": "examples/plantuml.java"
+        },
+        {
+          "a": "quarkus",
+          "c": "quarkus@jbangdev/jbang-examples",
+          "s": "examples/quarkus.java"
+        },
+        {
+          "a": "quarkusadv",
+          "c": "quarkusadv@jbangdev/jbang-examples",
+          "s": "examples/quarkusadv.java"
+        },
+        {
+          "a": "quarkuscli",
+          "c": "quarkuscli@jbangdev/jbang-examples",
+          "s": "examples/quarkuscli.java"
+        },
+        {
+          "a": "quarkusclidb",
+          "c": "quarkusclidb@jbangdev/jbang-examples",
+          "s": "examples/quarkusclidb.java"
+        },
+        {
+          "a": "quarkusclireddis",
+          "c": "quarkusclireddis@jbangdev/jbang-examples",
+          "s": "examples/quarkusclireddis.java"
+        },
+        {
+          "a": "quarkusjib",
+          "c": "quarkusjib@jbangdev/jbang-examples",
+          "s": "examples/quarkusjib.java"
+        },
+        {
+          "a": "quarkusmetrics",
+          "c": "quarkusmetrics@jbangdev/jbang-examples",
+          "s": "examples/quarkusmetrics.java"
+        },
+        {
+          "a": "quarkusnew",
+          "c": "quarkusnew@jbangdev/jbang-examples",
+          "s": "examples/quarkusnew.java"
+        },
+        {
+          "a": "resource",
+          "c": "resource@jbangdev/jbang-examples",
+          "s": "examples/resource.java"
+        },
+        {
+          "a": "update_catalog",
+          "c": "update_catalog@jbangdev/jbang-examples",
+          "s": "examples/update_catalog.java"
+        },
+        {
+          "a": "viewics",
+          "c": "viewics@jbangdev/jbang-examples",
+          "s": "examples/viewics.java"
+        },
+        {
+          "a": "qchat",
+          "c": "qchat@jbangdev/jbang-examples",
+          "s": "examples/qchat.java"
+        },
+        {
+          "a": "ecsh",
+          "c": "ecsh@jbangdev/jbang-examples",
+          "d": "<p>Eclipse Collections API for scripting\nTry out using <code>jbang -s ecsh@jbangdev -i</code></p>\n",
+          "s": "examples/ecsh.jsh"
+        },
+        {
+          "a": "j18inetresolver",
+          "c": "j18inetresolver@jbangdev/jbang-examples",
+          "s": "examples/java/J18InetAddressResolverProvider.java"
+        },
+        {
+          "a": "symjajsh",
+          "c": "symjajsh@jbangdev/jbang-examples",
+          "s": "examples/symja.jsh"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "perftest",
-      "scriptRef": "examples/benchmark/perftest.java",
-      "command": "perftest@jbangdev/jbang-examples",
-      "fullcommand": "jbang perftest@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "hibernate",
-      "scriptRef": "examples/hibernate.java",
-      "command": "hibernate@jbangdev/jbang-examples",
-      "fullcommand": "jbang hibernate@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "jfx",
-      "scriptRef": "examples/jfx.java",
-      "command": "jfx@jbangdev/jbang-examples",
-      "fullcommand": "jbang jfx@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "junitrun",
-      "scriptRef": "examples/junitrun.java",
-      "command": "junitrun@jbangdev/jbang-examples",
-      "fullcommand": "jbang junitrun@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "findmodule",
-      "scriptRef": "examples/findmodule.java",
-      "command": "findmodule@jbangdev/jbang-examples",
-      "fullcommand": "jbang findmodule@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "records",
-      "scriptRef": "examples/records.java",
-      "command": "records@jbangdev/jbang-examples",
-      "fullcommand": "jbang records@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "progress",
-      "scriptRef": "examples/progress.java",
-      "command": "progress@jbangdev/jbang-examples",
-      "fullcommand": "jbang progress@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "webdriver",
-      "scriptRef": "examples/webdriver.java",
-      "command": "webdriver@jbangdev/jbang-examples",
-      "fullcommand": "jbang webdriver@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "junit-run",
-      "scriptRef": "examples/junit-run.java",
-      "command": "junit-run@jbangdev/jbang-examples",
-      "fullcommand": "jbang junit-run@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "camel",
-      "scriptRef": "examples/camel.java",
-      "command": "camel@jbangdev/jbang-examples",
-      "fullcommand": "jbang camel@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "asciidoc",
-      "scriptRef": "examples/asciidoc.java",
-      "command": "asciidoc@jbangdev/jbang-examples",
-      "fullcommand": "jbang asciidoc@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "gh_fetch_release_assets",
-      "scriptRef": "examples/gh_fetch_release_assets.java",
-      "command": "gh_fetch_release_assets@jbangdev/jbang-examples",
-      "fullcommand": "jbang gh_fetch_release_assets@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "piping",
-      "scriptRef": "examples/piping.java",
-      "command": "piping@jbangdev/jbang-examples",
-      "fullcommand": "jbang piping@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "smee",
-      "scriptRef": "examples/smee.java",
-      "command": "smee@jbangdev/jbang-examples",
-      "fullcommand": "jbang smee@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "lang",
-      "scriptRef": "examples/lang.java",
-      "command": "lang@jbangdev/jbang-examples",
-      "fullcommand": "jbang lang@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "docker",
-      "scriptRef": "examples/docker.java",
-      "command": "docker@jbangdev/jbang-examples",
-      "fullcommand": "jbang docker@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "classpath_example",
-      "scriptRef": "examples/classpath_example.jsh",
-      "command": "classpath_example@jbangdev/jbang-examples",
-      "fullcommand": "jbang classpath_example@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "tz",
-      "scriptRef": "examples/tz.java",
-      "command": "tz@jbangdev/jbang-examples",
-      "fullcommand": "jbang tz@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "vertx",
-      "scriptRef": "examples/vertx.java",
-      "command": "vertx@jbangdev/jbang-examples",
-      "fullcommand": "jbang vertx@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "urldep",
-      "scriptRef": "examples/urldep.java",
-      "command": "urldep@jbangdev/jbang-examples",
-      "fullcommand": "jbang urldep@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "helloworld",
-      "scriptRef": "examples/helloworld.jsh",
-      "command": "helloworld@jbangdev/jbang-examples",
-      "fullcommand": "jbang helloworld@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "undertow",
-      "scriptRef": "examples/undertow.java",
-      "command": "undertow@jbangdev/jbang-examples",
-      "fullcommand": "jbang undertow@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "inetTest",
-      "scriptRef": "examples/inetTest.java",
-      "command": "inetTest@jbangdev/jbang-examples",
-      "fullcommand": "jbang inetTest@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "envdetector",
-      "scriptRef": "examples/envdetector.java",
-      "command": "envdetector@jbangdev/jbang-examples",
-      "fullcommand": "jbang envdetector@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "shrinkwrap",
-      "scriptRef": "examples/shrinkwrap.java",
-      "command": "shrinkwrap@jbangdev/jbang-examples",
-      "fullcommand": "jbang shrinkwrap@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "resteasyclient",
-      "scriptRef": "examples/resteasyclient.java",
-      "command": "resteasyclient@jbangdev/jbang-examples",
-      "fullcommand": "jbang resteasyclient@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "adoptopenjdk",
-      "scriptRef": "examples/adoptopenjdk.java",
-      "command": "adoptopenjdk@jbangdev/jbang-examples",
-      "fullcommand": "jbang adoptopenjdk@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "analytics",
-      "scriptRef": "examples/analytics.java",
-      "command": "analytics@jbangdev/jbang-examples",
-      "fullcommand": "jbang analytics@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "imap",
-      "scriptRef": "examples/imap.java",
-      "command": "imap@jbangdev/jbang-examples",
-      "fullcommand": "jbang imap@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "githubinfo",
-      "scriptRef": "examples/githubinfo.java",
-      "command": "githubinfo@jbangdev/jbang-examples",
-      "fullcommand": "jbang githubinfo@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "script",
-      "scriptRef": "examples/script.java",
-      "command": "script@jbangdev/jbang-examples",
-      "fullcommand": "jbang script@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "ratpack",
-      "scriptRef": "examples/ratpack.java",
-      "command": "ratpack@jbangdev/jbang-examples",
-      "fullcommand": "jbang ratpack@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "checksum",
-      "scriptRef": "examples/checksum.java",
-      "command": "checksum@jbangdev/jbang-examples",
-      "fullcommand": "jbang checksum@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "s3upload",
-      "scriptRef": "examples/s3upload.java",
-      "command": "s3upload@jbangdev/jbang-examples",
-      "fullcommand": "jbang s3upload@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "sparkjava",
-      "scriptRef": "examples/sparkjava.java",
-      "command": "sparkjava@jbangdev/jbang-examples",
-      "fullcommand": "jbang sparkjava@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "jetty",
-      "scriptRef": "examples/jetty.jsh",
-      "command": "jetty@jbangdev/jbang-examples",
-      "fullcommand": "jbang jetty@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "NanoClock",
-      "scriptRef": "examples/NanoClock.java",
-      "command": "NanoClock@jbangdev/jbang-examples",
-      "fullcommand": "jbang NanoClock@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "asciidoctor",
-      "scriptRef": "examples/asciidoctor.java",
-      "command": "asciidoctor@jbangdev/jbang-examples",
-      "fullcommand": "jbang asciidoctor@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "gh_release_stats",
-      "scriptRef": "examples/gh_release_stats.java",
-      "command": "gh_release_stats@jbangdev/jbang-examples",
-      "fullcommand": "jbang gh_release_stats@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "grabavatars",
-      "scriptRef": "examples/grabavatars.java",
-      "command": "grabavatars@jbangdev/jbang-examples",
-      "fullcommand": "jbang grabavatars@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "ilc",
-      "scriptRef": "examples/ilc.java",
-      "command": "ilc@jbangdev/jbang-examples",
-      "fullcommand": "jbang ilc@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "mockneatSQL",
-      "scriptRef": "examples/mockneatSQL.java",
-      "command": "mockneatSQL@jbangdev/jbang-examples",
-      "fullcommand": "jbang mockneatSQL@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "opencv_ball_tracker",
-      "scriptRef": "examples/opencv_ball_tracker.java",
-      "command": "opencv_ball_tracker@jbangdev/jbang-examples",
-      "fullcommand": "jbang opencv_ball_tracker@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "plantuml",
-      "scriptRef": "examples/plantuml.java",
-      "command": "plantuml@jbangdev/jbang-examples",
-      "fullcommand": "jbang plantuml@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkus",
-      "scriptRef": "examples/quarkus.java",
-      "command": "quarkus@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkus@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkusadv",
-      "scriptRef": "examples/quarkusadv.java",
-      "command": "quarkusadv@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkusadv@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkuscli",
-      "scriptRef": "examples/quarkuscli.java",
-      "command": "quarkuscli@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkuscli@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkusclidb",
-      "scriptRef": "examples/quarkusclidb.java",
-      "command": "quarkusclidb@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkusclidb@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkusclireddis",
-      "scriptRef": "examples/quarkusclireddis.java",
-      "command": "quarkusclireddis@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkusclireddis@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkusjib",
-      "scriptRef": "examples/quarkusjib.java",
-      "command": "quarkusjib@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkusjib@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkusmetrics",
-      "scriptRef": "examples/quarkusmetrics.java",
-      "command": "quarkusmetrics@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkusmetrics@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "quarkusnew",
-      "scriptRef": "examples/quarkusnew.java",
-      "command": "quarkusnew@jbangdev/jbang-examples",
-      "fullcommand": "jbang quarkusnew@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "resource",
-      "scriptRef": "examples/resource.java",
-      "command": "resource@jbangdev/jbang-examples",
-      "fullcommand": "jbang resource@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "update_catalog",
-      "scriptRef": "examples/update_catalog.java",
-      "command": "update_catalog@jbangdev/jbang-examples",
-      "fullcommand": "jbang update_catalog@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "viewics",
-      "scriptRef": "examples/viewics.java",
-      "command": "viewics@jbangdev/jbang-examples",
-      "fullcommand": "jbang viewics@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "qchat",
-      "scriptRef": "examples/qchat.java",
-      "command": "qchat@jbangdev/jbang-examples",
-      "fullcommand": "jbang qchat@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "ecsh",
-      "description": "\u003cp\u003eEclipse Collections API for scripting\nTry out using \u003ccode\u003ejbang -s ecsh@jbangdev -i\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "examples/ecsh.jsh",
-      "command": "ecsh@jbangdev/jbang-examples",
-      "fullcommand": "jbang ecsh@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "j18inetresolver",
-      "scriptRef": "examples/java/J18InetAddressResolverProvider.java",
-      "command": "j18inetresolver@jbangdev/jbang-examples",
-      "fullcommand": "jbang j18inetresolver@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
-      "stars": 23,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-examples",
-      "alias": "symjajsh",
-      "scriptRef": "examples/symja.jsh",
-      "command": "symjajsh@jbangdev/jbang-examples",
-      "fullcommand": "jbang symjajsh@jbangdev/jbang-examples",
-      "link": "https://github.com/jbangdev/jbang-examples/blob/69abd9e1bd39efc5fe5884f77351d3916412d509/jbang-catalog.json"
-    },
-    {
+      "owner": "luigidemasi",
+      "name": "camel-kit",
       "stars": 20,
-      "icon_url": "https://avatars.githubusercontent.com/u/5583341?v\u003d4",
-      "repoOwner": "luigidemasi",
-      "repoName": "camel-kit",
-      "alias": "camel-kit-aio",
-      "description": "\u003cp\u003eCamel Kit all-in-one — includes embedded MCP servers and knowledge index\u003c/p\u003e\n",
-      "scriptRef": "io.github.luigidemasi:camel-kit-standalone:0.3.2-SNAPSHOT",
-      "command": "camel-kit-aio@luigidemasi/camel-kit",
-      "fullcommand": "jbang camel-kit-aio@luigidemasi/camel-kit",
-      "link": "https://github.com/luigidemasi/camel-kit/blob/547cf6ba2996d0f31e85febfad8ebbc189fc0a61/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/5583341?v=4",
+      "link": "https://github.com/luigidemasi/camel-kit/blob/547cf6ba2996d0f31e85febfad8ebbc189fc0a61/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel-kit-aio",
+          "c": "camel-kit-aio@luigidemasi/camel-kit",
+          "d": "<p>Camel Kit all-in-one \u2014 includes embedded MCP servers and knowledge index</p>\n",
+          "s": "io.github.luigidemasi:camel-kit-standalone:0.3.2-SNAPSHOT"
+        },
+        {
+          "a": "camel-kit",
+          "c": "camel-kit@luigidemasi/camel-kit",
+          "d": "<p>Camel Kit lightweight \u2014 no embedded MCP servers, requires external setup</p>\n",
+          "s": "camel-kit-main/src/main/jbang/main/CamelKit.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 20,
-      "icon_url": "https://avatars.githubusercontent.com/u/5583341?v\u003d4",
-      "repoOwner": "luigidemasi",
-      "repoName": "camel-kit",
-      "alias": "camel-kit",
-      "description": "\u003cp\u003eCamel Kit lightweight — no embedded MCP servers, requires external setup\u003c/p\u003e\n",
-      "scriptRef": "camel-kit-main/src/main/jbang/main/CamelKit.java",
-      "command": "camel-kit@luigidemasi/camel-kit",
-      "fullcommand": "jbang camel-kit@luigidemasi/camel-kit",
-      "link": "https://github.com/luigidemasi/camel-kit/blob/547cf6ba2996d0f31e85febfad8ebbc189fc0a61/jbang-catalog.json"
-    },
-    {
+      "owner": "koppor",
+      "name": "github-contributors-list",
       "stars": 17,
-      "icon_url": "https://avatars.githubusercontent.com/u/1366654?v\u003d4",
-      "repoOwner": "koppor",
-      "repoName": "github-contributors-list",
-      "alias": "gcl",
-      "scriptRef": "gcl.java",
-      "command": "gcl@koppor/github-contributors-list",
-      "fullcommand": "jbang gcl@koppor/github-contributors-list",
-      "link": "https://github.com/koppor/github-contributors-list/blob/29f7debb7c8444031e2d7f20d345ded228ccfb4e/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/1366654?v=4",
+      "link": "https://github.com/koppor/github-contributors-list/blob/29f7debb7c8444031e2d7f20d345ded228ccfb4e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "gcl",
+          "c": "gcl@koppor/github-contributors-list",
+          "s": "gcl.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "hpcclab",
+      "name": "OaaS",
       "stars": 16,
-      "icon_url": "https://avatars.githubusercontent.com/u/20963129?v\u003d4",
-      "repoOwner": "hpcclab",
-      "repoName": "OaaS",
-      "alias": "ocli",
-      "scriptRef": "https://github.com/hpcclab/OaaS/releases/download/0.2.2/ocli.jar",
-      "command": "ocli@hpcclab/OaaS",
-      "fullcommand": "jbang ocli@hpcclab/OaaS",
-      "link": "https://github.com/hpcclab/OaaS/blob/3243e3b044ab84bd0ac64c6cb1ebe8fbd6b01b67/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/20963129?v=4",
+      "link": "https://github.com/hpcclab/OaaS/blob/3243e3b044ab84bd0ac64c6cb1ebe8fbd6b01b67/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "ocli",
+          "c": "ocli@hpcclab/OaaS",
+          "s": "https://github.com/hpcclab/OaaS/releases/download/0.2.2/ocli.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "quarkusio",
+      "name": "quarkus-agent-mcp",
       "stars": 15,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "quarkus-agent-mcp",
-      "alias": "quarkus-agent-mcp",
-      "description": "\u003cp\u003eStandalone MCP server for AI coding agents to manage Quarkus applications\u003c/p\u003e\n",
-      "scriptRef": "io.quarkus:quarkus-agent-mcp:RELEASE:runner",
-      "command": "quarkus-agent-mcp@quarkusio/quarkus-agent-mcp",
-      "fullcommand": "jbang quarkus-agent-mcp@quarkusio/quarkus-agent-mcp",
-      "link": "https://github.com/quarkusio/quarkus-agent-mcp/blob/c17280236a8080aab2bc10ff8e334922a2619a5f/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/quarkus-agent-mcp/blob/c17280236a8080aab2bc10ff8e334922a2619a5f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "quarkus-agent-mcp",
+          "c": "quarkus-agent-mcp@quarkusio/quarkus-agent-mcp",
+          "d": "<p>Standalone MCP server for AI coding agents to manage Quarkus applications</p>\n",
+          "s": "io.quarkus:quarkus-agent-mcp:RELEASE:runner"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "roastedroot",
+      "name": "lumis4j",
       "stars": 15,
-      "icon_url": "https://avatars.githubusercontent.com/u/197638293?v\u003d4",
-      "repoOwner": "roastedroot",
-      "repoName": "lumis4j",
-      "alias": "lumis4j",
-      "scriptRef": "lumis4j.java",
-      "command": "lumis4j@roastedroot/lumis4j",
-      "fullcommand": "jbang lumis4j@roastedroot/lumis4j",
-      "link": "https://github.com/roastedroot/lumis4j/blob/9725b8f79e1efb1f545da0501c90cac4e8f9422d/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/197638293?v=4",
+      "link": "https://github.com/roastedroot/lumis4j/blob/9725b8f79e1efb1f545da0501c90cac4e8f9422d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "lumis4j",
+          "c": "lumis4j@roastedroot/lumis4j",
+          "s": "lumis4j.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "jbangdev",
+      "name": "jbang-fmt",
       "stars": 15,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-fmt",
-      "alias": "jbang-fmt",
-      "scriptRef": "src/dev/jbang/fmt/Main.java",
-      "command": "jbang-fmt@jbangdev/jbang-fmt",
-      "fullcommand": "jbang jbang-fmt@jbangdev/jbang-fmt",
-      "link": "https://github.com/jbangdev/jbang-fmt/blob/8b310f34cf177f92bed869e017cace51978501ed/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang-fmt/blob/8b310f34cf177f92bed869e017cace51978501ed/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jbang-fmt",
+          "c": "jbang-fmt@jbangdev/jbang-fmt",
+          "s": "src/dev/jbang/fmt/Main.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "jbangdev",
+      "name": "jbang.dev",
       "stars": 13,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang.dev",
-      "alias": "main",
-      "scriptRef": "main.java",
-      "command": "main@jbangdev/jbang.dev~public",
-      "fullcommand": "jbang main@jbangdev/jbang.dev~public",
-      "link": "https://github.com/jbangdev/jbang.dev/blob/a16b1be50d46419dae56ded02b0f598ff9942c5e/public/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang.dev/blob/a16b1be50d46419dae56ded02b0f598ff9942c5e/public/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "main",
+          "c": "main@jbangdev/jbang.dev~public",
+          "s": "main.java"
+        },
+        {
+          "a": "tree",
+          "c": "tree@jbangdev/jbang.dev~public",
+          "s": "tree/main.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "tomitribe",
+      "name": "jamira",
       "stars": 13,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang.dev",
-      "alias": "tree",
-      "scriptRef": "tree/main.java",
-      "command": "tree@jbangdev/jbang.dev~public",
-      "fullcommand": "jbang tree@jbangdev/jbang.dev~public",
-      "link": "https://github.com/jbangdev/jbang.dev/blob/a16b1be50d46419dae56ded02b0f598ff9942c5e/public/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/2865265?v=4",
+      "link": "https://github.com/tomitribe/jamira/blob/e57f88c1997107f432787aed97c8221b83ea8932/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jamira",
+          "c": "jamira@tomitribe/jamira",
+          "s": "org.tomitribe.jamira:jamira-cli:LATEST:shaded"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "davsclaus",
+      "name": "camel-visual",
       "stars": 13,
-      "icon_url": "https://avatars.githubusercontent.com/u/2865265?v\u003d4",
-      "repoOwner": "tomitribe",
-      "repoName": "jamira",
-      "alias": "jamira",
-      "scriptRef": "org.tomitribe.jamira:jamira-cli:LATEST:shaded",
-      "command": "jamira@tomitribe/jamira",
-      "fullcommand": "jbang jamira@tomitribe/jamira",
-      "link": "https://github.com/tomitribe/jamira/blob/e57f88c1997107f432787aed97c8221b83ea8932/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/477100?v=4",
+      "link": "https://github.com/davsclaus/camel-visual/blob/c2cb65b943091cff862b3bb4d95d18f4234a28ad/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "launch",
+          "c": "launch@davsclaus/camel-visual",
+          "s": "src/main/java/org/apache/camel/visual/VisualRouteMain.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 13,
-      "icon_url": "https://avatars.githubusercontent.com/u/477100?v\u003d4",
-      "repoOwner": "davsclaus",
-      "repoName": "camel-visual",
-      "alias": "launch",
-      "scriptRef": "src/main/java/org/apache/camel/visual/VisualRouteMain.java",
-      "command": "launch@davsclaus/camel-visual",
-      "fullcommand": "jbang launch@davsclaus/camel-visual",
-      "link": "https://github.com/davsclaus/camel-visual/blob/c2cb65b943091cff862b3bb4d95d18f4234a28ad/jbang-catalog.json"
-    },
-    {
+      "owner": "microsoft",
+      "name": "jbang-catalog",
       "stars": 12,
-      "icon_url": "https://avatars.githubusercontent.com/u/6154722?v\u003d4",
-      "repoOwner": "microsoft",
-      "repoName": "jbang-catalog",
-      "alias": "minecraft-server",
-      "description": "\u003cp\u003eMinecraft: Java Edition Server\nRequires agreeing to EULA to run. Create \u003ccode\u003eeula.txt\u003c/code\u003e file with \u003ccode\u003eeula\u003dtrue\u003c/code\u003e as content and then run using \u003ccode\u003ejbang minecraft-server@microsoft\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar",
-      "command": "minecraft-server@microsoft",
-      "fullcommand": "jbang minecraft-server@microsoft",
-      "link": "https://github.com/microsoft/jbang-catalog/blob/c78ea752e84f40fa482a28b479a05493103380c7/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/6154722?v=4",
+      "link": "https://github.com/microsoft/jbang-catalog/blob/c78ea752e84f40fa482a28b479a05493103380c7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "minecraft-server",
+          "c": "minecraft-server@microsoft",
+          "d": "<p>Minecraft: Java Edition Server\nRequires agreeing to EULA to run. Create <code>eula.txt</code> file with <code>eula=true</code> as content and then run using <code>jbang minecraft-server@microsoft</code></p>\n",
+          "s": "https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar"
+        },
+        {
+          "a": "appinsights-agent",
+          "c": "appinsights-agent@microsoft",
+          "d": "<p>Azure Application Insights Agent 3.2.3\nRun with <code>jbang --javaagent appinsights-agent@microsoft &lt;yourapp&gt;</code>. Needs connection string setup - see <a rel=\"nofollow\" href=\"https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent\">https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent</a> for details.</p>\n",
+          "s": "com.microsoft.azure:applicationinsights-agent:3.2.3"
+        },
+        {
+          "a": "playwright",
+          "c": "playwright@microsoft",
+          "d": "<p>Playwright lets you automate Chromium, Firefox and Webkit with a single API.\nWith this CLI you can install, trace, generate pdf and screenshots and more.\nSee all commands available:</p>\n<pre><code>  jbang playwright@microsoft --help\n</code></pre>\n",
+          "s": "https://github.com/microsoft/playwright-java/blob/master/scripts/playwright.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "iunera",
+      "name": "druid-mcp-server",
       "stars": 12,
-      "icon_url": "https://avatars.githubusercontent.com/u/6154722?v\u003d4",
-      "repoOwner": "microsoft",
-      "repoName": "jbang-catalog",
-      "alias": "appinsights-agent",
-      "description": "\u003cp\u003eAzure Application Insights Agent 3.2.3\nRun with \u003ccode\u003ejbang --javaagent appinsights-agent@microsoft \u0026lt;yourapp\u0026gt;\u003c/code\u003e. Needs connection string setup - see \u003ca rel\u003d\"nofollow\" href\u003d\"https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent\"\u003ehttps://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent\u003c/a\u003e for details.\u003c/p\u003e\n",
-      "scriptRef": "com.microsoft.azure:applicationinsights-agent:3.2.3",
-      "command": "appinsights-agent@microsoft",
-      "fullcommand": "jbang appinsights-agent@microsoft",
-      "link": "https://github.com/microsoft/jbang-catalog/blob/c78ea752e84f40fa482a28b479a05493103380c7/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/9744636?v=4",
+      "link": "https://github.com/iunera/druid-mcp-server/blob/8b4c4920d7a68a0837418f4f6d594315470f914f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "druid-mcp-server",
+          "c": "druid-mcp-server@iunera/druid-mcp-server",
+          "d": "<p>A Model Context Protocol (MCP) server for Apache Druid.</p>\n",
+          "s": "com.iunera:druid-mcp-server:1.8.2"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 12,
-      "icon_url": "https://avatars.githubusercontent.com/u/6154722?v\u003d4",
-      "repoOwner": "microsoft",
-      "repoName": "jbang-catalog",
-      "alias": "playwright",
-      "description": "\u003cp\u003ePlaywright lets you automate Chromium, Firefox and Webkit with a single API.\nWith this CLI you can install, trace, generate pdf and screenshots and more.\nSee all commands available:\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003e  jbang playwright@microsoft --help\n\u003c/code\u003e\u003c/pre\u003e\n",
-      "scriptRef": "https://github.com/microsoft/playwright-java/blob/master/scripts/playwright.java",
-      "command": "playwright@microsoft",
-      "fullcommand": "jbang playwright@microsoft",
-      "link": "https://github.com/microsoft/jbang-catalog/blob/c78ea752e84f40fa482a28b479a05493103380c7/jbang-catalog.json"
-    },
-    {
-      "stars": 12,
-      "icon_url": "https://avatars.githubusercontent.com/u/9744636?v\u003d4",
-      "repoOwner": "iunera",
-      "repoName": "druid-mcp-server",
-      "alias": "druid-mcp-server",
-      "description": "\u003cp\u003eA Model Context Protocol (MCP) server for Apache Druid.\u003c/p\u003e\n",
-      "scriptRef": "com.iunera:druid-mcp-server:1.8.2",
-      "command": "druid-mcp-server@iunera/druid-mcp-server",
-      "fullcommand": "jbang druid-mcp-server@iunera/druid-mcp-server",
-      "link": "https://github.com/iunera/druid-mcp-server/blob/8b4c4920d7a68a0837418f4f6d594315470f914f/jbang-catalog.json"
-    },
-    {
+      "owner": "Delawen",
+      "name": "leyden-analyzer",
       "stars": 11,
-      "icon_url": "https://avatars.githubusercontent.com/u/726590?v\u003d4",
-      "repoOwner": "Delawen",
-      "repoName": "leyden-analyzer",
-      "alias": "analyzer",
-      "scriptRef": "https://github.com/Delawen/leyden-analyzer/releases/latest/download/leyden-analyzer-1.0.0-SNAPSHOT-runner.jar",
-      "command": "analyzer@Delawen/leyden-analyzer",
-      "fullcommand": "jbang analyzer@Delawen/leyden-analyzer",
-      "link": "https://github.com/Delawen/leyden-analyzer/blob/3e36a1ab625458c4d005206ef04c6d770a0476da/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/726590?v=4",
+      "link": "https://github.com/Delawen/leyden-analyzer/blob/3e36a1ab625458c4d005206ef04c6d770a0476da/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "analyzer",
+          "c": "analyzer@Delawen/leyden-analyzer",
+          "s": "https://github.com/Delawen/leyden-analyzer/releases/latest/download/leyden-analyzer-1.0.0-SNAPSHOT-runner.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "LimeBeck",
+      "name": "reveal-kt",
       "stars": 11,
-      "icon_url": "https://avatars.githubusercontent.com/u/7395251?v\u003d4",
-      "repoOwner": "LimeBeck",
-      "repoName": "reveal-kt",
-      "alias": "revealkt",
-      "description": "\u003cp\u003eCLI for Kotlin DSL wrapper around Reveal JS presentation library\u003c/p\u003e\n",
-      "scriptRef": "dev.limebeck:revealkt-cli:1.0.0",
-      "command": "revealkt@LimeBeck/reveal-kt~jbang",
-      "fullcommand": "jbang revealkt@LimeBeck/reveal-kt~jbang",
-      "link": "https://github.com/LimeBeck/reveal-kt/blob/7020af76f4113c7b7ee0f35d62d6e43dea89baeb/jbang/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/7395251?v=4",
+      "link": "https://github.com/LimeBeck/reveal-kt/blob/7020af76f4113c7b7ee0f35d62d6e43dea89baeb/jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "revealkt",
+          "c": "revealkt@LimeBeck/reveal-kt~jbang",
+          "d": "<p>CLI for Kotlin DSL wrapper around Reveal JS presentation library</p>\n",
+          "s": "dev.limebeck:revealkt-cli:1.0.0"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "maxandersen",
+      "name": "jdysk",
       "stars": 11,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jdysk",
-      "alias": "dysk",
-      "scriptRef": "Dysk.java",
-      "command": "dysk@maxandersen/jdysk",
-      "fullcommand": "jbang dysk@maxandersen/jdysk",
-      "link": "https://github.com/maxandersen/jdysk/blob/40f6bf6caed37ae344ce5b8dac5058e3e139fdc6/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jdysk/blob/40f6bf6caed37ae344ce5b8dac5058e3e139fdc6/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "dysk",
+          "c": "dysk@maxandersen/jdysk",
+          "s": "Dysk.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "parttimenerd",
+      "name": "jfr-query-experiments",
       "stars": 11,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "jfr-query-experiments",
-      "alias": "jfr-query",
-      "scriptRef": "https://github.com/parttimenerd/jfr-query-experiments/releases/download/snapshot/query.jar",
-      "command": "jfr-query@parttimenerd/jfr-query-experiments",
-      "fullcommand": "jbang jfr-query@parttimenerd/jfr-query-experiments",
-      "link": "https://github.com/parttimenerd/jfr-query-experiments/blob/8f43532ac435215e051c16e3273cf67887e9b022/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/jfr-query-experiments/blob/8f43532ac435215e051c16e3273cf67887e9b022/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfr-query",
+          "c": "jfr-query@parttimenerd/jfr-query-experiments",
+          "s": "https://github.com/parttimenerd/jfr-query-experiments/releases/download/snapshot/query.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "maxandersen",
+      "name": "wordle-solve",
       "stars": 11,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "wordle-solve",
-      "alias": "main",
-      "scriptRef": "src/main.java",
-      "command": "main@maxandersen/wordle-solve",
-      "fullcommand": "jbang main@maxandersen/wordle-solve",
-      "link": "https://github.com/maxandersen/wordle-solve/blob/42702ffbd1d39e47eebe96ef8be9f4f9c9489200/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/wordle-solve/blob/42702ffbd1d39e47eebe96ef8be9f4f9c9489200/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "main",
+          "c": "main@maxandersen/wordle-solve",
+          "s": "src/main.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "BrokkAi",
+      "name": "brokk",
       "stars": 10,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk",
-      "alias": "brokk",
-      "scriptRef": "https://github.com/BrokkAi/brokk/releases/download/0.14.1/brokk-0.14.1.jar",
-      "command": "brokk@BrokkAi/brokk",
-      "fullcommand": "jbang brokk@BrokkAi/brokk",
-      "link": "https://github.com/BrokkAi/brokk/blob/05a2b3a056f01a5ff8361faee06d5a95f3b3b26e/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/204942796?v=4",
+      "link": "https://github.com/BrokkAi/brokk/blob/05a2b3a056f01a5ff8361faee06d5a95f3b3b26e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "brokk",
+          "c": "brokk@BrokkAi/brokk",
+          "s": "https://github.com/BrokkAi/brokk/releases/download/0.14.1/brokk-0.14.1.jar"
+        },
+        {
+          "a": "brokk-0.13.3",
+          "c": "brokk-0.13.3@BrokkAi/brokk",
+          "s": "https://github.com/BrokkAi/brokk/releases/download/0.13.3/brokk-0.13.3.jar"
+        },
+        {
+          "a": "brokk-0.12.5.3",
+          "c": "brokk-0.12.5.3@BrokkAi/brokk",
+          "s": "https://github.com/BrokkAi/brokk/releases/download/0.12.5.3/brokk-0.12.5.3.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "alibaba",
+      "name": "jbang-catalog",
       "stars": 10,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk",
-      "alias": "brokk-0.13.3",
-      "scriptRef": "https://github.com/BrokkAi/brokk/releases/download/0.13.3/brokk-0.13.3.jar",
-      "command": "brokk-0.13.3@BrokkAi/brokk",
-      "fullcommand": "jbang brokk-0.13.3@BrokkAi/brokk",
-      "link": "https://github.com/BrokkAi/brokk/blob/05a2b3a056f01a5ff8361faee06d5a95f3b3b26e/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/1961952?v=4",
+      "link": "https://github.com/alibaba/jbang-catalog/blob/1ec049d0728788653354d56e046534751c941176/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "arthas",
+          "c": "arthas@alibaba",
+          "d": "<p>Launch Arthas Java Diagnostic Tool - <a rel=\"nofollow\" href=\"https://github.com/alibaba/arthas\">https://github.com/alibaba/arthas</a></p>\n",
+          "s": "https://repo1.maven.org/maven2/com/taobao/arthas/arthas-boot/3.7.2/arthas-boot-3.7.2.jar"
+        },
+        {
+          "a": "rsocket-broker",
+          "c": "rsocket-broker@alibaba",
+          "d": "<p>Start Alibaba RSocket Broker - <a rel=\"nofollow\" href=\"https://github.com/alibaba/alibaba-rsocket-broker\">https://github.com/alibaba/alibaba-rsocket-broker</a></p>\n",
+          "s": "https://repo1.maven.org/maven2/com/alibaba/rsocket/alibaba-broker-server/1.1.6/alibaba-broker-server-1.1.6.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "Sanne",
+      "name": "incus-spawn",
       "stars": 10,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk",
-      "alias": "brokk-0.12.5.3",
-      "scriptRef": "https://github.com/BrokkAi/brokk/releases/download/0.12.5.3/brokk-0.12.5.3.jar",
-      "command": "brokk-0.12.5.3@BrokkAi/brokk",
-      "fullcommand": "jbang brokk-0.12.5.3@BrokkAi/brokk",
-      "link": "https://github.com/BrokkAi/brokk/blob/05a2b3a056f01a5ff8361faee06d5a95f3b3b26e/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/42573?v=4",
+      "link": "https://github.com/Sanne/incus-spawn/blob/a73217a22f8aab2c837a9aae68b2e93dd89c4ba0/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "isx",
+          "c": "isx@Sanne/incus-spawn",
+          "d": "<p>Manage isolated Incus development environments</p>\n",
+          "s": "https://github.com/Sanne/incus-spawn/releases/latest/download/incus-spawn-runner.jar"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 10,
-      "icon_url": "https://avatars.githubusercontent.com/u/1961952?v\u003d4",
-      "repoOwner": "alibaba",
-      "repoName": "jbang-catalog",
-      "alias": "arthas",
-      "description": "\u003cp\u003eLaunch Arthas Java Diagnostic Tool - \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/alibaba/arthas\"\u003ehttps://github.com/alibaba/arthas\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "https://repo1.maven.org/maven2/com/taobao/arthas/arthas-boot/3.7.2/arthas-boot-3.7.2.jar",
-      "command": "arthas@alibaba",
-      "fullcommand": "jbang arthas@alibaba",
-      "link": "https://github.com/alibaba/jbang-catalog/blob/1ec049d0728788653354d56e046534751c941176/jbang-catalog.json"
-    },
-    {
-      "stars": 10,
-      "icon_url": "https://avatars.githubusercontent.com/u/1961952?v\u003d4",
-      "repoOwner": "alibaba",
-      "repoName": "jbang-catalog",
-      "alias": "rsocket-broker",
-      "description": "\u003cp\u003eStart Alibaba RSocket Broker - \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/alibaba/alibaba-rsocket-broker\"\u003ehttps://github.com/alibaba/alibaba-rsocket-broker\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "https://repo1.maven.org/maven2/com/alibaba/rsocket/alibaba-broker-server/1.1.6/alibaba-broker-server-1.1.6.jar",
-      "command": "rsocket-broker@alibaba",
-      "fullcommand": "jbang rsocket-broker@alibaba",
-      "link": "https://github.com/alibaba/jbang-catalog/blob/1ec049d0728788653354d56e046534751c941176/jbang-catalog.json"
-    },
-    {
-      "stars": 10,
-      "icon_url": "https://avatars.githubusercontent.com/u/42573?v\u003d4",
-      "repoOwner": "Sanne",
-      "repoName": "incus-spawn",
-      "alias": "isx",
-      "description": "\u003cp\u003eManage isolated Incus development environments\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/Sanne/incus-spawn/releases/latest/download/incus-spawn-runner.jar",
-      "command": "isx@Sanne/incus-spawn",
-      "fullcommand": "jbang isx@Sanne/incus-spawn",
-      "link": "https://github.com/Sanne/incus-spawn/blob/a73217a22f8aab2c837a9aae68b2e93dd89c4ba0/jbang-catalog.json"
-    },
-    {
+      "owner": "oracle",
+      "name": "graalpy-extensions",
       "stars": 9,
-      "icon_url": "https://avatars.githubusercontent.com/u/4430336?v\u003d4",
-      "repoOwner": "oracle",
-      "repoName": "graalpy-extensions",
-      "alias": "hello",
-      "description": "\u003cp\u003eScript that says hello from Python started from Java or execute Python expression as parameter.\u003c/p\u003e\n",
-      "scriptRef": "./org.graalvm.python.jbang/catalog/examples/hello.java",
-      "command": "hello@oracle/graalpy-extensions",
-      "fullcommand": "jbang hello@oracle/graalpy-extensions",
-      "link": "https://github.com/oracle/graalpy-extensions/blob/8ce0773fa86fbd4238f1e312137bedda9994f8fc/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/4430336?v=4",
+      "link": "https://github.com/oracle/graalpy-extensions/blob/8ce0773fa86fbd4238f1e312137bedda9994f8fc/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@oracle/graalpy-extensions",
+          "d": "<p>Script that says hello from Python started from Java or execute Python expression as parameter.</p>\n",
+          "s": "./org.graalvm.python.jbang/catalog/examples/hello.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "graalpy",
+          "c": "graalpy@oracle/graalpy-extensions",
+          "d": "<p>Basic template for Graal Python java file.</p>\n"
+        }
+      ]
     },
     {
+      "owner": "quarkusio",
+      "name": "jbang-catalog",
       "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "buginfo",
-      "description": "\u003cp\u003eScript that collects environment info for Quarkus issue reports\u003c/p\u003e\n",
-      "scriptRef": "quarkusissue.java",
-      "command": "buginfo@quarkusio",
-      "fullcommand": "jbang buginfo@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "buginfo",
+          "c": "buginfo@quarkusio",
+          "d": "<p>Script that collects environment info for Quarkus issue reports</p>\n",
+          "s": "quarkusissue.java"
+        },
+        {
+          "a": "catalog_check_updates",
+          "c": "catalog_check_updates@quarkusio",
+          "d": "<p>Script that checks for updates in an extension catalog</p>\n",
+          "s": "catalog_check_updates.java"
+        },
+        {
+          "a": "catalog_publish",
+          "c": "catalog_publish@quarkusio",
+          "d": "<p>Script that publishes an extension catalog to a registry</p>\n",
+          "s": "catalog_publish.java"
+        },
+        {
+          "a": "cli",
+          "c": "cli@quarkusio",
+          "s": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.35.2/quarkus-cli-3.35.2-runner.jar"
+        },
+        {
+          "a": "qs",
+          "c": "qs@quarkusio",
+          "s": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.35.2/quarkus-cli-3.35.2-runner.jar"
+        },
+        {
+          "a": "quarkus",
+          "c": "quarkus@quarkusio",
+          "s": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.35.2/quarkus-cli-3.35.2-runner.jar"
+        },
+        {
+          "a": "quarkus-kill",
+          "c": "quarkus-kill@quarkusio",
+          "s": "kill.java"
+        },
+        {
+          "a": "kill",
+          "c": "kill@quarkusio",
+          "s": "kill.java"
+        },
+        {
+          "a": "quarkus-agent-mcp",
+          "c": "quarkus-agent-mcp@quarkusio",
+          "d": "<p>MCP server for AI coding agents to create, manage, and interact with Quarkus applications</p>\n",
+          "s": "io.quarkus:quarkus-agent-mcp:RELEASE:runner"
+        },
+        {
+          "a": "quarkus-fmt",
+          "c": "quarkus-fmt@quarkusio",
+          "s": "fmt.java"
+        },
+        {
+          "a": "fmt",
+          "c": "fmt@quarkusio",
+          "s": "fmt.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "githubbot",
+          "c": "githubbot@quarkusio",
+          "d": "<p>Example of making a github app</p>\n"
+        }
+      ]
     },
     {
+      "owner": "mbien",
+      "name": "JFRLog",
       "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "catalog_check_updates",
-      "description": "\u003cp\u003eScript that checks for updates in an extension catalog\u003c/p\u003e\n",
-      "scriptRef": "catalog_check_updates.java",
-      "command": "catalog_check_updates@quarkusio",
-      "fullcommand": "jbang catalog_check_updates@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/114367?v=4",
+      "link": "https://github.com/mbien/JFRLog/blob/5023951b0c744c972b763fefda4cdcefa2c76493/cli/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfrprint",
+          "c": "jfrprint@mbien/JFRLog~cli",
+          "d": "<p>Prints formatted JFR events from JFR dumps or streams them live from repositories.</p>\n",
+          "s": "JFRPrint.java"
+        }
+      ],
+      "templates": []
     },
     {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "catalog_publish",
-      "description": "\u003cp\u003eScript that publishes an extension catalog to a registry\u003c/p\u003e\n",
-      "scriptRef": "catalog_publish.java",
-      "command": "catalog_publish@quarkusio",
-      "fullcommand": "jbang catalog_publish@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "cli",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.35.2/quarkus-cli-3.35.2-runner.jar",
-      "command": "cli@quarkusio",
-      "fullcommand": "jbang cli@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "qs",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.35.2/quarkus-cli-3.35.2-runner.jar",
-      "command": "qs@quarkusio",
-      "fullcommand": "jbang qs@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.35.2/quarkus-cli-3.35.2-runner.jar",
-      "command": "quarkus@quarkusio",
-      "fullcommand": "jbang quarkus@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-kill",
-      "scriptRef": "kill.java",
-      "command": "quarkus-kill@quarkusio",
-      "fullcommand": "jbang quarkus-kill@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "kill",
-      "scriptRef": "kill.java",
-      "command": "kill@quarkusio",
-      "fullcommand": "jbang kill@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-agent-mcp",
-      "description": "\u003cp\u003eMCP server for AI coding agents to create, manage, and interact with Quarkus applications\u003c/p\u003e\n",
-      "scriptRef": "io.quarkus:quarkus-agent-mcp:RELEASE:runner",
-      "command": "quarkus-agent-mcp@quarkusio",
-      "fullcommand": "jbang quarkus-agent-mcp@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-fmt",
-      "scriptRef": "fmt.java",
-      "command": "quarkus-fmt@quarkusio",
-      "fullcommand": "jbang quarkus-fmt@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "fmt",
-      "scriptRef": "fmt.java",
-      "command": "fmt@quarkusio",
-      "fullcommand": "jbang fmt@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/114367?v\u003d4",
-      "repoOwner": "mbien",
-      "repoName": "JFRLog",
-      "alias": "jfrprint",
-      "description": "\u003cp\u003ePrints formatted JFR events from JFR dumps or streams them live from repositories.\u003c/p\u003e\n",
-      "scriptRef": "JFRPrint.java",
-      "command": "jfrprint@mbien/JFRLog~cli",
-      "fullcommand": "jbang jfrprint@mbien/JFRLog~cli",
-      "link": "https://github.com/mbien/JFRLog/blob/5023951b0c744c972b763fefda4cdcefa2c76493/cli/jbang-catalog.json"
-    },
-    {
+      "owner": "tbee",
+      "name": "mavenToolchains",
       "stars": 7,
-      "icon_url": "https://avatars.githubusercontent.com/u/1429698?v\u003d4",
-      "repoOwner": "tbee",
-      "repoName": "mavenToolchains",
-      "alias": "sdkman",
-      "description": "\u003cp\u003eGenerate ~/.m2/toolchains.xml jdk entries using the installed Java JDKs in SDKMAN\u003c/p\u003e\n",
-      "scriptRef": "https://raw.githubusercontent.com/tbee/mavenToolchains/main/GenerateToolchainsFromSDKMAN.java",
-      "command": "sdkman@tbee/mavenToolchains",
-      "fullcommand": "jbang sdkman@tbee/mavenToolchains",
-      "link": "https://github.com/tbee/mavenToolchains/blob/d2ad3a08fec947a7ddfe661bfd9427b2afc09931/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/1429698?v=4",
+      "link": "https://github.com/tbee/mavenToolchains/blob/d2ad3a08fec947a7ddfe661bfd9427b2afc09931/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "sdkman",
+          "c": "sdkman@tbee/mavenToolchains",
+          "d": "<p>Generate ~/.m2/toolchains.xml jdk entries using the installed Java JDKs in SDKMAN</p>\n",
+          "s": "https://raw.githubusercontent.com/tbee/mavenToolchains/main/GenerateToolchainsFromSDKMAN.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "maxandersen",
+      "name": "rewrite-jbang",
       "stars": 7,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "rewrite-jbang",
-      "alias": "rewrite",
-      "scriptRef": "rewrite.java",
-      "command": "rewrite@maxandersen/rewrite-jbang",
-      "fullcommand": "jbang rewrite@maxandersen/rewrite-jbang",
-      "link": "https://github.com/maxandersen/rewrite-jbang/blob/4689051238d0e65fc8bc6e15d967248aaee72881/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/rewrite-jbang/blob/4689051238d0e65fc8bc6e15d967248aaee72881/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "rewrite",
+          "c": "rewrite@maxandersen/rewrite-jbang",
+          "s": "rewrite.java"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "maxandersen",
+      "name": "jskills",
       "stars": 7,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jskills",
-      "alias": "skills",
-      "description": "\u003cp\u003eThe CLI for the open agent skills ecosystem\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jskills/releases/download/early-access/jskills-0.0.0-SNAPSHOT.jar",
-      "command": "skills@maxandersen/jskills",
-      "fullcommand": "jbang skills@maxandersen/jskills",
-      "link": "https://github.com/maxandersen/jskills/blob/c4423eb32d88a9c19ade091647c841a3893219d8/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jskills/blob/c4423eb32d88a9c19ade091647c841a3893219d8/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "skills",
+          "c": "skills@maxandersen/jskills",
+          "d": "<p>The CLI for the open agent skills ecosystem</p>\n",
+          "s": "https://github.com/maxandersen/jskills/releases/download/early-access/jskills-0.0.0-SNAPSHOT.jar"
+        },
+        {
+          "a": "jskills",
+          "c": "jskills@maxandersen/jskills",
+          "d": "<p>The CLI for the open agent skills ecosystem</p>\n",
+          "s": "https://github.com/maxandersen/jskills/releases/download/early-access/jskills-0.0.0-SNAPSHOT.jar"
+        }
+      ],
+      "templates": []
     },
     {
+      "owner": "koppor",
+      "name": "ghprcomment",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/1366654?v=4",
+      "link": "https://github.com/koppor/ghprcomment/blob/83222d22e425fed21b56a524e96f4faedbb508c2/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "ghprcomment",
+          "c": "ghprcomment@koppor/ghprcomment",
+          "s": "ghprcomment.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jbangdev",
+      "name": "jbang-minecraft",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jbang-minecraft/blob/befa69092fd196b911f45a034bda301668760906/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "sponge",
+          "c": "sponge@jbangdev/jbang-minecraft",
+          "s": "sponge.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "linux-china",
+      "name": "zookeeper-shell",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/zookeeper-shell/blob/f49001e0b2ea90b504a80f093af034ef4b54b9a2/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "shell",
+          "c": "shell@linux-china/zookeeper-shell",
+          "d": "<p>ZooKeeper Shell</p>\n",
+          "s": "https://github.com/linux-china/zookeeper-shell/releases/download/0.1.0/zookeeper-shell-0.1.0.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "iunera",
+      "name": "ypipe",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/9744636?v=4",
+      "link": "https://github.com/iunera/ypipe/blob/c416f71ba052d92bcddd9620ad31dc98bdddaa3a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "ypipe",
+          "c": "ypipe@iunera/ypipe",
+          "d": "<p>YPipe - Easy Local AI Pipeline</p>\n",
+          "s": "https://github.com/iunera/ypipe/releases/download/jar/v1.0.0/ypipe-1.0.0-cross-platform.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "kiegroup",
+      "name": "jbang-catalog",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/517980?v=4",
+      "link": "https://github.com/kiegroup/jbang-catalog/blob/addbd6476d11b26da5a9c0b0b4d47ad5b3a385e7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "dmn",
+          "c": "dmn@kiegroup",
+          "d": "<p>Evaluate a DMN model using the Drools DMN Engine.</p>\n",
+          "s": "dmn.java"
+        },
+        {
+          "a": "feel",
+          "c": "feel@kiegroup",
+          "d": "<p>Evaluate a FEEL expression using the Drools DMN Engine.</p>\n",
+          "s": "feel.java"
+        },
+        {
+          "a": "optaplannerHelloWorld",
+          "c": "optaplannerHelloWorld@kiegroup",
+          "d": "<p>OptaPlanner Hello world to solve a school timetable to assign lessons to timeslots and rooms.</p>\n",
+          "s": "optaplannerHelloWorld.java"
+        },
+        {
+          "a": "xls2dmn",
+          "c": "xls2dmn@kiegroup",
+          "d": "<p>JBang script proxy of the Converter for Excel (.xls/.xlsx) files containing DMN decision tables.</p>\n",
+          "s": "xls2dmn.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "koppor",
+      "name": "magic-merge-commit",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/1366654?v=4",
+      "link": "https://github.com/koppor/magic-merge-commit/blob/76e8286e50a3219015cbb985ff2c11e7f4bc2c86/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "do",
+          "c": "do@koppor/magic-merge-commit",
+          "s": "CreatePRMergeCommit.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "quarkusio",
+      "name": "quarkus-reveal",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/quarkus-reveal/blob/831481bee5703909a996381999981c151605b592/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "quarkus-reveal",
+          "c": "quarkus-reveal@quarkusio/quarkus-reveal",
+          "d": "<p>Develop and use your Reveal.js decks easily with Quarkus</p>\n",
+          "s": "https://github.com/quarkusio/quarkus-reveal/releases/latest/download/quarkus-reveal.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "parttimenerd",
+      "name": "jfr-query",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/jfr-query/blob/03f53124c2c6c9bdd6661fbeccf7173b6bed262b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfr-query",
+          "c": "jfr-query@parttimenerd/jfr-query",
+          "s": "https://github.com/parttimenerd/jfr-query/releases/download/snapshot/query.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "parttimenerd",
+      "name": "hprof-redact",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/hprof-redact/blob/6263d6329d982ed1812ecdaf4f964e7e5b7e2e46/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jstall",
+          "c": "jstall@parttimenerd/hprof-redact",
+          "s": "https://github.com/parttimenerd/hprof-redact/releases/download/v0.2.1/hprof-redact.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "jbang-catalog",
+      "stars": 6,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "quarkusinfo",
+          "c": "quarkusinfo@maxandersen",
+          "d": "<p>Script that collects environment info for Quarkus issue reports</p>\n",
+          "s": "quarkusissue.java"
+        },
+        {
+          "a": "jruby",
+          "c": "jruby@maxandersen",
+          "d": "<p>Run jruby</p>\n",
+          "s": "org.jruby:jruby-complete:9.2.12.0"
+        },
+        {
+          "a": "groovy",
+          "c": "groovy@maxandersen",
+          "d": "<p>Run groovy</p>\n",
+          "s": "org.codehaus.groovy:groovy:3.0.5"
+        },
+        {
+          "a": "ghview",
+          "c": "ghview@maxandersen",
+          "d": "<p>GitHub View - based on current directory and locate the right 'thing' on github</p>\n",
+          "s": "ghview.java"
+        },
+        {
+          "a": "byteman",
+          "c": "byteman@maxandersen",
+          "s": "org.jboss.byteman:byteman:RELEASE"
+        },
+        {
+          "a": "jamira",
+          "c": "jamira@maxandersen",
+          "s": "jamira.java"
+        },
+        {
+          "a": "dashbuilder",
+          "c": "dashbuilder@maxandersen",
+          "s": "dashbuilder/dashbuilder.java"
+        },
+        {
+          "a": "prelude",
+          "c": "prelude@maxandersen",
+          "s": "prelude.jsh"
+        },
+        {
+          "a": "jackson",
+          "c": "jackson@maxandersen",
+          "s": "jackson.jsh"
+        },
+        {
+          "a": "ap-loader",
+          "c": "ap-loader@maxandersen",
+          "s": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar"
+        },
+        {
+          "a": "jarkanoid",
+          "c": "jarkanoid@maxandersen",
+          "s": "https://github.com/HanSolo/jarkanoid/releases/download/17.0.7/jarkanoid-windows-x64-17.0.7.jar"
+        },
+        {
+          "a": "sqlsh",
+          "c": "sqlsh@maxandersen",
+          "s": "org.apache.calcite:calcite-plus:RELEASE"
+        },
+        {
+          "a": "quarkus-explain",
+          "c": "quarkus-explain@maxandersen",
+          "s": "explain/explain.java"
+        },
+        {
+          "a": "shellscript",
+          "c": "shellscript@maxandersen",
+          "d": "<p>Simple example of how to wrap and run a shellscript using jbang catalogs.</p>\n",
+          "s": "shellscripts/shellscript.java"
+        },
+        {
+          "a": "quack",
+          "c": "quack@maxandersen",
+          "s": "quack.jsh"
+        },
+        {
+          "a": "gython",
+          "c": "gython@maxandersen",
+          "s": "org.vafer:helloworld:1.0"
+        },
+        {
+          "a": "lazyslide",
+          "c": "lazyslide@maxandersen",
+          "d": "<p>lazyslide: render, serve, watch, and initialize AsciiDoc reveal.js decks</p>\n",
+          "s": "lazyslide@maxandersen/lazyslide"
+        },
+        {
+          "a": "qrcode",
+          "c": "qrcode@maxandersen",
+          "s": "qrcode.java"
+        },
+        {
+          "a": "jdbc",
+          "c": "jdbc@maxandersen",
+          "s": "jdbc.java"
+        },
+        {
+          "a": "quarkus-edit",
+          "c": "quarkus-edit@maxandersen",
+          "s": "QuarkusEdit.java"
+        },
+        {
+          "a": "hass-qli-early-access",
+          "c": "hass-qli-early-access@maxandersen",
+          "s": "https://github.com/maxandersen/home-assistant-qli/releases/download/early-access/hass-qli-early-access.jar"
+        },
+        {
+          "a": "jfr-report",
+          "c": "jfr-report@maxandersen",
+          "s": "org.openjdk.jmc:flightrecorder.rules:8.3.1"
+        },
+        {
+          "a": "llmspeed",
+          "c": "llmspeed@maxandersen",
+          "d": "<p>Calculate the speed of a Large Language Model using OpenAI model. The speed is measured in tokens per second based on the models own reported data.</p>\n",
+          "s": "llmspeed.java"
+        },
+        {
+          "a": "j2xgenie",
+          "c": "j2xgenie@maxandersen",
+          "s": "j2xgenie/j2xgenie.java"
+        },
+        {
+          "a": "imgcat",
+          "c": "imgcat@maxandersen",
+          "s": "imgcat/imgcat.java"
+        },
+        {
+          "a": "hibernatetools",
+          "c": "hibernatetools@maxandersen",
+          "s": "hibernatetools/hibernatetools.java"
+        },
+        {
+          "a": "mcpcalculator",
+          "c": "mcpcalculator@maxandersen",
+          "s": "mcpcalc/mcpcalculator.java"
+        },
+        {
+          "a": "tinypng",
+          "c": "tinypng@maxandersen",
+          "s": "tinypng-cli/tinypng.java"
+        },
+        {
+          "a": "jupyter-jbang",
+          "c": "jupyter-jbang@maxandersen",
+          "s": "jjbang.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "helloworld",
+          "c": "helloworld@maxandersen",
+          "d": "<p>maxs first template</p>\n"
+        },
+        {
+          "a": "gcal",
+          "c": "gcal@maxandersen",
+          "d": "<p>Google Calendar API Template</p>\n"
+        },
+        {
+          "a": "dashboard",
+          "c": "dashboard@maxandersen"
+        },
+        {
+          "a": "setup-jitpack",
+          "c": "setup-jitpack@maxandersen",
+          "d": "<p>Setup Jitpack for a java/mvn based project</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "jupyter-java",
+      "name": "jbang-catalog",
+      "stars": 5,
+      "icon": "https://avatars.githubusercontent.com/u/150655885?v=4",
+      "link": "https://github.com/jupyter-java/jbang-catalog/blob/8a62bd9014481246de26d8115915a96ffa7634a5/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "install-kernel",
+          "c": "install-kernel@jupyter-java",
+          "s": "installkernel.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "parttimenerd",
+      "name": "execjar",
+      "stars": 5,
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/execjar/blob/9f7e3e65327e93833caa71b3d23ce07d181449d2/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jstall",
+          "c": "jstall@parttimenerd/execjar",
+          "s": "https://github.com/parttimenerd/execjar/releases/download/v0.3.4/jstall.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jxfzzzt",
+      "name": "ASE2024-Magneto",
+      "stars": 5,
+      "icon": "https://avatars.githubusercontent.com/u/62193161?v=4",
+      "link": "https://github.com/jxfzzzt/ASE2024-Magneto/blob/c45e4ae037b3be3a9a04c9da24309661efa3f1c5/Evaluation_Data/client-apps/karate/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@jxfzzzt/ASE2024-Magneto~Evaluation_Data/client-apps/karate",
+          "s": "com.intuit.karate:karate-core:1.3.0:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jamezp",
+      "name": "jbang-catalog",
+      "stars": 5,
+      "icon": "https://avatars.githubusercontent.com/u/420065?v=4",
+      "link": "https://github.com/jamezp/jbang-catalog/blob/0cd88db0317004fcfa9a9d711ccb2984d436f78a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "parse-surefire-report",
+          "c": "parse-surefire-report@jamezp",
+          "d": "<p>Parses surefire and failsafe XML reports and outputs a summary report. See help for more details.</p>\n",
+          "s": "parsesurefire.java"
+        },
+        {
+          "a": "jdk-manager",
+          "c": "jdk-manager@jamezp",
+          "d": "<p>A utility to manage JDK's for local usage.</p>\n",
+          "s": "jdkmanager/jdkmanager.java"
+        },
+        {
+          "a": "echo-server",
+          "c": "echo-server@jamezp",
+          "d": "<p>A utility which echos output from a TCP socket, UDP socket or HTTP server to stdout.</p>\n",
+          "s": "EchoServer.java"
+        },
+        {
+          "a": "jira-from-pr",
+          "c": "jira-from-pr@jamezp",
+          "d": "<p>Creates a JIRA based on a GitHub PR. Please note this is very specific to Red Hat JIRA and GitHub.</p>\n",
+          "s": "JiraFromPullRequest.java"
+        },
+        {
+          "a": "zip-util",
+          "c": "zip-util@jamezp",
+          "d": "<p>A utility to query, recursively, information in a ZIP, JAR, WAR, etc. file.</p>\n",
+          "s": "ziputil.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "parttimenerd",
+      "name": "femtojar",
+      "stars": 5,
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/femtojar/blob/ac1e346093bc5fef08fe86ea873dcc7ae7b38c89/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "femtojar",
+          "c": "femtojar@parttimenerd/femtojar",
+          "s": "https://github.com/parttimenerd/femtojar/releases/download/v0.1.6/femtojar-0.1.6.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "glawson6",
+      "name": "jaiclaw",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/4186933?v=4",
+      "link": "https://github.com/glawson6/jaiclaw/blob/96a9b3b7a4212ea0e69d483b9193ef69141eb2c7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "shell",
+          "c": "shell@glawson6/jaiclaw",
+          "d": "<p>JaiClaw interactive shell \u2014 personal AI assistant CLI</p>\n",
+          "s": "io.jaiclaw:jaiclaw-shell:0.1.0"
+        },
+        {
+          "a": "gateway",
+          "c": "gateway@glawson6/jaiclaw",
+          "d": "<p>JaiClaw gateway server \u2014 REST API + WebSocket + channel adapters</p>\n",
+          "s": "io.jaiclaw:jaiclaw-gateway-app:0.1.0"
+        },
+        {
+          "a": "jaiclaw",
+          "c": "jaiclaw@glawson6/jaiclaw",
+          "d": "<p>JaiClaw launcher \u2014 start gateway, shell, or manage containers</p>\n",
+          "s": "JaiClaw.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "quintesse",
+      "name": "jbang-catalog",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/778793?v=4",
+      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "imap",
+          "c": "imap@quintesse~experimental",
+          "s": "imap.java"
+        },
+        {
+          "a": "picocli-codegen",
+          "c": "picocli-codegen@quintesse~experimental",
+          "s": "picocli-codegen.java"
+        },
+        {
+          "a": "jfrdump",
+          "c": "jfrdump@quintesse~experimental",
+          "s": "jfrdump.java"
+        },
+        {
+          "a": "kcdel",
+          "c": "kcdel@quintesse~experimental",
+          "s": "kcdel.java"
+        },
+        {
+          "a": "kcusers",
+          "c": "kcusers@quintesse~experimental",
+          "s": "kcusers.java"
+        },
+        {
+          "a": "memmap",
+          "c": "memmap@quintesse~experimental",
+          "s": "memmap.java"
+        },
+        {
+          "a": "pmatch_instanceof",
+          "c": "pmatch_instanceof@quintesse~experimental",
+          "s": "pmatch_instanceof.java"
+        },
+        {
+          "a": "switch_expr",
+          "c": "switch_expr@quintesse~experimental",
+          "s": "switch_expr.java"
+        },
+        {
+          "a": "text_block",
+          "c": "text_block@quintesse~experimental",
+          "s": "text_block.java"
+        },
+        {
+          "a": "telegram",
+          "c": "telegram@quintesse~experimental",
+          "s": "telegram.java"
+        },
+        {
+          "a": "chelloworld16",
+          "c": "chelloworld16@quintesse~experimental",
+          "s": "foreign/chelloworld16.java"
+        },
+        {
+          "a": "chelloworld",
+          "c": "chelloworld@quintesse~experimental",
+          "s": "foreign/chelloworld.java"
+        },
+        {
+          "a": "cstrlen16",
+          "c": "cstrlen16@quintesse~experimental",
+          "s": "foreign/cstrlen16.java"
+        },
+        {
+          "a": "cstrlen17",
+          "c": "cstrlen17@quintesse~experimental",
+          "s": "foreign/cstrlen17.java"
+        },
+        {
+          "a": "cstrlen",
+          "c": "cstrlen@quintesse~experimental",
+          "s": "foreign/cstrlen.java"
+        },
+        {
+          "a": "guarded_switch",
+          "c": "guarded_switch@quintesse~experimental",
+          "s": "guarded_switch.java"
+        },
+        {
+          "a": "shelly",
+          "c": "shelly@quintesse~experimental",
+          "s": "shelly.java"
+        },
+        {
+          "a": "example_server",
+          "c": "example_server@quintesse~experimental",
+          "s": "example_server/example_server.java"
+        },
+        {
+          "a": "lanterna",
+          "c": "lanterna@quintesse~experimental",
+          "s": "lanterna.java"
+        },
+        {
+          "a": "quickserv",
+          "c": "quickserv@quintesse~experimental",
+          "s": "quickserv.java"
+        },
+        {
+          "a": "grep",
+          "c": "grep@quintesse~experimental",
+          "s": "grep.jsh"
+        },
+        {
+          "a": "terminal",
+          "c": "terminal@quintesse~experimental",
+          "s": "terminal.java"
+        },
+        {
+          "a": "xecho",
+          "c": "xecho@quintesse~experimental",
+          "d": "<p>Test to see how a ref to another alias works</p>\n",
+          "s": "echo@quintesse"
+        },
+        {
+          "a": "cat",
+          "c": "cat@quintesse",
+          "d": "<p>Simply copies the contents of the provided files to the standard output</p>\n",
+          "s": "cat.java"
+        },
+        {
+          "a": "echo",
+          "c": "echo@quintesse",
+          "d": "<p>Just prints out its arguments</p>\n",
+          "s": "echo.java"
+        },
+        {
+          "a": "hello",
+          "c": "hello@quintesse",
+          "d": "<p>Our perennial demo friend</p>\n",
+          "s": "hello.java"
+        },
+        {
+          "a": "jget",
+          "c": "jget@quintesse",
+          "d": "<p>Like a simplistic wget but written in Java</p>\n",
+          "s": "jget.java"
+        },
+        {
+          "a": "jvmci",
+          "c": "jvmci@quintesse",
+          "d": "<p>Checks if JVMCI is enabled</p>\n",
+          "s": "jvmci.java"
+        },
+        {
+          "a": "rest",
+          "c": "rest@quintesse",
+          "d": "<p>A cli tool for REST queries and transformations</p>\n",
+          "s": "rest.java"
+        },
+        {
+          "a": "httpd",
+          "c": "httpd@quintesse",
+          "d": "<p>Starts a simple HTTP server on the files in the current directory</p>\n",
+          "s": "simple_httpd.java"
+        },
+        {
+          "a": "sysenv",
+          "c": "sysenv@quintesse",
+          "d": "<p>Prints out Java's System environment</p>\n",
+          "s": "system_env.java"
+        },
+        {
+          "a": "sysprops",
+          "c": "sysprops@quintesse",
+          "d": "<p>Prints out Java's System properties</p>\n",
+          "s": "system_properties.java"
+        },
+        {
+          "a": "mdns",
+          "c": "mdns@quintesse",
+          "s": "mdns.java"
+        },
+        {
+          "a": "mvn2jbang",
+          "c": "mvn2jbang@quintesse",
+          "d": "<p>Adds a Maven project's dependencies to a JBang script</p>\n",
+          "s": "mvn2jbang.java"
+        },
+        {
+          "a": "redir",
+          "c": "redir@quintesse",
+          "d": "<p>Lists and updates directives in JBang scripts</p>\n",
+          "s": "redir.java"
+        },
+        {
+          "a": "runall",
+          "c": "runall@quintesse",
+          "d": "<p>Runs multiple commands in parallel. By default the command that is run is <code>jbang</code></p>\n",
+          "s": "runall.java"
+        },
+        {
+          "a": "refactor",
+          "c": "refactor@quintesse",
+          "d": "<p>Runs Netbeans Jackpot tool for refactoring Java code</p>\n",
+          "s": "org.apache.netbeans.modules.jackpot30:tool:28.0"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ZenWave360",
+      "name": "zenwave-playground",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/93670347?v=4",
+      "link": "https://github.com/ZenWave360/zenwave-playground/blob/ba5aab3c4c79269950194e8b7aa03f2f65212d57/examples/kustomer-address-jpa/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "zw",
+          "c": "zw@ZenWave360/zenwave-playground~examples/kustomer-address-jpa",
+          "s": "io.zenwave360.sdk:zenwave-sdk-cli:2.1.0-SNAPSHOT"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "neo4j",
+      "name": "jbang-catalog",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/201120?v=4",
+      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello_neo4j",
+          "c": "hello_neo4j@neo4j",
+          "d": "<p>Get some statistics out of your Neo4j instance.\nCall jbang hello_neo4j@neo4j --help to see the usage.</p>\n",
+          "s": "hello_neo4j.java"
+        },
+        {
+          "a": "cypher",
+          "c": "cypher@neo4j",
+          "d": "<p>Use Neo4j's Cypher shell to execute Cypher queries.\nInteractive shell without parameters or e.g. jbang neo4j@cypher -a <a rel=\"nofollow\" href=\"\">neo4j://localhost:7687</a> -u neo4j -p secret 'MATCH (n) return n'</p>\n",
+          "s": "cypher_shell.java"
+        },
+        {
+          "a": "neo4j-migrations",
+          "c": "neo4j-migrations@neo4j",
+          "d": "<p>Simple, Flyway DB inspired migrations for Neo4j.</p>\n",
+          "s": "neo4j_migrations.java"
+        },
+        {
+          "a": "rdbms2neo4j",
+          "c": "rdbms2neo4j@neo4j",
+          "d": "<p>Imports the provided tables from an JDBC-URL (postgres, mysql drivers bundled) into Neo4j.</p>\n",
+          "s": "rdbms2neo4j.java"
+        },
+        {
+          "a": "liquibase-neo4j",
+          "c": "liquibase-neo4j@neo4j",
+          "d": "<p>Manage and run your Neo4j database changes with Liquibase</p>\n",
+          "s": "liquibase_neo4j.java"
+        },
+        {
+          "a": "format-cypher",
+          "c": "format-cypher@neo4j",
+          "d": "<p>Pretty print Cypher statements</p>\n",
+          "s": "format_cypher.java"
+        },
+        {
+          "a": "enforce-relationship-directions",
+          "c": "enforce-relationship-directions@neo4j",
+          "d": "<p>Validates and enforces relationship directions in Cypher statements</p>\n",
+          "s": "enforce_relationship_directions.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "run-neo4j",
+          "c": "run-neo4j@neo4j",
+          "d": "<p>Basic Neo4j Driver example</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "snowdrop",
+      "name": "rewrite-client",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/558276?v=4",
+      "link": "https://github.com/snowdrop/rewrite-client/blob/3d1aa442f78f844917a230776242bc12b023d0f6/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "rewrite",
+          "c": "rewrite@snowdrop/rewrite-client",
+          "d": "<p>Quarkus OpenRewrite client to execute recipes</p>\n",
+          "s": "https://github.com/snowdrop/rewrite-client/releases/download/early-access/client-0.3.5-SNAPSHOT-runner.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "glaforge",
+      "name": "arxiv-mcp-server",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/47907?v=4",
+      "link": "https://github.com/glaforge/arxiv-mcp-server/blob/a5f16e522118dcc8560a15f3f08a68787228c354/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "arxiv-mcp",
+          "c": "arxiv-mcp@glaforge/arxiv-mcp-server",
+          "d": "<p>ArXiv MCP Server</p>\n",
+          "s": "https://github.com/glaforge/arxiv-mcp-server/releases/latest/download/arxiv-mcp-server-runner.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "metacosm",
+      "name": "power-server",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/120057?v=4",
+      "link": "https://github.com/metacosm/power-server/blob/08371c5bcba5275a781f5837e36c8925dbe84825/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "power",
+          "c": "power@metacosm/power-server",
+          "d": "<p>A command line tool to measure power consumption of processes</p>\n",
+          "s": "cli/src/main/java/net/laprun/sustainability/cli/Power.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jabrena",
+      "name": "jbang-catalog",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/147263?v=4",
+      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "raton-loco",
+          "c": "raton-loco@jabrena",
+          "d": "<p>'Raton Loco' is a Windows utility to avoid the Screensaver</p>\n",
+          "s": "https://github.com/jabrena/raton-loco/blob/main/src/main/java/info/jab/utils/RatonLoco.java"
+        },
+        {
+          "a": "setup",
+          "c": "setup@jabrena",
+          "d": "<p>Setup is a command line utility designed to help developers when initializing new projects using Maven</p>\n",
+          "s": "https://github.com/jabrena/setup-cli/releases/download/0.12.0/setup-0.12.0.jar"
+        },
+        {
+          "a": "stopwatch-mcp",
+          "c": "stopwatch-mcp@jabrena",
+          "d": "<p>StopWatch MCP. A MCP Server designed to measure the time used by an Agent to implement a Prompt</p>\n",
+          "s": "https://github.com/jabrena/stopwatch-mcp/blob/main/src/main/java/info/jab/jbang/MCPStopWatch.java"
+        },
+        {
+          "a": "cursor-mcp-config",
+          "c": "cursor-mcp-config@jabrena",
+          "d": "<p>Cursor AI MCP Cursor is a Terminal CLI to handle multiple configurations for ~/.cursor/mcp.json</p>\n",
+          "s": "https://github.com/jabrena/cursor-mcp-config-cli/blob/main/src/main/java/info/jab/jbang/CursorMCPConfig.java"
+        },
+        {
+          "a": "qr-code",
+          "c": "qr-code@jabrena",
+          "d": "<p>Generate a QR Code from a URL</p>\n",
+          "s": "https://github.com/jabrena/qr-code-cli/blob/main/src/main/java/info/jab/cli/TerminalQRCode.java"
+        },
+        {
+          "a": "puml-to-png",
+          "c": "puml-to-png@jabrena",
+          "d": "<p>Convert PlantUML (.puml) files to .png format</p>\n",
+          "s": "https://github.com/jabrena/plantuml-to-png-cli/releases/download/0.5.0/puml-to-png-0.5.0.jar"
+        },
+        {
+          "a": "churrera",
+          "c": "churrera@jabrena",
+          "d": "<p>Tasks like Churros! Churrera is a CLI tool designed to orchestrate Cursor Cloud Agents REST API in an easy way.</p>\n",
+          "s": "https://github.com/jabrena/churrera-cli/releases/download/0.2.0/churrera-cli-0.2.0.jar"
+        },
+        {
+          "a": "aoc",
+          "c": "aoc@jabrena",
+          "d": "<p>Advent of Code CLI tool</p>\n",
+          "s": "https://github.com/jabrena/aoc-cli/releases/download/0.1.0/aoc-cli-0.1.0.jar"
+        },
+        {
+          "a": "sonar-search",
+          "c": "sonar-search@jabrena",
+          "d": "<p>Sonar Search CLI tool</p>\n",
+          "s": "https://github.com/jabrena/sonar-search-cli/releases/download/0.2.0-SNAPSHOT/sonar-search-0.2.0-SNAPSHOT.jar"
+        },
+        {
+          "a": "result-json-map.0.1.0-SNAPSHOT",
+          "c": "result-json-map.0.1.0-SNAPSHOT@jabrena",
+          "d": "<p>A CLI tool designed to help models when they return data in a structured way.</p>\n",
+          "s": "https://github.com/jabrena/result-json-map-cli/releases/download/0.1.0-SNAPSHOT/result-json-map-0.1.0-SNAPSHOT.jar"
+        },
+        {
+          "a": "pml-to-md",
+          "c": "pml-to-md@jabrena",
+          "d": "<p>A CLI tool designed to convert PML files to Markdown.</p>\n",
+          "s": "https://github.com/jabrena/pml/releases/download/0.7.0/pml-to-md-0.7.0.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "galderz",
+      "name": "qollider",
+      "stars": 3,
+      "icon": "https://avatars.githubusercontent.com/u/50187?v=4",
+      "link": "https://github.com/galderz/qollider/blob/fcb74445163748ae78df8d138c7fcceb93aeb9c9/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "graal",
+          "c": "graal@galderz/qollider",
+          "d": "<p>Script to build Graal</p>\n",
+          "s": "graal.java"
+        },
+        {
+          "a": "infinispan-native",
+          "c": "infinispan-native@galderz/qollider",
+          "d": "<p>Script to build Infinispan Quarkus native server</p>\n",
+          "s": "infinispan_native.java"
+        },
+        {
+          "a": "jdk",
+          "c": "jdk@galderz/qollider",
+          "d": "<p>Script to build a JDK</p>\n",
+          "s": "jdk.java"
+        },
+        {
+          "a": "quarkus",
+          "c": "quarkus@galderz/qollider",
+          "d": "<p>Script to build Quarkus</p>\n",
+          "s": "quarkus.java"
+        },
+        {
+          "a": "mandrel",
+          "c": "mandrel@galderz/qollider",
+          "d": "<p>Script to build Mandrel</p>\n",
+          "s": "mandrel.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "linux-china",
+      "name": "jbang-rsocket",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/jbang-rsocket/blob/8feb033c38a2c85ee6dd8dbee1477f2a7e0fd677/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "ClientExample",
+          "c": "ClientExample@linux-china/jbang-rsocket",
+          "s": "src/ClientExample.java"
+        },
+        {
+          "a": "ServerExample",
+          "c": "ServerExample@linux-china/jbang-rsocket",
+          "s": "src/ServerExample.java"
+        },
+        {
+          "a": "ClientExampleKt",
+          "c": "ClientExampleKt@linux-china/jbang-rsocket",
+          "s": "kotlin/src/RSocketClientApp.kt"
+        },
+        {
+          "a": "ServerExampleKt",
+          "c": "ServerExampleKt@linux-china/jbang-rsocket",
+          "s": "kotlin/src/RSocketServerApp.kt"
+        },
+        {
+          "a": "RSocketSpringBootServer",
+          "c": "RSocketSpringBootServer@linux-china/jbang-rsocket",
+          "s": "src/spring/RSocketSpringBootServer.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "aizedevops",
+      "name": "spring-boot-projects",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/106387436?v=4",
+      "link": "https://github.com/aizedevops/spring-boot-projects/blob/44b4c4101a353183a54761b38ea203a7d9f8ee90/jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@aizedevops/spring-boot-projects~jbang",
+          "s": "hello.java"
+        },
+        {
+          "a": "hellocli",
+          "c": "hellocli@aizedevops/spring-boot-projects~jbang",
+          "s": "hellocli.java"
+        },
+        {
+          "a": "jbangquarkus",
+          "c": "jbangquarkus@aizedevops/spring-boot-projects~jbang",
+          "s": "jbangquarkus.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "lazyslide",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/lazyslide/blob/2cf557b9aa3c47e76267b4da7ee29ef07703b9a8/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "lazyslide",
+          "c": "lazyslide@maxandersen/lazyslide",
+          "d": "<p>lazyslide: render, serve, watch, and initialize AsciiDoc reveal.js decks</p>\n",
+          "s": "lazyslide.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "scratches",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/3737888?v=4",
+      "link": "https://github.com/scratches/jbang-catalog/blob/2152ed5234ebe63ccce23579318c54ffc08459d4/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "spring",
+          "c": "spring@scratches",
+          "d": "<p>Spring Boot CLI</p>\n",
+          "s": "org.springframework.boot:spring-boot-cli:3.3.0:full"
+        },
+        {
+          "a": "script",
+          "c": "script@scratches",
+          "d": "<p>Spring Script Runner</p>\n",
+          "s": "example/SpringScript.java"
+        },
+        {
+          "a": "springbom",
+          "c": "springbom@scratches",
+          "d": "<p>Spring Bom</p>\n",
+          "s": "example/SpringBom.java"
+        },
+        {
+          "a": "generic",
+          "c": "generic@scratches",
+          "d": "<p>Generic Spring Application</p>\n",
+          "s": "example/GenericApplication.java"
+        },
+        {
+          "a": "configserver",
+          "c": "configserver@scratches",
+          "d": "<p>Spring Cloud Config Server with example config repo</p>\n",
+          "s": "example/ConfigServerApplication.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "tors42",
+      "name": "jbang-chariot",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/4084220?v=4",
+      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "liga",
+          "c": "liga@tors42/jbang-chariot",
+          "s": "scripts/liga.java"
+        },
+        {
+          "a": "nonthematic",
+          "c": "nonthematic@tors42/jbang-chariot",
+          "s": "scripts/nonthematic.java"
+        },
+        {
+          "a": "membercount",
+          "c": "membercount@tors42/jbang-chariot",
+          "s": "scripts/membercount.java"
+        },
+        {
+          "a": "opponents",
+          "c": "opponents@tors42/jbang-chariot",
+          "s": "scripts/opponents.java"
+        },
+        {
+          "a": "flatten",
+          "c": "flatten@tors42/jbang-chariot",
+          "s": "scripts/flatten.java"
+        },
+        {
+          "a": "evalsummary",
+          "c": "evalsummary@tors42/jbang-chariot",
+          "s": "scripts/evalsummary.java"
+        },
+        {
+          "a": "autoscore",
+          "c": "autoscore@tors42/jbang-chariot",
+          "s": "scripts/autoscore.java"
+        },
+        {
+          "a": "uci2san",
+          "c": "uci2san@tors42/jbang-chariot",
+          "s": "scripts/uci2san.jsh"
+        },
+        {
+          "a": "oauth2pkce",
+          "c": "oauth2pkce@tors42/jbang-chariot",
+          "s": "scripts/oauth2pkce.java"
+        },
+        {
+          "a": "updateArena",
+          "c": "updateArena@tors42/jbang-chariot",
+          "s": "scripts/updateArena.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ayagmar",
+      "name": "quarkus-forge",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/62888618?v=4",
+      "link": "https://github.com/ayagmar/quarkus-forge/blob/55cad9d7cc1bf25bf84fe7ee16eb9e8f5cdadab8/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "quarkus-forge",
+          "c": "quarkus-forge@ayagmar/quarkus-forge",
+          "d": "<p>Keyboard-first Quarkus project generator TUI</p>\n",
+          "s": "https://github.com/ayagmar/quarkus-forge/releases/latest/download/quarkus-forge-jvm.jar"
+        },
+        {
+          "a": "quarkus-forge-headless",
+          "c": "quarkus-forge-headless@ayagmar/quarkus-forge",
+          "d": "<p>Quarkus project generator headless CLI (no TUI dependencies)</p>\n",
+          "s": "https://github.com/ayagmar/quarkus-forge/releases/latest/download/quarkus-forge-headless.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "FroMage",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/179265?v=4",
+      "link": "https://github.com/FroMage/jbang-catalog/blob/7aae6527207f06395ae3b30c36bc0d81b734180b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "static-init-finder",
+          "c": "static-init-finder@FroMage",
+          "d": "<p>Find static init calls to classes</p>\n",
+          "s": "ListStaticInit.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "skills",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/skills/blob/8f466b21f1b4f75f131ada4de7345f30a710cf1f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jgccli",
+          "c": "jgccli@maxandersen/skills",
+          "d": "<p>Minimal Google Calendar CLI (Java)</p>\n",
+          "s": "https://github.com/maxandersen/jgccli/blob/main/src/main/java/jgccli.java"
+        },
+        {
+          "a": "jgmcli",
+          "c": "jgmcli@maxandersen/skills",
+          "d": "<p>Minimal Gmail CLI (Java)</p>\n",
+          "s": "https://github.com/maxandersen/jgmcli/blob/main/src/main/java/jgmcli.java"
+        },
+        {
+          "a": "jgdcli",
+          "c": "jgdcli@maxandersen/skills",
+          "d": "<p>Minimal Google Drive CLI (Java)</p>\n",
+          "s": "https://github.com/maxandersen/jgdcli/blob/main/src/main/java/jgdcli.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "opt-nc",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/63334958?v=4",
+      "link": "https://github.com/opt-nc/jbang-catalog/blob/e5b5a07a9c0af4d3b3cc944b1db9a324cdd10f22/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello-optnc",
+          "c": "hello-optnc@opt-nc",
+          "s": "https://github.com/opt-nc/jbang-catalog/blob/main/hello-optnc/HelloOptNc.java"
+        },
+        {
+          "a": "phonenumber-validator",
+          "c": "phonenumber-validator@opt-nc",
+          "s": "https://github.com/opt-nc/jbang-catalog/blob/main/phonenumber-validator/Validator.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "38leinaD",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/413413?v=4",
+      "link": "https://github.com/38leinaD/jbang-catalog/blob/796de69d6c4e59ebd3df39b0e293e4cc40a8318d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "quarkus-starter",
+          "c": "quarkus-starter@38leinaD",
+          "d": "<p>Script to scaffold a Quarkus project</p>\n",
+          "s": "src/QuarkusStarter.java"
+        },
+        {
+          "a": "firestarter",
+          "c": "firestarter@38leinaD",
+          "d": "<p>Display a YouTube video on your RasPi or similar (e.g. to build a 'virtual fireplace'). Also, simple web-ui to edit the video URL.</p>\n",
+          "s": "src/firestarter.java"
+        },
+        {
+          "a": "httpserver",
+          "c": "httpserver@38leinaD",
+          "d": "<p>Minimalist JDK-internal http-server</p>\n",
+          "s": "src/httpserver.java"
+        },
+        {
+          "a": "whisper",
+          "c": "whisper@38leinaD",
+          "d": "<p>Voice-to-text via whisper.cpp: hold mic button to record, transcribes and pastes into focused field</p>\n",
+          "s": "src/WhisperTranscribe.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "BrokkAi",
+      "name": "brokk-releases",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/204942796?v=4",
+      "link": "https://github.com/BrokkAi/brokk-releases/blob/ad26e9f405a380c408ae0f2a481a3815ea58608c/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "brokk",
+          "c": "brokk@BrokkAi/brokk-releases",
+          "s": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.6/brokk-0.23.6.jar"
+        },
+        {
+          "a": "brokk-headless",
+          "c": "brokk-headless@BrokkAi/brokk-releases",
+          "s": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.6/brokk-0.23.6.jar"
+        },
+        {
+          "a": "brokk-core",
+          "c": "brokk-core@BrokkAi/brokk-releases",
+          "s": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.6/brokk-core-0.23.6.jar"
+        },
+        {
+          "a": "brokk-0.23.5.beta8",
+          "c": "brokk-0.23.5.beta8@BrokkAi/brokk-releases",
+          "s": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.5.beta8/brokk-0.23.5.beta8.jar"
+        },
+        {
+          "a": "brokk-0.23.5.beta7",
+          "c": "brokk-0.23.5.beta7@BrokkAi/brokk-releases",
+          "s": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.5.beta7/brokk-0.23.5.beta7.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "parttimenerd",
+      "name": "jfr-redact",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/jfr-redact/blob/8a5538d6874d003cd14d3c4933efd40ce425b773/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfr-redact",
+          "c": "jfr-redact@parttimenerd/jfr-redact",
+          "s": "https://github.com/parttimenerd/jfr-redact/releases/download/v0.3.0/jfr-redact.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "linux-china",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "intro",
+          "c": "intro@linux-china",
+          "d": "<p>Introduction for linux_china</p>\n",
+          "s": "src/me/Intro.java"
+        },
+        {
+          "a": "resume",
+          "c": "resume@linux-china",
+          "d": "<p>Resume for linux_china</p>\n",
+          "s": "src/me/Resume.java"
+        },
+        {
+          "a": "DemoCli",
+          "c": "DemoCli@linux-china",
+          "d": "<p>Demo CLI</p>\n",
+          "s": "src/main/java/org/mvnsearch/DemoCli.java"
+        },
+        {
+          "a": "HelloWorld",
+          "c": "HelloWorld@linux-china",
+          "d": "<p>Hello World</p>\n",
+          "s": "src/hello/java/HelloWorld.java"
+        },
+        {
+          "a": "IJSharedIndexes",
+          "c": "IJSharedIndexes@linux-china",
+          "d": "<p>Generate project IJ Shared Indexes</p>\n",
+          "s": "src/ijSharedIndexes/SharedIndexBuilder.kt"
+        },
+        {
+          "a": "ij-shared-indexes-cli",
+          "c": "ij-shared-indexes-cli@linux-china",
+          "d": "<p>Generates project shared indexes and starts local server on them.</p>\n",
+          "s": "com.jetbrains.intellij.indexing.shared:ij-shared-indexes-tool-cli:0.9.0"
+        },
+        {
+          "a": "SpringBootApp",
+          "c": "SpringBootApp@linux-china",
+          "d": "<p>Spring Boot App</p>\n",
+          "s": "src/springBoot/java/demo1/SpringBootApp.java"
+        },
+        {
+          "a": "google-java-format",
+          "c": "google-java-format@linux-china",
+          "s": "https://github.com/google/google-java-format/releases/download/v1.13.0/google-java-format-1.13.0-all-deps.jar"
+        },
+        {
+          "a": "pkl-cli",
+          "c": "pkl-cli@linux-china",
+          "s": "org.pkl-lang:pkl-tools:0.25.2"
+        },
+        {
+          "a": "pkl-codegen",
+          "c": "pkl-codegen@linux-china",
+          "s": "org.pkl-lang:pkl-tools:0.25.2"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "nbbrd",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/8778468?v=4",
+      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello-nbbrd",
+          "c": "hello-nbbrd@nbbrd",
+          "d": "<p>Hello NBBRD</p>\n",
+          "s": "hello_nbbrd.java"
+        },
+        {
+          "a": "sdmx-dl",
+          "c": "sdmx-dl@nbbrd",
+          "d": "<p>Easily download official statistics</p>\n",
+          "s": "sdmx_dl.java"
+        },
+        {
+          "a": "heylogs",
+          "c": "heylogs@nbbrd",
+          "d": "<p>Keep-a-changelog tool</p>\n",
+          "s": "heylogs.java"
+        },
+        {
+          "a": "hello-nbbrd-picocli",
+          "c": "hello-nbbrd-picocli@nbbrd",
+          "d": "<p>Hello NBBRD</p>\n",
+          "s": "hello_nbbrd_picocli.java"
+        },
+        {
+          "a": "sasquatch",
+          "c": "sasquatch@nbbrd",
+          "d": "<p>A java reader of SAS datasets - Bill of Materials</p>\n",
+          "s": "sasquatch.java"
+        },
+        {
+          "a": "sasquatchw",
+          "c": "sasquatchw@nbbrd",
+          "d": "<p>A java reader of SAS datasets - Bill of Materials</p>\n",
+          "s": "sasquatchw.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jreleaser",
+      "name": "jbang-catalog",
+      "stars": 2,
+      "icon": "https://avatars.githubusercontent.com/u/81020166?v=4",
+      "link": "https://github.com/jreleaser/jbang-catalog/blob/20368c8b5c30d1b174adf9206a813975ff41e8f6/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jreleaser",
+          "c": "jreleaser@jreleaser",
+          "d": "<p>Release projects quickly and easily with JReleaser</p>\n",
+          "s": "jreleaser.java"
+        },
+        {
+          "a": "jreleaser-snapshot",
+          "c": "jreleaser-snapshot@jreleaser",
+          "d": "<p>Release projects quickly and easily with JReleaser</p>\n",
+          "s": "jreleaser_snapshot.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "xam.dk",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/xam.dk/blob/1a7796699252369e09cf967514a6c0523fdcec3c/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "tree",
+          "c": "tree@maxandersen/xam.dk",
+          "s": "tree/main.java"
+        },
+        {
+          "a": "qrcode",
+          "c": "qrcode@maxandersen/xam.dk",
+          "s": "qrcode/main.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "HanSolo",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/62843?v=4",
+      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jarkanoid",
+          "c": "jarkanoid@HanSolo",
+          "s": "https://github.com/HanSolo/jarkanoid/releases/download/17.0.17/jarkanoid-mac-x64-17.0.17.jar"
+        },
+        {
+          "a": "jdkmon",
+          "c": "jdkmon@HanSolo",
+          "s": "https://github.com/HanSolo/JDKMon/releases/download/17.0.77/JDKMon-17.0.77-linux-x64.jar"
+        },
+        {
+          "a": "jcpu",
+          "c": "jcpu@HanSolo",
+          "s": "https://github.com/HanSolo/jcpu/releases/download/17.0.0/jcpu-macos-x64-17.0.0.jar"
+        },
+        {
+          "a": "discocli",
+          "c": "discocli@HanSolo",
+          "s": "https://github.com/HanSolo/discocli/releases/download/17.0.15/discocli-17.0.15-fat.jar"
+        },
+        {
+          "a": "javafinder",
+          "c": "javafinder@HanSolo",
+          "s": "https://github.com/HanSolo/javafinder/releases/download/17.0.33/javafinder-17.0.33.jar"
+        },
+        {
+          "a": "glucostatusfx",
+          "c": "glucostatusfx@HanSolo",
+          "s": "https://github.com/HanSolo/glucostatusfx/releases/download/17.0.57/GlucoStatusFX-17.0.61-linux-x64.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "redhat-camel",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/202962512?v=4",
+      "link": "https://github.com/redhat-camel/jbang-catalog/blob/01f62746bdc36aff06f3ce6fe050543bd0c2397b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel",
+          "c": "camel@redhat-camel",
+          "d": "<p>Create and run Red Hat Build of Apache Camel routes easily</p>\n",
+          "s": "CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "philippart-s",
+      "name": "jbang",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/26224751?v=4",
+      "link": "https://github.com/philippart-s/jbang/blob/36fe37a6fe8c648d477cf7dfc717b1fd851eddab/jbang-demo/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jarvis-catalog",
+          "c": "jarvis-catalog@philippart-s/jbang~jbang-demo",
+          "d": "<p>Jarvis application alias</p>\n",
+          "s": "Jarvis.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "bmvermeer",
+      "name": "eventmcp",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/47326976?v=4",
+      "link": "https://github.com/bmvermeer/eventmcp/blob/05600d29c044ce11219035e173708919de31e392/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "eventmcp",
+          "c": "eventmcp@bmvermeer/eventmcp",
+          "d": "<p>Run the Snyk Event MCP tool</p>\n",
+          "s": "https://github.com/bmvermeer/eventmcp/releases/latest/download/eventmcp-runner.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "Hyperfoil",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/46731024?v=4",
+      "link": "https://github.com/Hyperfoil/jbang-catalog/blob/cd70d1e84b8407a80f75c5fd9f174c5f65cd326b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "wrk2",
+          "c": "wrk2@Hyperfoil",
+          "s": "io.hyperfoil:hyperfoil-cli:0.29.1"
+        },
+        {
+          "a": "wrk",
+          "c": "wrk@Hyperfoil",
+          "s": "io.hyperfoil:hyperfoil-cli:0.29.1"
+        },
+        {
+          "a": "cli",
+          "c": "cli@Hyperfoil",
+          "s": "io.hyperfoil:hyperfoil-cli:0.29.1"
+        },
+        {
+          "a": "run",
+          "c": "run@Hyperfoil",
+          "s": "io.hyperfoil:hyperfoil-cli:0.29.1"
+        },
+        {
+          "a": "qDup",
+          "c": "qDup@Hyperfoil",
+          "s": "io.hyperfoil.tools:qDup:0.11.0"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "snowdrop",
+      "name": "migration-tool",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/558276?v=4",
+      "link": "https://github.com/snowdrop/migration-tool/blob/8d2231d1ad70b78d2892ad001a31a7bbedaa9a7b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mtool",
+          "c": "mtool@snowdrop/migration-tool",
+          "d": "<p>Migration tool client to migrate Java applications</p>\n",
+          "s": "https://github.com/snowdrop/migration-tool/releases/download/early-access/migration-cli-1.0.5-SNAPSHOT-runner.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "javatechno",
+      "name": "camel-4.6.2",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/32136482?v=4",
+      "link": "https://github.com/javatechno/camel-4.6.2/blob/e25aa994a62b2c34d6e538b71ec95121fbaefd05/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel",
+          "c": "camel@javatechno/camel-4.6.2",
+          "d": "<p>Run Apache Camel routes easily</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "Gonzivang",
+      "name": "SecondTry",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/29268941?v=4",
+      "link": "https://github.com/Gonzivang/SecondTry/blob/992a6661e0c116747021824e7e8bbbf3c6a49734/CodeResources/Apache%20Camel/camel-main/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel",
+          "c": "camel@Gonzivang/SecondTry~CodeResources/Apache Camel/camel-main",
+          "d": "<p>Run Apache Camel routes easily</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "cf-explorer",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/cf-explorer/blob/d4685b76febe82b56ee2c472b59af1b327051046/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "cf-explorer",
+          "c": "cf-explorer@garodriguezlp/cf-explorer",
+          "s": "CfExplorer.java"
+        },
+        {
+          "a": "mock-server",
+          "c": "mock-server@garodriguezlp/cf-explorer",
+          "s": "wiremock/MockServer.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "CedricNdong",
+      "name": "springforge-tui",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/92950547?v=4",
+      "link": "https://github.com/CedricNdong/springforge-tui/blob/24f4a760fb4b1bac01433535685b662462aa72a7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "springforge",
+          "c": "springforge@CedricNdong/springforge-tui",
+          "d": "<p>SpringForge TUI \u2014 Generate Spring Boot API stacks from @Entity classes</p>\n",
+          "s": "dev.springforge:springforge-tui:RELEASE"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jbanghub",
+      "name": "h2",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/156902772?v=4",
+      "link": "https://github.com/jbanghub/h2/blob/432699361f7d60cf229f060989ce5ea20313b4ae/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "h2",
+          "c": "h2@jbanghub/h2",
+          "s": "com.h2database:h2:2.3.232"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jacoco",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/1939631?v=4",
+      "link": "https://github.com/jacoco/jbang-catalog/blob/678e949a1f87fcb1c92f0f781921e1290bc3ebde/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "cli",
+          "c": "cli@jacoco",
+          "d": "<p>Runs jacoco cli, see <a rel=\"nofollow\" href=\"https://www.jacoco.org/jacoco/trunk/doc/cli.html\">https://www.jacoco.org/jacoco/trunk/doc/cli.html</a> for documentation.</p>\n",
+          "s": "org.jacoco:org.jacoco.cli:RELEASE:nodeps"
+        },
+        {
+          "a": "agent",
+          "c": "agent@jacoco",
+          "d": "<p>jacoco agent, use like <code>jbang --javaagent &lt;script&gt;</code></p>\n",
+          "s": "org.jacoco:org.jacoco.agent:RELEASE:runtime"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jruby",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/55687?v=4",
+      "link": "https://github.com/jruby/jbang-catalog/blob/d22a9ed3704c9d8e47a8f286175341e6b4392292/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "run",
+          "c": "run@jruby",
+          "d": "<p>Run a Ruby command line with JRuby</p>\n",
+          "s": "org.jruby:jruby-complete:10.1.0.0"
+        },
+        {
+          "a": "run10.0",
+          "c": "run10.0@jruby",
+          "d": "<p>Run a Ruby command line with JRuby</p>\n",
+          "s": "org.jruby:jruby-complete:10.0.5.0"
+        },
+        {
+          "a": "run9.4",
+          "c": "run9.4@jruby",
+          "d": "<p>Run a Ruby command line with JRuby</p>\n",
+          "s": "org.jruby:jruby-complete:9.4.14.0"
+        },
+        {
+          "a": "run9.3",
+          "c": "run9.3@jruby",
+          "d": "<p>Run a Ruby command line with JRuby</p>\n",
+          "s": "org.jruby:jruby-complete:9.3.15.0"
+        },
+        {
+          "a": "run9.2",
+          "c": "run9.2@jruby",
+          "d": "<p>Run a Ruby command line with JRuby 9.2</p>\n",
+          "s": "org.jruby:jruby-complete:9.2.21.0"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "reactive-rsocket-broker",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/71858344?v=4",
+      "link": "https://github.com/reactive-rsocket-broker/jbang-catalog/blob/41b880d21e29476cd071678a270f7101fec587e3/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "BrokerClient",
+          "c": "BrokerClient@reactive-rsocket-broker",
+          "d": "<p>A client that connects to a broker and sends a request</p>\n",
+          "s": "src/brokerSimpleClient/java/RSocketBrokerClientApp.java"
+        },
+        {
+          "a": "rsocket-broker",
+          "c": "rsocket-broker@reactive-rsocket-broker",
+          "d": "<p>Start Alibaba Broker Server</p>\n",
+          "s": "https://repo1.maven.org/maven2/com/alibaba/rsocket/alibaba-broker-server/1.1.3/alibaba-broker-server-1.1.3.jar"
+        },
+        {
+          "a": "brokerService",
+          "c": "brokerService@reactive-rsocket-broker",
+          "d": "<p>RSocket Broker Service Provider</p>\n",
+          "s": "src/brokerService/java/demo/RSocketServiceApp.java"
+        },
+        {
+          "a": "brokerConsumer",
+          "c": "brokerConsumer@reactive-rsocket-broker",
+          "d": "<p>RSocket Broker Service Consumer</p>\n",
+          "s": "src/brokerConsumer/java/demo/RSocketConsumerApp.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "codejive",
+      "name": "twinkle",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/56220728?v=4",
+      "link": "https://github.com/codejive/twinkle/blob/d4b0db46a562306154f30f8b3a3cb1f5bd82f394/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "bounce",
+          "c": "bounce@codejive/twinkle",
+          "d": "<p>A simple TUI that demonstrates a bouncing Twinkle.</p>\n",
+          "s": "examples/src/main/java/org/codejive/twinkle/demos/BouncingTwinkleDemo.java"
+        },
+        {
+          "a": "image",
+          "c": "image@codejive/twinkle",
+          "d": "<p>A simple TUI that demonstrates image rendering.</p>\n",
+          "s": "examples/src/main/java/org/codejive/twinkle/demos/ImageEncoderDemo.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "quarkusio",
+      "name": "quarkus.ai",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/quarkus.ai/blob/188194f732fbe3b13eb1721e23dd0e0e14bf3eda/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mcp-proxy",
+          "c": "mcp-proxy@quarkusio/quarkus.ai",
+          "s": "io.quarkiverse.mcp:quarkus-mcp-stdio-sse-proxy:1.0.0.CR1@fatjar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "linux-china",
+      "name": "jbang-alibaba-spring-cloud",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "NacosService",
+          "c": "NacosService@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>Nacos Service</p>\n",
+          "s": "nacos-service/src/demo/NacosServiceApp.java"
+        },
+        {
+          "a": "NacosClient",
+          "c": "NacosClient@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>Nacos Client</p>\n",
+          "s": "nacos-client/src/demo/NacosClientApp.java"
+        },
+        {
+          "a": "RocketmqConsumer",
+          "c": "RocketmqConsumer@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>RocketMQ Consumer</p>\n",
+          "s": "rocketmq-consumer/src/demo/RocketmqConsumerApp.java"
+        },
+        {
+          "a": "RocketmqSender",
+          "c": "RocketmqSender@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>RocketMQ Sender</p>\n",
+          "s": "rocketmq-sender/src/RocketmqSender.java"
+        },
+        {
+          "a": "DubboServiceApp",
+          "c": "DubboServiceApp@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>Dubbo Service Provider</p>\n",
+          "s": "dubbo-demo/src/DubboServiceApp.java"
+        },
+        {
+          "a": "DubboClientApp",
+          "c": "DubboClientApp@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>Dubbo Service Consumer</p>\n",
+          "s": "dubbo-demo/src/DubboClientApp.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "RocketmqConsumer",
+          "c": "RocketmqConsumer@linux-china/jbang-alibaba-spring-cloud",
+          "d": "<p>Basic template for RocketMQ Consumer</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "jOOQ",
+      "name": "jbang-catalog",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/1666512?v=4",
+      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "codegen",
+          "c": "codegen@jOOQ",
+          "s": "codegen.java"
+        },
+        {
+          "a": "codegen-pro",
+          "c": "codegen-pro@jOOQ",
+          "s": "codegenpro.java"
+        },
+        {
+          "a": "codegen-pro-java-8",
+          "c": "codegen-pro-java-8@jOOQ",
+          "s": "codegenprojava8.java"
+        },
+        {
+          "a": "codegen-pro-java-11",
+          "c": "codegen-pro-java-11@jOOQ",
+          "s": "codegenprojava11.java"
+        },
+        {
+          "a": "codegen-trial",
+          "c": "codegen-trial@jOOQ",
+          "s": "codegentrial.java"
+        },
+        {
+          "a": "codegen-trial-java-8",
+          "c": "codegen-trial-java-8@jOOQ",
+          "s": "codegentrialjava8.java"
+        },
+        {
+          "a": "codegen-trial-java-11",
+          "c": "codegen-trial-java-11@jOOQ",
+          "s": "codegentrialjava11.java"
+        },
+        {
+          "a": "parser",
+          "c": "parser@jOOQ",
+          "s": "parser.java"
+        },
+        {
+          "a": "parser-pro",
+          "c": "parser-pro@jOOQ",
+          "s": "parserpro.java"
+        },
+        {
+          "a": "parser-pro-java-8",
+          "c": "parser-pro-java-8@jOOQ",
+          "s": "parserprojava8.java"
+        },
+        {
+          "a": "parser-pro-java-11",
+          "c": "parser-pro-java-11@jOOQ",
+          "s": "parserprojava11.java"
+        },
+        {
+          "a": "parser-trial",
+          "c": "parser-trial@jOOQ",
+          "s": "parsertrial.java"
+        },
+        {
+          "a": "parser-trial-java-8",
+          "c": "parser-trial-java-8@jOOQ",
+          "s": "parsertrialjava8.java"
+        },
+        {
+          "a": "parser-trial-java-11",
+          "c": "parser-trial-java-11@jOOQ",
+          "s": "parsertrialjava11.java"
+        },
+        {
+          "a": "diff",
+          "c": "diff@jOOQ",
+          "s": "diff.java"
+        },
+        {
+          "a": "diff-pro",
+          "c": "diff-pro@jOOQ",
+          "s": "diffpro.java"
+        },
+        {
+          "a": "diff-pro-java-8",
+          "c": "diff-pro-java-8@jOOQ",
+          "s": "diffprojava8.java"
+        },
+        {
+          "a": "diff-pro-java-11",
+          "c": "diff-pro-java-11@jOOQ",
+          "s": "diffprojava11.java"
+        },
+        {
+          "a": "diff-trial",
+          "c": "diff-trial@jOOQ",
+          "s": "difftrial.java"
+        },
+        {
+          "a": "diff-trial-java-8",
+          "c": "diff-trial-java-8@jOOQ",
+          "s": "difftrialjava8.java"
+        },
+        {
+          "a": "diff-trial-java-11",
+          "c": "diff-trial-java-11@jOOQ",
+          "s": "difftrialjava11.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "parttimenerd",
+      "name": "jhserr",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/490655?v=4",
+      "link": "https://github.com/parttimenerd/jhserr/blob/008e9142fdd9b02f94c857946a9305eecfc77199/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jhserr",
+          "c": "jhserr@parttimenerd/jhserr",
+          "s": "https://github.com/parttimenerd/jhserr/releases/download/v0.1.0/jhserr.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "tgm-templates",
+      "name": "jbang-script",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/71794210?v=4",
+      "link": "https://github.com/tgm-templates/jbang-script/blob/c092862fa2eeda74212836d80554a1a4a712476a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "HelloWorld",
+          "c": "HelloWorld@tgm-templates/jbang-script",
+          "s": "src/hello/HelloWorld.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "gomezrondon",
+      "name": "spring-jbang",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/27861160?v=4",
+      "link": "https://github.com/gomezrondon/spring-jbang/blob/a425bf3bb9cb2fffd61c5c1805248b08b91a6b40/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "springjbang",
+          "c": "springjbang@gomezrondon/spring-jbang",
+          "s": "com/gomezrondon/springjbang/Application.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jbangdev",
+      "name": "jdkdb-scraper",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jdkdb-scraper/blob/72f05e666210ac3471d51707ea599a82c946ddc2/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "scraper",
+          "c": "scraper@jbangdev/jdkdb-scraper",
+          "s": "https://github.com/jbangdev/jdkdb-scraper/releases/latest/download/jdkdb-scraper-standalone.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "linux-china",
+      "name": "pkl-demo",
+      "stars": 1,
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/pkl-demo/blob/6edab5087fe6d0f04661a97e969eafd9a60dfef3/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pkl-cli",
+          "c": "pkl-cli@linux-china/pkl-demo",
+          "s": "org.pkl-lang:pkl-tools:0.27.0"
+        },
+        {
+          "a": "pkl-codegen",
+          "c": "pkl-codegen@linux-china/pkl-demo",
+          "s": "org.pkl-lang:pkl-tools:0.27.0"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "pgcheck",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/pgcheck/blob/8e7d28a57706fcf0140c77f63c529e9f5b9a8372/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pgcheck",
+          "c": "pgcheck@garodriguezlp/pgcheck",
+          "d": "<p>One-shot PostgreSQL executor for LLM agents</p>\n",
+          "s": "pgcheck.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "rodnansol",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/107804610?v=4",
+      "link": "https://github.com/rodnansol/jbang-catalog/blob/e6b402f7b96e09cb13812fabfd0f54f9d7d29704/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "spring-configuration-property-documenter",
+          "c": "spring-configuration-property-documenter@rodnansol",
+          "d": "<p>Reads your spring-configuration-metadata.json and generates Markdown/AsciiDoc/HTML/XML based documentation from it.</p>\n",
+          "s": "SpringConfigurationPropertyDocumenter.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "yostane",
+      "name": "adventofcode",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1958676?v=4",
+      "link": "https://github.com/yostane/adventofcode/blob/df00369dcb0ad3765d8c7c7537d28723b7aed468/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "2024-1",
+          "c": "2024-1@yostane/adventofcode",
+          "d": "<p>Advent of code 2024 day  in Kotlin</p>\n",
+          "s": "2024/day1-kotlin/2024-day1.kt"
+        },
+        {
+          "a": "2024-2",
+          "c": "2024-2@yostane/adventofcode",
+          "d": "<p>Advent of code 2024 day  in Kotlin</p>\n",
+          "s": "2024/day1-kotlin/2024-day2.kt"
+        },
+        {
+          "a": "2024-3",
+          "c": "2024-3@yostane/adventofcode",
+          "d": "<p>Advent of code 2024 day  in Kotlin</p>\n",
+          "s": "2024/day1-kotlin/2024-day3.kt"
+        },
+        {
+          "a": "2024-4",
+          "c": "2024-4@yostane/adventofcode",
+          "d": "<p>Advent of code 2024 day  in Kotlin</p>\n",
+          "s": "2024/day1-kotlin/2024-day4.kt"
+        }
+      ],
+      "templates": [
+        {
+          "a": "kt",
+          "c": "kt@yostane/adventofcode",
+          "d": "<p>Kotlin Template</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "gomezrondon",
+      "name": "spring-in-container",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/27861160?v=4",
+      "link": "https://github.com/gomezrondon/spring-in-container/blob/546df82c9b5bd1159c9866101c79a2fd5d3b1388/script/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "cleanyaml",
+          "c": "cleanyaml@gomezrondon/spring-in-container~script",
+          "s": "jscript.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "forest-town",
+      "name": "repo-2823585",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/86825428?v=4",
+      "link": "https://github.com/forest-town/repo-2823585/blob/b22e6473485b0c5163de12360a1b00069e9efcf9/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel",
+          "c": "camel@forest-town/repo-2823585",
+          "d": "<p>Run Apache Camel routes easily</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "splunkctl",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/splunkctl/blob/4711f97e92440837f4e0c6ff52974e1afddce88f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "splunk-samples",
+          "c": "splunk-samples@garodriguezlp/splunkctl",
+          "s": "support/dev-assets/SplunkSamples.java"
+        },
+        {
+          "a": "splunkctl",
+          "c": "splunkctl@garodriguezlp/splunkctl",
+          "s": "SplunkCtl.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "base2Services",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/478604?v=4",
+      "link": "https://github.com/base2Services/jbang-catalog/blob/b35b5a203947f6e6eae17d5cfd22abb04aa1bbcc/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "env",
+          "c": "env@base2Services",
+          "d": "<p>Dump table of Environment Variables</p>\n",
+          "s": "env.java"
+        },
+        {
+          "a": "awsssm",
+          "c": "awsssm@base2Services",
+          "d": "<p>AWS SSM Session Manager Tunnels</p>\n",
+          "s": "awsssm.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "wfouche",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/13682850?v=4",
+      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/testapp2/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "testapp2",
+          "c": "testapp2@wfouche~testapp2",
+          "s": "io/tulip/App.java"
+        },
+        {
+          "a": "hello",
+          "c": "hello@wfouche~apps/hello/1.0.0",
+          "s": "src/hello.java"
+        },
+        {
+          "a": "camel",
+          "c": "camel@wfouche~apps/camel/4.17.0",
+          "s": "../CamelJBang.java"
+        },
+        {
+          "a": "asciidoc",
+          "c": "asciidoc@wfouche",
+          "s": "src/asciidoc.java"
+        },
+        {
+          "a": "asciidoctorj",
+          "c": "asciidoctorj@wfouche",
+          "s": "src/asciidoctorj.java"
+        },
+        {
+          "a": "asciidoctorj-cli",
+          "c": "asciidoctorj-cli@wfouche",
+          "s": "src/asciidoctorj_cli.java"
+        },
+        {
+          "a": "camel",
+          "c": "camel@wfouche",
+          "s": "camel@wfouche~/apps/camel/4.16.0"
+        },
+        {
+          "a": "camel2",
+          "c": "camel2@wfouche",
+          "s": "camel@apps/camel/4.17.0/jbang-catalog.json"
+        },
+        {
+          "a": "clojure",
+          "c": "clojure@wfouche",
+          "s": "src/Clojure.java"
+        },
+        {
+          "a": "command-dev",
+          "c": "command-dev@wfouche",
+          "s": "src/Command.java"
+        },
+        {
+          "a": "command",
+          "c": "command@wfouche",
+          "s": "src/Command/1/Command.java"
+        },
+        {
+          "a": "deps",
+          "c": "deps@wfouche",
+          "s": "src/deps.java"
+        },
+        {
+          "a": "java-cli",
+          "c": "java-cli@wfouche",
+          "s": "src/JavaCli.java"
+        },
+        {
+          "a": "jgit",
+          "c": "jgit@wfouche",
+          "s": "src/jgit.java"
+        },
+        {
+          "a": "jython-jpm",
+          "c": "jython-jpm@wfouche",
+          "s": "src/JythonJpm.java"
+        },
+        {
+          "a": "hello",
+          "c": "hello@wfouche",
+          "s": "src/hello.java"
+        },
+        {
+          "a": "import",
+          "c": "import@wfouche",
+          "s": "src/JBangImport.java"
+        },
+        {
+          "a": "kwrk-dev",
+          "c": "kwrk-dev@wfouche",
+          "s": "src/kwrk.kt"
+        },
+        {
+          "a": "kwrk",
+          "c": "kwrk@wfouche",
+          "s": "src/kwrk/1/kwrk.kt"
+        },
+        {
+          "a": "situi",
+          "c": "situi@wfouche",
+          "s": "apps/situi/0.1.1/spring-initializr-tui-0.1.1.jar"
+        },
+        {
+          "a": "snapshot-cli-dev",
+          "c": "snapshot-cli-dev@wfouche",
+          "s": "src/SnapshotCli.java"
+        },
+        {
+          "a": "snapshot-cli",
+          "c": "snapshot-cli@wfouche",
+          "s": "src/SnapshotCli/1/SnapshotCli.java"
+        },
+        {
+          "a": "testapp",
+          "c": "testapp@wfouche",
+          "s": "src/testapp/io/tulip/App.java"
+        },
+        {
+          "a": "tulip-cli-dev",
+          "c": "tulip-cli-dev@wfouche",
+          "s": "src/TulipCli.java"
+        },
+        {
+          "a": "tulip-cli",
+          "c": "tulip-cli@wfouche",
+          "s": "src/TulipCli/1/TulipCli.java"
+        },
+        {
+          "a": "timestamp",
+          "c": "timestamp@wfouche",
+          "s": "src/timestamp.java"
+        },
+        {
+          "a": "wrapper-cli",
+          "c": "wrapper-cli@wfouche",
+          "s": "src/WrapperCli.java"
+        },
+        {
+          "a": "pong",
+          "c": "pong@wfouche",
+          "s": "src/Pong.java"
+        },
+        {
+          "a": "python-jvm-dev",
+          "c": "python-jvm-dev@wfouche",
+          "s": "src/python_jvm.java"
+        },
+        {
+          "a": "python-jvm",
+          "c": "python-jvm@wfouche",
+          "s": "src/python_jvm/1/python_jvm.java"
+        },
+        {
+          "a": "python-cli",
+          "c": "python-cli@wfouche",
+          "s": "src/python_cli.java"
+        },
+        {
+          "a": "jython-cli",
+          "c": "jython-cli@wfouche",
+          "s": "src/JythonCli.java"
+        },
+        {
+          "a": "jython-java-fmt",
+          "c": "jython-java-fmt@wfouche",
+          "d": "<p>Formats Java Source Code in src folder</p>\n",
+          "s": "jbang-fmt@jbangdev/jbang-fmt"
+        },
+        {
+          "a": "schemaspy",
+          "c": "schemaspy@wfouche",
+          "s": "src/SchemaSpy.java"
+        },
+        {
+          "a": "show-version",
+          "c": "show-version@wfouche",
+          "s": "src/ShowVersion.java"
+        },
+        {
+          "a": "camel-dev",
+          "c": "camel-dev@wfouche",
+          "s": "src/CamelJBang.java"
+        },
+        {
+          "a": "situi",
+          "c": "situi@wfouche~apps/situi/0.1.1",
+          "s": "./spring-initializr-tui-0.1.1.jar"
+        },
+        {
+          "a": "hello",
+          "c": "hello@wfouche~apps/hello/1.0.1",
+          "s": "src/hello.java"
+        },
+        {
+          "a": "camel",
+          "c": "camel@wfouche~apps/camel/4.16.0",
+          "s": "../CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "asciidoctor",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/3137042?v=4",
+      "link": "https://github.com/asciidoctor/jbang-catalog/blob/115d7276735a69ff421731b0693d9a031061c055/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "asciidoctorj",
+          "c": "asciidoctorj@asciidoctor",
+          "d": "<p>Run AsciidoctorJ 3.0</p>\n",
+          "s": "asciidoctorj.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "mfietz",
+      "name": "msr-mcp",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/6860662?v=4",
+      "link": "https://github.com/mfietz/msr-mcp/blob/3b7b35df84e93043eb665f354ca7c5c913a2573b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "msr-mcp",
+          "c": "msr-mcp@mfietz/msr-mcp",
+          "d": "<p>MSR MCP Server \u2014 Mining Software Repository analyses (hotspots, coupling, history) via MCP protocol</p>\n",
+          "s": "https://github.com/mfietz/msr-mcp/releases/latest/download/msr-mcp-server.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "nandorholozsnyak",
+      "name": "jbang-catalog-doc-generator",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/11406183?v=4",
+      "link": "https://github.com/nandorholozsnyak/jbang-catalog-doc-generator/blob/5b0a0d3627b30fe46c51d7f1ef1dba50a5c8dd34/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "cli",
+          "c": "cli@nandorholozsnyak/jbang-catalog-doc-generator",
+          "s": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.6.1.Final/quarkus-cli-2.6.1.Final-runner.jar"
+        },
+        {
+          "a": "qs",
+          "c": "qs@nandorholozsnyak/jbang-catalog-doc-generator",
+          "s": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.6.1.Final/quarkus-cli-2.6.1.Final-runner.jar"
+        },
+        {
+          "a": "quarkus",
+          "c": "quarkus@nandorholozsnyak/jbang-catalog-doc-generator",
+          "s": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.6.1.Final/quarkus-cli-2.6.1.Final-runner.jar"
+        }
+      ],
+      "templates": [
+        {
+          "a": "q-aws-lambda-tf",
+          "c": "q-aws-lambda-tf@nandorholozsnyak/jbang-catalog-doc-generator",
+          "d": "<p>Quarkus AWS Lambda template with Terraform template. Use the -Dnative-function flag to have native image based Terraform resources</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "karatelabs",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/91312095?v=4",
+      "link": "https://github.com/karatelabs/jbang-catalog/blob/63a7884565eb689f6022407185d5d68d052d8e5e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@karatelabs",
+          "s": "io.karatelabs:karate-core:1.5.2:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "Ingvord",
+      "name": "bookish-succotash",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/11678364?v=4",
+      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "ring-dashboard",
+          "c": "ring-dashboard@Ingvord/bookish-succotash",
+          "d": "<p>Live dashboard reading the C++ Tango storage-ring simulator</p>\n",
+          "s": "demo/scripts/StorageRingDashboard.java"
+        },
+        {
+          "a": "ring-correlation",
+          "c": "ring-correlation@Ingvord/bookish-succotash",
+          "d": "<p>Correlated reads across controller and sector devices</p>\n",
+          "s": "demo/scripts/CorrelatedOrbitSnapshot.java"
+        },
+        {
+          "a": "ring-smoothing",
+          "c": "ring-smoothing@Ingvord/bookish-succotash",
+          "d": "<p>Sliding average and guarded write-back to the controller</p>\n",
+          "s": "demo/scripts/SmoothedCurrentWriter.java"
+        },
+        {
+          "a": "ring-interlocks",
+          "c": "ring-interlocks@Ingvord/bookish-succotash",
+          "d": "<p>Fan-in alarm stream across the sector devices</p>\n",
+          "s": "demo/scripts/BeamLossInterlocks.java"
+        },
+        {
+          "a": "ring-backpressure",
+          "c": "ring-backpressure@Ingvord/bookish-succotash",
+          "d": "<p>Backpressure demo against fast sector polling</p>\n",
+          "s": "demo/scripts/RingBackpressure.java"
+        },
+        {
+          "a": "ring-scenario",
+          "c": "ring-scenario@Ingvord/bookish-succotash",
+          "d": "<p>Switch the storage-ring simulator scenario for live fault demos</p>\n",
+          "s": "demo/scripts/SetStorageRingScenario.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "jbang-processing",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jbang-processing/blob/0f18d428957c7aa61a7238a6b8d2fb309e1a3574/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pderun",
+          "c": "pderun@maxandersen/jbang-processing",
+          "s": "pderun.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "Ingvord",
+      "name": "RxJTango",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/11678364?v=4",
+      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "read-attribute",
+          "c": "read-attribute@Ingvord/RxJTango",
+          "d": "<p>Read one or more Tango attributes and print their values</p>\n",
+          "s": "examples/ReadAttribute.java"
+        },
+        {
+          "a": "poll",
+          "c": "poll@Ingvord/RxJTango",
+          "d": "<p>Poll a Tango attribute on a fixed interval and stream the values</p>\n",
+          "s": "examples/PollAttribute.java"
+        },
+        {
+          "a": "monitor",
+          "c": "monitor@Ingvord/RxJTango",
+          "d": "<p>Stream Tango attribute change events to stdout</p>\n",
+          "s": "examples/MonitorAttribute.java"
+        },
+        {
+          "a": "zip",
+          "c": "zip@Ingvord/RxJTango",
+          "d": "<p>Poll and zip two attributes from (possibly different) devices</p>\n",
+          "s": "examples/ZipAttributes.java"
+        },
+        {
+          "a": "snapshot",
+          "c": "snapshot@Ingvord/RxJTango",
+          "d": "<p>Read attributes from multiple devices in parallel and print a combined snapshot</p>\n",
+          "s": "examples/MultiDeviceSnapshot.java"
+        },
+        {
+          "a": "stats",
+          "c": "stats@Ingvord/RxJTango",
+          "d": "<p>Collect N samples of double_scalar and compute min/max/mean/stddev</p>\n",
+          "s": "examples/TangoTestStats.java"
+        },
+        {
+          "a": "correlate",
+          "c": "correlate@Ingvord/RxJTango",
+          "d": "<p>Read double_scalar and long_scalar in parallel on each tick, print both with their difference</p>\n",
+          "s": "examples/TangoTestCorrelate.java"
+        },
+        {
+          "a": "calibrate",
+          "c": "calibrate@Ingvord/RxJTango",
+          "d": "<p>Read-transform-write pipeline with linear calibration (gain * value + offset)</p>\n",
+          "s": "examples/CalibrationPipeline.java"
+        },
+        {
+          "a": "alarm",
+          "c": "alarm@Ingvord/RxJTango",
+          "d": "<p>Fan-in alarm monitor: merge N polling streams, alert when threshold is exceeded</p>\n",
+          "s": "examples/AlarmMonitor.java"
+        },
+        {
+          "a": "pipeline",
+          "c": "pipeline@Ingvord/RxJTango",
+          "d": "<p>6-step fluent TangoClient pipeline on TangoTest: read \u2192 command \u2192 calibrate \u2192 command \u2192 write \u2192 read-back</p>\n",
+          "s": "examples/TangoTestPipeline.java"
+        },
+        {
+          "a": "throttle",
+          "c": "throttle@Ingvord/RxJTango",
+          "d": "<p>Poll at high frequency, display at low rate via throttleLast \u2014 shows Rx rate control</p>\n",
+          "s": "examples/TangoTestThrottle.java"
+        },
+        {
+          "a": "sliding-avg",
+          "c": "sliding-avg@Ingvord/RxJTango",
+          "d": "<p>Rolling average over a sliding window of N samples using buffer(N, 1)</p>\n",
+          "s": "examples/TangoTestSlidingAverage.java"
+        },
+        {
+          "a": "running-stats",
+          "c": "running-stats@Ingvord/RxJTango",
+          "d": "<p>Live streaming min/max/mean/stddev using scan() \u2014 O(1) memory, Welford algorithm</p>\n",
+          "s": "examples/TangoTestRunningStats.java"
+        },
+        {
+          "a": "backpressure",
+          "c": "backpressure@Ingvord/RxJTango",
+          "d": "<p>Fast producer vs slow consumer: demonstrate onBackpressureLatest/Drop/Buffer strategies</p>\n",
+          "s": "examples/TangoTestBackpressure.java"
+        },
+        {
+          "a": "verify-spec",
+          "c": "verify-spec@Ingvord/RxJTango",
+          "d": "<p>Run the reactive-streams TCK against RxTangoAttribute</p>\n",
+          "s": "examples/VerifySpec.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "zemiak",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/2537804?v=4",
+      "link": "https://github.com/zemiak/jbang-catalog/blob/2e21ec821ce53c3ba3b10d96abf68c8dfcef9c8d/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "letnecesty2025",
+          "c": "letnecesty2025@zemiak",
+          "s": "letnecesty2025/main.java"
+        },
+        {
+          "a": "letnecesty2025_sharkix",
+          "c": "letnecesty2025_sharkix@zemiak",
+          "s": "letnecesty2025_sharkix/main.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "jarkata-data-quarkus-jbang",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jarkata-data-quarkus-jbang/blob/e6d79d0178deab3739005bbddf8fc91364054e64/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "h2console",
+          "c": "h2console@maxandersen/jarkata-data-quarkus-jbang",
+          "s": "h2@jbanghub/h2"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "SimonScholz",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/7559962?v=4",
+      "link": "https://github.com/SimonScholz/jbang-catalog/blob/2cc41ee6e972c583ecf4f1e23178b51b9e443ae0/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "qr-code-app",
+          "c": "qr-code-app@SimonScholz",
+          "d": "<p>QR code with logo app by Simon Scholz</p>\n",
+          "s": "https://github.com/SimonScholz/qr-code-with-logo/releases/download/0.4.0/qr-code-app-all.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "yaodahua",
+      "name": "fuxian_ChatTester",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/96721872?v=4",
+      "link": "https://github.com/yaodahua/fuxian_ChatTester/blob/eb4c78ff31049765a9e28a6803c71e621ead32a9/Repos/tabulapdf_tabula-java/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "tabula",
+          "c": "tabula@yaodahua/fuxian_ChatTester~Repos/tabulapdf_tabula-java",
+          "s": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar"
+        },
+        {
+          "a": "tabula",
+          "c": "tabula@yaodahua/fuxian_ChatTester~CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java",
+          "s": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar"
+        },
+        {
+          "a": "tabula",
+          "c": "tabula@yaodahua/fuxian_ChatTester~CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java",
+          "s": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jlengrand",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/921666?v=4",
+      "link": "https://github.com/jlengrand/jbang-catalog/blob/20a69fcc6aa072afa05c23ca478693ccf367b382/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "app-snapshot",
+          "c": "app-snapshot@jlengrand",
+          "d": "<p>helidon-quickstart-se</p>\n",
+          "s": "app_snapshot.java"
+        },
+        {
+          "a": "helidon-quickstart-se-snapshot",
+          "c": "helidon-quickstart-se-snapshot@jlengrand",
+          "d": "<p>helidon-quickstart-se</p>\n",
+          "s": "helidon_quickstart_se_snapshot.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "codesapienbe",
+      "name": "jbang-tools",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/124777905?v=4",
+      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jobops",
+          "c": "jobops@codesapienbe/jbang-tools",
+          "d": "<p>AI motivation letter daemon with web crawling</p>\n",
+          "s": "jobops/JobOps.java"
+        },
+        {
+          "a": "instyper",
+          "c": "instyper@codesapienbe/jbang-tools",
+          "d": "<p>Ultra-low latency speech-to-text conversion</p>\n",
+          "s": "instyper/Instyper.java"
+        },
+        {
+          "a": "offlan",
+          "c": "offlan@codesapienbe/jbang-tools",
+          "d": "<p>Completely offline translator (90+ languages)</p>\n",
+          "s": "offlan/Offlan.java"
+        },
+        {
+          "a": "inspeak",
+          "c": "inspeak@codesapienbe/jbang-tools",
+          "d": "<p>Instant text-to-speech with file monitoring</p>\n",
+          "s": "inspeak/Inspeak.java"
+        },
+        {
+          "a": "qproj",
+          "c": "qproj@codesapienbe/jbang-tools",
+          "d": "<p>Project generator with 100k+ templates</p>\n",
+          "s": "qproj/Qproj.java"
+        },
+        {
+          "a": "pertun",
+          "c": "pertun@codesapienbe/jbang-tools",
+          "d": "<p>Performance tuning and OS optimization</p>\n",
+          "s": "pertun/Pertun.java"
+        },
+        {
+          "a": "sysmon",
+          "c": "sysmon@codesapienbe/jbang-tools",
+          "d": "<p>Comprehensive system monitoring with AI predictions</p>\n",
+          "s": "sysmon/Sysmon.java"
+        },
+        {
+          "a": "netwatch",
+          "c": "netwatch@codesapienbe/jbang-tools",
+          "d": "<p>Network traffic monitoring with threat detection</p>\n",
+          "s": "netwatch/Netwatch.java"
+        },
+        {
+          "a": "procman",
+          "c": "procman@codesapienbe/jbang-tools",
+          "d": "<p>Advanced process manager with AI recommendations</p>\n",
+          "s": "procman/Procman.java"
+        },
+        {
+          "a": "diskman",
+          "c": "diskman@codesapienbe/jbang-tools",
+          "d": "<p>Intelligent disk analyzer with smart cleanup</p>\n",
+          "s": "diskman/Diskman.java"
+        },
+        {
+          "a": "powmon",
+          "c": "powmon@codesapienbe/jbang-tools",
+          "d": "<p>Battery and power management with learning optimization</p>\n",
+          "s": "powmon/Powmon.java"
+        },
+        {
+          "a": "lazyme",
+          "c": "lazyme@codesapienbe/jbang-tools",
+          "d": "<p>Cross-platform face recognition authentication</p>\n",
+          "s": "lazyme/Lazyme.java"
+        },
+        {
+          "a": "safeclip",
+          "c": "safeclip@codesapienbe/jbang-tools",
+          "d": "<p>AI-powered clipboard security scanner</p>\n",
+          "s": "safeclip/Safeclip.java"
+        },
+        {
+          "a": "mahrem",
+          "c": "mahrem@codesapienbe/jbang-tools",
+          "d": "<p>Universal end-to-end message encryption</p>\n",
+          "s": "mahrem/Mahrem.java"
+        },
+        {
+          "a": "vaultray",
+          "c": "vaultray@codesapienbe/jbang-tools",
+          "d": "<p>Lightweight password manager with tray integration</p>\n",
+          "s": "vaultray/Vaultray.java"
+        },
+        {
+          "a": "screengrab",
+          "c": "screengrab@codesapienbe/jbang-tools",
+          "d": "<p>Professional screen capture with AI annotation</p>\n",
+          "s": "screengrab/Screengrab.java"
+        },
+        {
+          "a": "medilook",
+          "c": "medilook@codesapienbe/jbang-tools",
+          "d": "<p>AI-powered video content search</p>\n",
+          "s": "medilook/Medilook.java"
+        },
+        {
+          "a": "newlook",
+          "c": "newlook@codesapienbe/jbang-tools",
+          "d": "<p>Real-time appearance modification with computer vision</p>\n",
+          "s": "newlook/Newlook.java"
+        },
+        {
+          "a": "audioctl",
+          "c": "audioctl@codesapienbe/jbang-tools",
+          "d": "<p>Advanced audio control with device switching</p>\n",
+          "s": "audioctl/Audioctl.java"
+        },
+        {
+          "a": "clipstack",
+          "c": "clipstack@codesapienbe/jbang-tools",
+          "d": "<p>Advanced clipboard manager with AI categorization</p>\n",
+          "s": "clipstack/Clipstack.java"
+        },
+        {
+          "a": "quickfile",
+          "c": "quickfile@codesapienbe/jbang-tools",
+          "d": "<p>Lightning-fast file search with learning algorithms</p>\n",
+          "s": "quickfile/Quickfile.java"
+        },
+        {
+          "a": "filewatch",
+          "c": "filewatch@codesapienbe/jbang-tools",
+          "d": "<p>Real-time file system monitoring with anomaly detection</p>\n",
+          "s": "filewatch/Filewatch.java"
+        },
+        {
+          "a": "syncmate",
+          "c": "syncmate@codesapienbe/jbang-tools",
+          "d": "<p>Intelligent file synchronization with smart conflict resolution</p>\n",
+          "s": "syncmate/Syncmate.java"
+        },
+        {
+          "a": "winman",
+          "c": "winman@codesapienbe/jbang-tools",
+          "d": "<p>Advanced window manager with learning-based layouts</p>\n",
+          "s": "winman/Winman.java"
+        },
+        {
+          "a": "trayorg",
+          "c": "trayorg@codesapienbe/jbang-tools",
+          "d": "<p>System tray organizer with AI importance ranking</p>\n",
+          "s": "trayorg/Trayorg.java"
+        },
+        {
+          "a": "displayctl",
+          "c": "displayctl@codesapienbe/jbang-tools",
+          "d": "<p>Advanced display control with adaptive ML settings</p>\n",
+          "s": "displayctl/Displayctl.java"
+        },
+        {
+          "a": "quickset",
+          "c": "quickset@codesapienbe/jbang-tools",
+          "d": "<p>Rapid system settings access with contextual suggestions</p>\n",
+          "s": "quickset/Quickset.java"
+        },
+        {
+          "a": "servicectl",
+          "c": "servicectl@codesapienbe/jbang-tools",
+          "d": "<p>System service manager with predictive failure detection</p>\n",
+          "s": "servicectl/Servicectl.java"
+        },
+        {
+          "a": "voicebytes",
+          "c": "voicebytes@codesapienbe/jbang-tools",
+          "d": "<p>Audio analysis with real-time speaker isolation</p>\n",
+          "s": "voicebytes/Voicebytes.java"
+        },
+        {
+          "a": "netguard",
+          "c": "netguard@codesapienbe/jbang-tools",
+          "d": "<p>Network security monitor with ML threat detection</p>\n",
+          "s": "netguard/Netguard.java"
+        },
+        {
+          "a": "vpnmon",
+          "c": "vpnmon@codesapienbe/jbang-tools",
+          "d": "<p>VPN connection monitor with intelligent server selection</p>\n",
+          "s": "vpnmon/Vpnmon.java"
+        },
+        {
+          "a": "pingmon",
+          "c": "pingmon@codesapienbe/jbang-tools",
+          "d": "<p>Network connectivity monitor with predictive issue detection</p>\n",
+          "s": "pingmon/Pingmon.java"
+        },
+        {
+          "a": "facebytes",
+          "c": "facebytes@codesapienbe/jbang-tools",
+          "d": "<p>Event photo management with privacy features</p>\n",
+          "s": "facebytes/Facebytes.java"
+        },
+        {
+          "a": "visiplay",
+          "c": "visiplay@codesapienbe/jbang-tools",
+          "d": "<p>Touchless gaming platform using hand-tracking</p>\n",
+          "s": "visiplay/Visiplay.java"
+        },
+        {
+          "a": "feedme",
+          "c": "feedme@codesapienbe/jbang-tools",
+          "d": "<p>AI-powered food inspection and nutrition analysis</p>\n",
+          "s": "feedme/Feedme.java"
+        },
+        {
+          "a": "codewatch",
+          "c": "codewatch@codesapienbe/jbang-tools",
+          "d": "<p>Real-time code quality monitor that analyzes your codebase continuously, detecting code smells, security vulnerabilities, and performance bottlenecks with AI-powered suggestions for improvement.</p>\n",
+          "s": "codewatch/CodeWatch.java"
+        },
+        {
+          "a": "gitflow",
+          "c": "gitflow@codesapienbe/jbang-tools",
+          "d": "<p>Advanced Git workflow manager with visual branch management, automated conflict resolution, intelligent merge strategies, and team collaboration insights with productivity analytics.</p>\n",
+          "s": "gitflow/GitFlow.java"
+        },
+        {
+          "a": "apitest",
+          "c": "apitest@codesapienbe/jbang-tools",
+          "d": "<p>Comprehensive API testing framework with automated test generation from OpenAPI specs, performance benchmarking, load testing, and real-time monitoring with alerting.</p>\n",
+          "s": "apitest/ApiTest.java"
+        },
+        {
+          "a": "docgen",
+          "c": "docgen@codesapienbe/jbang-tools",
+          "d": "<p>Intelligent documentation generator that creates comprehensive API docs, README files, and technical specifications from code comments, structure analysis, and usage patterns.</p>\n",
+          "s": "docgen/DocGen.java"
+        },
+        {
+          "a": "depcheck",
+          "c": "depcheck@codesapienbe/jbang-tools",
+          "d": "<p>Dependency vulnerability scanner and updater that monitors security issues, license compliance, version compatibility, and provides automated update suggestions with impact analysis.</p>\n",
+          "s": "depcheck/DepCheck.java"
+        },
+        {
+          "a": "buildopt",
+          "c": "buildopt@codesapienbe/jbang-tools",
+          "d": "<p>Build optimization analyzer that identifies bottlenecks in compilation processes, suggests performance improvements, and provides detailed metrics for faster development cycles.</p>\n",
+          "s": "buildopt/BuildOpt.java"
+        },
+        {
+          "a": "testgen",
+          "c": "testgen@codesapienbe/jbang-tools",
+          "d": "<p>AI-powered unit test generator that creates comprehensive test suites based on code analysis, coverage requirements, and best practices with mutation testing support.</p>\n",
+          "s": "testgen/TestGen.java"
+        },
+        {
+          "a": "logview",
+          "c": "logview@codesapienbe/jbang-tools",
+          "d": "<p>Advanced log analyzer with pattern recognition, anomaly detection, intelligent filtering, and real-time debugging assistance for complex distributed applications.</p>\n",
+          "s": "logview/LogView.java"
+        },
+        {
+          "a": "perfmon",
+          "c": "perfmon@codesapienbe/jbang-tools",
+          "d": "<p>Real-time application performance monitor with memory profiling, CPU usage analysis, database query optimization, and performance bottleneck identification.</p>\n",
+          "s": "perfmon/PerfMon.java"
+        },
+        {
+          "a": "coderev",
+          "c": "coderev@codesapienbe/jbang-tools",
+          "d": "<p>AI-powered code review assistant that provides instant feedback on code quality, security vulnerabilities, performance optimizations, and adherence to coding standards.</p>\n",
+          "s": "coderev/CodeRev.java"
+        },
+        {
+          "a": "dbtools",
+          "c": "dbtools@codesapienbe/jbang-tools",
+          "d": "<p>Database management toolkit with query optimization, schema analysis, data migration tools, and performance monitoring across multiple database engines.</p>\n",
+          "s": "dbtools/DbTools.java"
+        },
+        {
+          "a": "envman",
+          "c": "envman@codesapienbe/jbang-tools",
+          "d": "<p>Environment management tool that handles configuration across development, staging, and production environments with secret management and deployment automation.</p>\n",
+          "s": "envman/EnvMan.java"
+        },
+        {
+          "a": "mockgen",
+          "c": "mockgen@codesapienbe/jbang-tools",
+          "d": "<p>API mocking service generator that creates realistic mock APIs from specifications, supports dynamic responses, and provides testing scenarios.</p>\n",
+          "s": "mockgen/MockGen.java"
+        },
+        {
+          "a": "refactor",
+          "c": "refactor@codesapienbe/jbang-tools",
+          "d": "<p>Intelligent code refactoring assistant that suggests improvements, automates common refactoring patterns, and ensures code quality during transformations.</p>\n",
+          "s": "refactor/Refactor.java"
+        },
+        {
+          "a": "metrics",
+          "c": "metrics@codesapienbe/jbang-tools",
+          "d": "<p>Development metrics dashboard that tracks productivity, code quality, deployment frequency, and team performance with actionable insights.</p>\n",
+          "s": "metrics/Metrics.java"
+        },
+        {
+          "a": "exptrack",
+          "c": "exptrack@codesapienbe/jbang-tools",
+          "d": "<p>Advanced expense tracking with receipt scanning using OCR, automatic categorization with AI, tax preparation support, and multi-currency handling with real-time exchange rates.</p>\n",
+          "s": "exptrack/ExpTrack.java"
+        },
+        {
+          "a": "invoicegen",
+          "c": "invoicegen@codesapienbe/jbang-tools",
+          "d": "<p>Professional invoice generator with customizable templates, payment tracking, client management, automated reminders, and integration with accounting systems.</p>\n",
+          "s": "invoicegen/InvoiceGen.java"
+        },
+        {
+          "a": "budgetplan",
+          "c": "budgetplan@codesapienbe/jbang-tools",
+          "d": "<p>Intelligent budget planning tool with expense forecasting, goal tracking, financial health analysis, and investment recommendations based on spending patterns.</p>\n",
+          "s": "budgetplan/BudgetPlan.java"
+        },
+        {
+          "a": "taxcalc",
+          "c": "taxcalc@codesapienbe/jbang-tools",
+          "d": "<p>Multi-jurisdiction tax calculator with deduction optimization, filing assistance, audit support, and real-time tax law updates with compliance checking.</p>\n",
+          "s": "taxcalc/TaxCalc.java"
+        },
+        {
+          "a": "cryptotrack",
+          "c": "cryptotrack@codesapienbe/jbang-tools",
+          "d": "<p>Cryptocurrency portfolio tracker with real-time prices, profit/loss analysis, tax reporting, DeFi integration, and market sentiment analysis.</p>\n",
+          "s": "cryptotrack/CryptoTrack.java"
+        },
+        {
+          "a": "stockmon",
+          "c": "stockmon@codesapienbe/jbang-tools",
+          "d": "<p>Stock market monitor with portfolio tracking, alert systems, technical analysis tools, and AI-powered trading insights with risk assessment.</p>\n",
+          "s": "stockmon/StockMon.java"
+        },
+        {
+          "a": "bizplan",
+          "c": "bizplan@codesapienbe/jbang-tools",
+          "d": "<p>Business plan generator with financial projections, market analysis, presentation templates, and investor pitch deck creation with industry benchmarks.</p>\n",
+          "s": "bizplan/BizPlan.java"
+        },
+        {
+          "a": "leadmgr",
+          "c": "leadmgr@codesapienbe/jbang-tools",
+          "d": "<p>Lead management system with contact tracking, follow-up scheduling, conversion analysis, and sales pipeline optimization with CRM integration.</p>\n",
+          "s": "leadmgr/LeadMgr.java"
+        },
+        {
+          "a": "contractmgr",
+          "c": "contractmgr@codesapienbe/jbang-tools",
+          "d": "<p>Contract management with template library, renewal tracking, compliance monitoring, and automated workflow management with legal review assistance.</p>\n",
+          "s": "contractmgr/ContractMgr.java"
+        },
+        {
+          "a": "payroll",
+          "c": "payroll@codesapienbe/jbang-tools",
+          "d": "<p>Payroll management system with tax calculations, benefit administration, time tracking integration, and compliance reporting across multiple jurisdictions.</p>\n",
+          "s": "payroll/Payroll.java"
+        },
+        {
+          "a": "imgproc",
+          "c": "imgproc@codesapienbe/jbang-tools",
+          "d": "<p>Batch image processor with AI-powered optimization, format conversion, quality enhancement, watermarking, and metadata management with cloud storage integration.</p>\n",
+          "s": "imgproc/ImgProc.java"
+        },
+        {
+          "a": "vidconv",
+          "c": "vidconv@codesapienbe/jbang-tools",
+          "d": "<p>Video converter with format optimization, compression algorithms, batch processing, subtitle management, and quality preservation with GPU acceleration.</p>\n",
+          "s": "vidconv/VidConv.java"
+        },
+        {
+          "a": "audiocut",
+          "c": "audiocut@codesapienbe/jbang-tools",
+          "d": "<p>Audio editor with noise reduction, format conversion, automated podcast processing, voice enhancement, and multi-track editing capabilities.</p>\n",
+          "s": "audiocut/AudioCut.java"
+        },
+        {
+          "a": "pdftools",
+          "c": "pdftools@codesapienbe/jbang-tools",
+          "d": "<p>Comprehensive PDF toolkit with merging, splitting, OCR, form processing, digital signatures, and batch operations with security features.</p>\n",
+          "s": "pdftools/PdfTools.java"
+        },
+        {
+          "a": "markconv",
+          "c": "markconv@codesapienbe/jbang-tools",
+          "d": "<p>Markdown converter with multiple output formats, template support, automated styling, and integration with documentation platforms.</p>\n",
+          "s": "markconv/MarkConv.java"
+        },
+        {
+          "a": "codebeaut",
+          "c": "codebeaut@codesapienbe/jbang-tools",
+          "d": "<p>Code beautifier and formatter supporting 100+ programming languages with customizable style guides, team standards, and automated formatting.</p>\n",
+          "s": "codebeaut/CodeBeaut.java"
+        },
+        {
+          "a": "thumbgen",
+          "c": "thumbgen@codesapienbe/jbang-tools",
+          "d": "<p>Thumbnail generator for videos and images with batch processing, customizable templates, and automated optimization for different platforms.</p>\n",
+          "s": "thumbgen/ThumbGen.java"
+        },
+        {
+          "a": "watermark",
+          "c": "watermark@codesapienbe/jbang-tools",
+          "d": "<p>Batch watermarking tool with customizable overlays, transparency control, position management, and copyright protection features.</p>\n",
+          "s": "watermark/Watermark.java"
+        },
+        {
+          "a": "fontmgr",
+          "c": "fontmgr@codesapienbe/jbang-tools",
+          "d": "<p>Font management tool with preview capabilities, installation automation, collection organization, and licensing compliance tracking.</p>\n",
+          "s": "fontmgr/FontMgr.java"
+        },
+        {
+          "a": "colorpal",
+          "c": "colorpal@codesapienbe/jbang-tools",
+          "d": "<p>Color palette generator and manager with accessibility checking, brand consistency tools, and design system integration.</p>\n",
+          "s": "colorpal/ColorPal.java"
+        },
+        {
+          "a": "designkit",
+          "c": "designkit@codesapienbe/jbang-tools",
+          "d": "<p>Design toolkit with asset management, style guide generation, mockup creation, and collaboration features for design teams.</p>\n",
+          "s": "designkit/DesignKit.java"
+        },
+        {
+          "a": "brandkit",
+          "c": "brandkit@codesapienbe/jbang-tools",
+          "d": "<p>Brand management tool with logo variations, color schemes, typography guidelines, and asset distribution with usage tracking.</p>\n",
+          "s": "brandkit/BrandKit.java"
+        },
+        {
+          "a": "healthlog",
+          "c": "healthlog@codesapienbe/jbang-tools",
+          "d": "<p>Comprehensive health tracking with symptom logging, medication reminders, doctor appointment scheduling, and health trend analysis with AI insights.</p>\n",
+          "s": "healthlog/HealthLog.java"
+        },
+        {
+          "a": "fittrack",
+          "c": "fittrack@codesapienbe/jbang-tools",
+          "d": "<p>Fitness tracker with workout planning, progress monitoring, nutrition guidance, and integration with wearable devices and health platforms.</p>\n",
+          "s": "fittrack/FitTrack.java"
+        },
+        {
+          "a": "sleepmon",
+          "c": "sleepmon@codesapienbe/jbang-tools",
+          "d": "<p>Sleep monitor with pattern analysis, quality assessment, improvement recommendations, and integration with smart home devices for optimization.</p>\n",
+          "s": "sleepmon/SleepMon.java"
+        },
+        {
+          "a": "moodtrack",
+          "c": "moodtrack@codesapienbe/jbang-tools",
+          "d": "<p>Mood tracking with pattern recognition, trigger identification, wellness suggestions, and mental health resources with professional referrals.</p>\n",
+          "s": "moodtrack/MoodTrack.java"
+        },
+        {
+          "a": "waterrem",
+          "c": "waterrem@codesapienbe/jbang-tools",
+          "d": "<p>Water intake reminder with consumption tracking, hydration goals, health insights, and personalized recommendations based on activity levels.</p>\n",
+          "s": "waterrem/WaterRem.java"
+        },
+        {
+          "a": "breathe",
+          "c": "breathe@codesapienbe/jbang-tools",
+          "d": "<p>Breathing exercise guide with stress reduction techniques, meditation timers, relaxation programs, and biometric feedback integration.</p>\n",
+          "s": "breathe/Breathe.java"
+        },
+        {
+          "a": "eyecare",
+          "c": "eyecare@codesapienbe/jbang-tools",
+          "d": "<p>Eye care reminder with break scheduling, exercise routines, blue light monitoring, and vision health tracking with professional recommendations.</p>\n",
+          "s": "eyecare/EyeCare.java"
+        },
+        {
+          "a": "posture",
+          "c": "posture@codesapienbe/jbang-tools",
+          "d": "<p>Posture monitoring with correction reminders, exercise suggestions, ergonomic assessments, and workplace optimization recommendations.</p>\n",
+          "s": "posture/Posture.java"
+        },
+        {
+          "a": "langlearn",
+          "c": "langlearn@codesapienbe/jbang-tools",
+          "d": "<p>Language learning platform with spaced repetition, pronunciation practice, progress tracking, and cultural context integration with native speaker connections.</p>\n",
+          "s": "langlearn/LangLearn.java"
+        },
+        {
+          "a": "skilltrack",
+          "c": "skilltrack@codesapienbe/jbang-tools",
+          "d": "<p>Skill development tracker with learning paths, progress monitoring, certification management, and career advancement recommendations.</p>\n",
+          "s": "skilltrack/SkillTrack.java"
+        },
+        {
+          "a": "studyplan",
+          "c": "studyplan@codesapienbe/jbang-tools",
+          "d": "<p>Study planner with schedule optimization, progress tracking, performance analytics, and adaptive learning algorithms with peer collaboration.</p>\n",
+          "s": "studyplan/StudyPlan.java"
+        },
+        {
+          "a": "flashcard",
+          "c": "flashcard@codesapienbe/jbang-tools",
+          "d": "<p>Intelligent flashcard system with spaced repetition algorithms, multimedia support, and collaborative study groups with performance analytics.</p>\n",
+          "s": "flashcard/FlashCard.java"
+        },
+        {
+          "a": "quizgen",
+          "c": "quizgen@codesapienbe/jbang-tools",
+          "d": "<p>Quiz generator with automatic question creation, difficulty adjustment, performance analysis, and adaptive testing with learning insights.</p>\n",
+          "s": "quizgen/QuizGen.java"
+        },
+        {
+          "a": "mindmap",
+          "c": "mindmap@codesapienbe/jbang-tools",
+          "d": "<p>Mind mapping tool with collaborative features, export options, template libraries, and integration with note-taking and project management tools.</p>\n",
+          "s": "mindmap/MindMap.java"
+        },
+        {
+          "a": "readtrack",
+          "c": "readtrack@codesapienbe/jbang-tools",
+          "d": "<p>Reading tracker with progress monitoring, goal setting, recommendation systems, and book club integration with social features.</p>\n",
+          "s": "readtrack/ReadTrack.java"
+        },
+        {
+          "a": "notelink",
+          "c": "notelink@codesapienbe/jbang-tools",
+          "d": "<p>Note-taking system with intelligent linking, knowledge graphs, search capabilities, and cross-platform synchronization with AI organization.</p>\n",
+          "s": "notelink/NoteLink.java"
+        },
+        {
+          "a": "certtrack",
+          "c": "certtrack@codesapienbe/jbang-tools",
+          "d": "<p>Certification tracker with renewal reminders, study planning, career path guidance, and industry requirement monitoring.</p>\n",
+          "s": "certtrack/CertTrack.java"
+        },
+        {
+          "a": "knowbase",
+          "c": "knowbase@codesapienbe/jbang-tools",
+          "d": "<p>Knowledge base manager with AI-powered search, content organization, collaboration features, and expert system integration.</p>\n",
+          "s": "knowbase/KnowBase.java"
+        },
+        {
+          "a": "gamelib",
+          "c": "gamelib@codesapienbe/jbang-tools",
+          "d": "<p>Game library manager with playtime tracking, achievement monitoring, recommendation systems, and social features with performance analytics.</p>\n",
+          "s": "gamelib/GameLib.java"
+        },
+        {
+          "a": "movietrack",
+          "c": "movietrack@codesapienbe/jbang-tools",
+          "d": "<p>Movie and TV show tracker with watchlist management, rating systems, recommendation engines, and social sharing with review aggregation.</p>\n",
+          "s": "movietrack/MovieTrack.java"
+        },
+        {
+          "a": "bookclub",
+          "c": "bookclub@codesapienbe/jbang-tools",
+          "d": "<p>Book club organizer with reading schedules, discussion forums, progress tracking, and author event integration with social features.</p>\n",
+          "s": "bookclub/BookClub.java"
+        },
+        {
+          "a": "recipemgr",
+          "c": "recipemgr@codesapienbe/jbang-tools",
+          "d": "<p>Recipe manager with meal planning, shopping list generation, nutritional analysis, and dietary restriction support with cooking timers.</p>\n",
+          "s": "recipemgr/RecipeMgr.java"
+        },
+        {
+          "a": "travelplan",
+          "c": "travelplan@codesapienbe/jbang-tools",
+          "d": "<p>Travel planner with itinerary management, budget tracking, local recommendations, and real-time updates with emergency assistance.</p>\n",
+          "s": "travelplan/TravelPlan.java"
+        },
+        {
+          "a": "hobbytrack",
+          "c": "hobbytrack@codesapienbe/jbang-tools",
+          "d": "<p>Hobby tracker with project management, progress monitoring, community features, and skill development with tutorial integration.</p>\n",
+          "s": "hobbytrack/HobbyTrack.java"
+        },
+        {
+          "a": "eventplan",
+          "c": "eventplan@codesapienbe/jbang-tools",
+          "d": "<p>Event planner with guest management, budget tracking, timeline coordination, and vendor management with automated reminders.</p>\n",
+          "s": "eventplan/EventPlan.java"
+        },
+        {
+          "a": "gifttrack",
+          "c": "gifttrack@codesapienbe/jbang-tools",
+          "d": "<p>Gift tracker with occasion reminders, budget management, recipient preferences, and purchase history with recommendation engine.</p>\n",
+          "s": "gifttrack/GiftTrack.java"
+        },
+        {
+          "a": "petcare",
+          "c": "petcare@codesapienbe/jbang-tools",
+          "d": "<p>Pet care manager with health tracking, appointment scheduling, care reminders, and veterinary integration with emergency contacts.</p>\n",
+          "s": "petcare/PetCare.java"
+        },
+        {
+          "a": "plantcare",
+          "c": "plantcare@codesapienbe/jbang-tools",
+          "d": "<p>Plant care assistant with watering schedules, growth tracking, care instructions, and disease identification with expert consultation.</p>\n",
+          "s": "plantcare/PlantCare.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "kordamp",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/59115480?v=4",
+      "link": "https://github.com/kordamp/jbang-catalog/blob/8cb01f2e6c5d97886b75f4060afa9098fae6e6ee/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pomchecker",
+          "c": "pomchecker@kordamp",
+          "d": "<p>Checks POM files may be uploaded to Maven Central</p>\n",
+          "s": "pomchecker.java"
+        },
+        {
+          "a": "pomchecker-snapshot",
+          "c": "pomchecker-snapshot@kordamp",
+          "d": "<p>Checks POM files may be uploaded to Maven Central</p>\n",
+          "s": "pomchecker_snapshot.java"
+        },
+        {
+          "a": "jarviz-snapshot",
+          "c": "jarviz-snapshot@kordamp",
+          "d": "<p>JAR file analyzer</p>\n",
+          "s": "jarviz_snapshot.java"
+        },
+        {
+          "a": "jarviz",
+          "c": "jarviz@kordamp",
+          "d": "<p>JAR file analyzer</p>\n",
+          "s": "jarviz.java"
+        },
+        {
+          "a": "naum-snapshot",
+          "c": "naum-snapshot@kordamp",
+          "d": "<p>Java binary compatibility checking tool</p>\n",
+          "s": "naum_snapshot.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "btraceio",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/16762720?v=4",
+      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jafar-shell",
+          "c": "jafar-shell@btraceio",
+          "d": "<p>Interactive CLI for exploring and analyzing Java Flight Recorder files with JfrPath query language</p>\n",
+          "s": "io.btrace:jafar-shell:0.21.8"
+        },
+        {
+          "a": "jafar-shell-latest",
+          "c": "jafar-shell-latest@btraceio",
+          "d": "<p>JFR Shell latest development version</p>\n",
+          "s": "jafar-shell-latest.java"
+        },
+        {
+          "a": "jfr-shell",
+          "c": "jfr-shell@btraceio",
+          "d": "<p>Legacy alias for jafar-shell (use jafar-shell instead)</p>\n",
+          "s": "jafar-shell.java"
+        },
+        {
+          "a": "jfr-mcp",
+          "c": "jfr-mcp@btraceio",
+          "d": "<p>JFR MCP Server; snapshot version</p>\n",
+          "s": "io.btrace:jfr-mcp:0.21.8"
+        },
+        {
+          "a": "jfr-mcp-latest",
+          "c": "jfr-mcp-latest@btraceio",
+          "d": "<p>JFR MCP Server latest development version</p>\n",
+          "s": "jfr-mcp-latest.java"
+        },
+        {
+          "a": "btrace",
+          "c": "btrace@btraceio",
+          "d": "<p>BTrace client launcher</p>\n",
+          "s": "btrace.java"
+        },
+        {
+          "a": "btrace-latest",
+          "c": "btrace-latest@btraceio",
+          "d": "<p>BTrace client launcher (latest snapshot)</p>\n",
+          "s": "btrace-latest.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "a-services",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/26920499?v=4",
+      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "grep",
+          "c": "grep@a-services",
+          "d": "<p>Find substring like grep</p>\n",
+          "s": "find_grep.java"
+        },
+        {
+          "a": "csv",
+          "c": "csv@a-services",
+          "d": "<p>Export CSV file from database table</p>\n",
+          "s": "csv_from_db.java"
+        },
+        {
+          "a": "images2pdf",
+          "c": "images2pdf@a-services",
+          "d": "<p>Create PDF from images</p>\n",
+          "s": "images2pdf.java"
+        },
+        {
+          "a": "strapdownjs",
+          "c": "strapdownjs@a-services",
+          "d": "<p>Create HTML from markdown using strapdownjs</p>\n",
+          "s": "strapdownjs.java"
+        },
+        {
+          "a": "folder_sizes",
+          "c": "folder_sizes@a-services",
+          "d": "<p>Read and write CSV with folder sizes</p>\n",
+          "s": "folder_sizes.java"
+        },
+        {
+          "a": "find_cordova",
+          "c": "find_cordova@a-services",
+          "d": "<p>Search Cordova 8.x docs</p>\n",
+          "s": "find_cordova.java"
+        },
+        {
+          "a": "paste_log",
+          "c": "paste_log@a-services",
+          "d": "<p>Paste log from clipboard to file</p>\n",
+          "s": "paste_log.java"
+        },
+        {
+          "a": "ts_imports",
+          "c": "ts_imports@a-services",
+          "d": "<p>Find list of TypeScript imports in folder</p>\n",
+          "s": "ts_imports.java"
+        },
+        {
+          "a": "exc",
+          "c": "exc@a-services",
+          "d": "<p>Checking for exceptions in log file</p>\n",
+          "s": "exc.java"
+        },
+        {
+          "a": "yml_table",
+          "c": "yml_table@a-services",
+          "d": "<p>Convert YAML list to HTML</p>\n",
+          "s": "yml_table.java"
+        },
+        {
+          "a": "calibre_page",
+          "c": "calibre_page@a-services",
+          "d": "<p>Extract page from HTML created by Calibre</p>\n",
+          "s": "calibre_page.java"
+        },
+        {
+          "a": "fix_chapters",
+          "c": "fix_chapters@a-services",
+          "d": "<p>Fix numbers in markdown chapters</p>\n",
+          "s": "fix_chapters.java"
+        },
+        {
+          "a": "svg_icons",
+          "c": "svg_icons@a-services",
+          "d": "<p>Create set of png icons from svg file</p>\n",
+          "s": "svg_icons.java"
+        },
+        {
+          "a": "har2postman",
+          "c": "har2postman@a-services",
+          "d": "<p>Convert HAR file with HTTP requests exported from Chrome to Postman collection</p>\n",
+          "s": "har2postman.java"
+        },
+        {
+          "a": "file_index",
+          "c": "file_index@a-services",
+          "d": "<p>Generate index of files for current folder</p>\n",
+          "s": "file_index.java"
+        },
+        {
+          "a": "p_stats",
+          "c": "p_stats@a-services",
+          "d": "<p>Calculate project stats</p>\n",
+          "s": "p_stats.java"
+        },
+        {
+          "a": "extract_html_headers",
+          "c": "extract_html_headers@a-services",
+          "d": "<p>Extract header tags from html file as indented text to create table of contents</p>\n",
+          "s": "extract_html_headers.java"
+        },
+        {
+          "a": "bookserver",
+          "c": "bookserver@a-services",
+          "d": "<p>HTTP server that serves markdown files from folder which name ends with <code> Book</code></p>\n",
+          "s": "bookserver.java"
+        },
+        {
+          "a": "udemy_html_toc",
+          "c": "udemy_html_toc@a-services",
+          "d": "<p>Parse html file with Udemy course TOC</p>\n",
+          "s": "udemy_html_toc.java"
+        },
+        {
+          "a": "remove_html",
+          "c": "remove_html@a-services",
+          "d": "<p>Remove html tags from markdown file</p>\n",
+          "s": "remove_html.java"
+        },
+        {
+          "a": "replace_br",
+          "c": "replace_br@a-services",
+          "d": "<p>Replace &lt;br&gt; tags with newlines</p>\n",
+          "s": "replace_br.java"
+        },
+        {
+          "a": "cmp_tstamps",
+          "c": "cmp_tstamps@a-services",
+          "d": "<p>Compare timestamps in two folders</p>\n",
+          "s": "cmp_tstamps.java"
+        },
+        {
+          "a": "obsidian_folder",
+          "c": "obsidian_folder@a-services",
+          "d": "<p>Convert Obsidian folder to HTML</p>\n",
+          "s": "obsidian_folder.java"
+        },
+        {
+          "a": "git_changes",
+          "c": "git_changes@a-services",
+          "d": "<p>Copy added/changed files from git to backup folder</p>\n",
+          "s": "git_changes.java"
+        },
+        {
+          "a": "tommy",
+          "c": "tommy@a-services",
+          "d": "<p>Tomcat - Create Windows Deployment Scripts</p>\n",
+          "s": "tommy.java"
+        },
+        {
+          "a": "README",
+          "c": "README@a-services",
+          "d": "<p>Generate <code>README.adoc</code> from <code>jbang-catalog.json</code></p>\n",
+          "s": "README.java"
+        },
+        {
+          "a": "ai_note",
+          "c": "ai_note@a-services",
+          "d": "<p>Running OpenAI prompts</p>\n",
+          "s": "ai_note.java"
+        },
+        {
+          "a": "maven_deps",
+          "c": "maven_deps@a-services",
+          "d": "<p>Extract maven dependency tree for each project in current folder</p>\n",
+          "s": "maven_deps.java"
+        },
+        {
+          "a": "o_ed",
+          "c": "o_ed@a-services",
+          "d": "<p>Obsidian Web Editor</p>\n",
+          "s": "o_ed.java"
+        },
+        {
+          "a": "tree",
+          "c": "tree@a-services",
+          "d": "<p>Directory tree in ASCII symbols up to a specified depth</p>\n",
+          "s": "tree.java"
+        },
+        {
+          "a": "insert_files",
+          "c": "insert_files@a-services",
+          "d": "<p>Replace file names with the contents of the respective files</p>\n",
+          "s": "insert_files.java"
+        },
+        {
+          "a": "copy_box",
+          "c": "copy_box@a-services",
+          "d": "<p>Copy binary file to clipboard or paste it back from clipboard to binary file.</p>\n",
+          "s": "copy_box.java"
+        },
+        {
+          "a": "grafana_log",
+          "c": "grafana_log@a-services",
+          "d": "<p>Extracts JSON 'body' field from the CSV 'Line' column into a .log file.</p>\n",
+          "s": "grafana_log.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "pgcheck-mcp",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/pgcheck-mcp/blob/2c752df0259bbb94a60866ae79beaf1cd425e757/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pgcheck-mcp",
+          "c": "pgcheck-mcp@garodriguezlp/pgcheck-mcp",
+          "d": "<p>PostgreSQL MCP Server with connection pooling</p>\n",
+          "s": "PgcheckMcpServer.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "Maps-Messaging",
+      "name": "mapsmessaging-jbang",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/76028870?v=4",
+      "link": "https://github.com/Maps-Messaging/mapsmessaging-jbang/blob/1a3a78fec009029e8bf55bac912f9303e11844c9/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mapsmessaging",
+          "c": "mapsmessaging@Maps-Messaging/mapsmessaging-jbang",
+          "d": "<p>MAPS Messaging Server</p>\n",
+          "s": "MAPS_Messaging.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "aswiniqaconsultants",
+      "name": "jbangdev",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/88204064?v=4",
+      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/itests/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@aswiniqaconsultants/jbangdev~itests",
+          "s": "hello.jsh"
+        },
+        {
+          "a": "echo",
+          "c": "echo@aswiniqaconsultants/jbangdev~itests",
+          "d": "<p>echo echo echo description</p>\n",
+          "s": "echo.java"
+        },
+        {
+          "a": "resource",
+          "c": "resource@aswiniqaconsultants/jbangdev~itests",
+          "s": "res/resource.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "agent",
+          "c": "agent@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>Agent template</p>\n"
+        },
+        {
+          "a": "cli",
+          "c": "cli@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>CLI template</p>\n"
+        },
+        {
+          "a": "hello",
+          "c": "hello@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>Basic Hello World template</p>\n"
+        },
+        {
+          "a": "hello.kt",
+          "c": "hello.kt@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>Basic kotlin Hello World template</p>\n"
+        },
+        {
+          "a": "qcli",
+          "c": "qcli@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>Quarkus CLI template</p>\n"
+        },
+        {
+          "a": "qmetrics",
+          "c": "qmetrics@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>Quarkus Metrics template</p>\n"
+        },
+        {
+          "a": "qrest",
+          "c": "qrest@aswiniqaconsultants/jbangdev~src/main/resources",
+          "d": "<p>Quarkus REST template</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "JabRef",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/3914421?v=4",
+      "link": "https://github.com/JabRef/jbang-catalog/blob/c512c0c05e303fa82862001a042dd3d078b24e6b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jabkit",
+          "c": "jabkit@JabRef",
+          "s": "https://github.com/JabRef/jabref/blob/main/.jbang/JabKitLauncher.java"
+        },
+        {
+          "a": "jabls",
+          "c": "jabls@JabRef",
+          "s": "https://github.com/JabRef/jabref/blob/main/.jbang/JabLsLauncher.java"
+        },
+        {
+          "a": "jabsrv",
+          "c": "jabsrv@JabRef",
+          "s": "https://github.com/JabRef/jabref/blob/main/.jbang/JabSrvLauncher.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "sebastienblanc",
+      "name": "limit-request",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/335133?v=4",
+      "link": "https://github.com/sebastienblanc/limit-request/blob/010bc8d7617ddfec40ca609cc0e29234735600b0/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "kubectl-limit",
+          "c": "kubectl-limit@sebastienblanc/limit-request",
+          "s": "src/kubectl-limit"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "dotCMS",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1005263?v=4",
+      "link": "https://github.com/dotCMS/jbang-catalog/blob/27796bbff9fe53ff9bde15ba1ca37dbf991ab064/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "qcli-jbang",
+          "c": "qcli-jbang@dotCMS",
+          "d": "<p>app -- Sample Quarkus CLI application</p>\n",
+          "s": "qcli_jbang.java"
+        },
+        {
+          "a": "jreleaser-cli-snapshot",
+          "c": "jreleaser-cli-snapshot@dotCMS",
+          "d": "<p>app -- Sample Quarkus CLI application</p>\n",
+          "s": "jreleaser_cli_snapshot.java"
+        },
+        {
+          "a": "dotcms-cli-snapshot",
+          "c": "dotcms-cli-snapshot@dotCMS",
+          "d": "<p>app -- DotCMS CLI</p>\n",
+          "s": "dotcms_cli_snapshot.java"
+        },
+        {
+          "a": "dotcms-cli",
+          "c": "dotcms-cli@dotCMS",
+          "d": "<p>app -- DotCMS CLI</p>\n",
+          "s": "dotcms_cli.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "Lewik",
+      "name": "mcp-tools-proxy",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1853182?v=4",
+      "link": "https://github.com/Lewik/mcp-tools-proxy/blob/1e16bd45674b86a560497bdb7a1e3bdbbb436744/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mcpproxy",
+          "c": "mcpproxy@Lewik/mcp-tools-proxy",
+          "d": "<p>MCP Tools Proxy CLI</p>\n",
+          "s": "https://github.com/Lewik/mcp-tools-proxy/releases/download/v0.1.5/mcp-tools-proxy.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "dsyer",
+      "name": "java-jupyter",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/124075?v=4",
+      "link": "https://github.com/dsyer/java-jupyter/blob/569585edb509bf1218600c9457807d31850fd093/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "app",
+          "c": "app@dsyer/java-jupyter",
+          "d": "<p>Application</p>\n",
+          "s": "src/main/java/com/example/Application.java"
+        },
+        {
+          "a": "db",
+          "c": "db@dsyer/java-jupyter",
+          "d": "<p>H2 Database</p>\n",
+          "s": "h2@jbanghub/h2"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ArjunSai",
+      "name": "camel",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/37168181?v=4",
+      "link": "https://github.com/ArjunSai/camel/blob/2c1451aab95bc2ee232e4b20ca27e6ebd613ea62/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "CamelJBang",
+          "c": "CamelJBang@ArjunSai/camel",
+          "d": "<p>Run Apache Camel routes easily (deprecated - use camel instead)</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        },
+        {
+          "a": "camel",
+          "c": "camel@ArjunSai/camel",
+          "d": "<p>Run Apache Camel routes easily</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "aucampia",
+      "name": "issues",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/4481387?v=4",
+      "link": "https://github.com/aucampia/issues/blob/1fe5785fea45c6641b7d2daa221bef0bc11833bb/20220908-datahub-protobuf/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "datahub-protobuf-old",
+          "c": "datahub-protobuf-old@aucampia/issues~20220908-datahub-protobuf",
+          "s": "https://raw.githubusercontent.com/datahub-project/datahub/b9068ffd2ef527a2b24b5d3828a9cc6c0f23b4fb/metadata-integration/java/datahub-protobuf-example/libs/datahub-protobuf.jar"
+        },
+        {
+          "a": "datahub-protobuf",
+          "c": "datahub-protobuf@aucampia/issues~20220908-datahub-protobuf",
+          "s": "io.acryl:datahub-protobuf:0.8.44-2rc1"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "fbricon",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/148698?v=4",
+      "link": "https://github.com/fbricon/jbang-catalog/blob/ee8fc4c84a0f35a645bcdf008600a58753e872f0/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "lastweek",
+          "c": "lastweek@fbricon",
+          "d": "<p>Script listing the commits that were published in my favourite repos for the past 7 days</p>\n",
+          "s": "lastweek.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "codejive",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/56220728?v=4",
+      "link": "https://github.com/codejive/jbang-catalog/blob/3afc11a8c108eb0089a46e34a1b9a68d1bfe600e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jpm",
+          "c": "jpm@codejive",
+          "d": "<p>A simple command line tool, taking inspiration from Node's npm, to manage Maven dependencies for Java projects that are not using build systems like Maven or Gradle. See <a rel=\"nofollow\" href=\"https://github.com/codejive/java-jpm\">Jpm website</a></p>\n",
+          "s": "org.codejive.jpm:jpm:0.6.4"
+        },
+        {
+          "a": "jpm-latest",
+          "c": "jpm-latest@codejive",
+          "d": "<p>[latest development version] A simple command line tool, taking inspiration from Node's npm, to manage Maven dependencies for Java projects that are not using build systems like Maven or Gradle. See <a rel=\"nofollow\" href=\"https://github.com/codejive/java-jpm\">Jpm website</a></p>\n",
+          "s": "https://github.com/codejive/java-jpm/blob/main/src/main/java/org/codejive/jpm/Main.java"
+        },
+        {
+          "a": "jvm",
+          "c": "jvm@codejive",
+          "d": "<p>A command line tool that helps you install and manage multiple Java versions on your machine. See <a rel=\"nofollow\" href=\"https://github.com/codejive/java-jvm\">Jvm website</a></p>\n",
+          "s": "org.codejive.jvm:jvm:0.1.0"
+        },
+        {
+          "a": "jvm-latest",
+          "c": "jvm-latest@codejive",
+          "d": "<p>[latest development version] A command line tool that helps you install and manage multiple Java versions on your machine. See <a rel=\"nofollow\" href=\"https://github.com/codejive/java-jvm\">Jvm website</a></p>\n",
+          "s": "https://github.com/codejive/java-jvm/blob/main/src/main/java/org/codejive/jvm/Main.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "redis-developer",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/69006381?v=4",
+      "link": "https://github.com/redis-developer/jbang-catalog/blob/aa4b66671235f1c6a2b916edca57ada4b2de8c22/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "riot-snapshot",
+          "c": "riot-snapshot@redis-developer",
+          "d": "<p>Get data in and out of Redis with RIOT</p>\n",
+          "s": "riot_snapshot.java"
+        },
+        {
+          "a": "riot",
+          "c": "riot@redis-developer",
+          "d": "<p>Get data in and out of Redis with RIOT</p>\n",
+          "s": "riot.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "codacy-open-source-projects-scans",
+      "name": "jbang",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/131972263?v=4",
+      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@codacy-open-source-projects-scans/jbang~itests",
+          "s": "hello.jsh"
+        },
+        {
+          "a": "helloworld",
+          "c": "helloworld@codacy-open-source-projects-scans/jbang~itests",
+          "s": "helloworld.java"
+        },
+        {
+          "a": "echo",
+          "c": "echo@codacy-open-source-projects-scans/jbang~itests",
+          "d": "<p>echo echo echo description</p>\n",
+          "s": "echo.java"
+        },
+        {
+          "a": "resource",
+          "c": "resource@codacy-open-source-projects-scans/jbang~itests",
+          "s": "res/resource.java"
+        },
+        {
+          "a": "alltags",
+          "c": "alltags@codacy-open-source-projects-scans/jbang~itests",
+          "d": "<p>twodesc</p>\n",
+          "s": "alltags.java"
+        },
+        {
+          "a": "hellojar",
+          "c": "hellojar@codacy-open-source-projects-scans/jbang~itests",
+          "d": "<p>twodesc</p>\n",
+          "s": "hellojar.jar"
+        },
+        {
+          "a": "pgmgav",
+          "c": "pgmgav@codacy-open-source-projects-scans/jbang~itests",
+          "d": "<p>twodesc</p>\n",
+          "s": "org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r"
+        },
+        {
+          "a": "jbang-fmt",
+          "c": "jbang-fmt@codacy-open-source-projects-scans/jbang~docs/modules/ROOT/examples",
+          "d": "<p>A script that formats JBang Java example files for use in the JBang documentation</p>\n",
+          "s": "jbang-fmt@jbangdev/jbang-fmt"
+        }
+      ],
+      "templates": [
+        {
+          "a": "test",
+          "c": "test@codacy-open-source-projects-scans/jbang~itests"
+        },
+        {
+          "a": "gpt",
+          "c": "gpt@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Template using ChatGPT (requires --preview and OPENAI_API_KEY)</p>\n"
+        },
+        {
+          "a": "gpt.kt",
+          "c": "gpt.kt@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Template using ChatGPT for kotlin (requires --preview and OPENAI_API_KEY)</p>\n"
+        },
+        {
+          "a": "gpt.groovy",
+          "c": "gpt.groovy@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Template using ChatGPT for groovy (requires --preview and OPENAI_API_KEY)</p>\n"
+        },
+        {
+          "a": "agent",
+          "c": "agent@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Agent template</p>\n"
+        },
+        {
+          "a": "cli",
+          "c": "cli@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>CLI template</p>\n"
+        },
+        {
+          "a": "hello",
+          "c": "hello@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Basic Hello World template</p>\n"
+        },
+        {
+          "a": "hello.kt",
+          "c": "hello.kt@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Basic kotlin Hello World template</p>\n"
+        },
+        {
+          "a": "hello.groovy",
+          "c": "hello.groovy@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Basic groovy Hello World template</p>\n"
+        },
+        {
+          "a": "readme.md",
+          "c": "readme.md@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Basic markdown readme template</p>\n"
+        },
+        {
+          "a": "qcli",
+          "c": "qcli@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Quarkus CLI template</p>\n"
+        },
+        {
+          "a": "qmetrics",
+          "c": "qmetrics@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Quarkus Metrics template</p>\n"
+        },
+        {
+          "a": "qrest",
+          "c": "qrest@codacy-open-source-projects-scans/jbang~src/main/resources",
+          "d": "<p>Quarkus REST template</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "javatechno",
+      "name": "camel",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/32136482?v=4",
+      "link": "https://github.com/javatechno/camel/blob/6e9c0299a5cc44b110c758cee99d06ea8a99ef22/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel",
+          "c": "camel@javatechno/camel",
+          "d": "<p>Run Apache Camel routes easily</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "comute",
+      "name": "CamelPMD",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/191113961?v=4",
+      "link": "https://github.com/comute/CamelPMD/blob/820f7a6febe04773d0524848c7a1558227a4dddb/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "camel",
+          "c": "camel@comute/CamelPMD",
+          "d": "<p>Run Apache Camel routes easily</p>\n",
+          "s": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "TheShubham-K",
+      "name": "getting-started-with-springboot",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/52125841?v=4",
+      "link": "https://github.com/TheShubham-K/getting-started-with-springboot/blob/7c1d7f60541f1d6fead15de987107c135a1914ee/jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@TheShubham-K/getting-started-with-springboot~jbang",
+          "s": "hello.java"
+        },
+        {
+          "a": "hellocli",
+          "c": "hellocli@TheShubham-K/getting-started-with-springboot~jbang",
+          "s": "hellocli.java"
+        },
+        {
+          "a": "jbangquarkus",
+          "c": "jbangquarkus@TheShubham-K/getting-started-with-springboot~jbang",
+          "s": "jbangquarkus.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "addagadavasubabu",
+      "name": "devops-tasks",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/34202657?v=4",
+      "link": "https://github.com/addagadavasubabu/devops-tasks/blob/0c109237a3c66a178873991c67d4aab73e8ca3d6/jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@addagadavasubabu/devops-tasks~jbang",
+          "s": "hello.java"
+        },
+        {
+          "a": "hellocli",
+          "c": "hellocli@addagadavasubabu/devops-tasks~jbang",
+          "s": "hellocli.java"
+        },
+        {
+          "a": "jbangquarkus",
+          "c": "jbangquarkus@addagadavasubabu/devops-tasks~jbang",
+          "s": "jbangquarkus.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "zubairmujeeb",
+      "name": "spring-boot-sample-projects",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/31179784?v=4",
+      "link": "https://github.com/zubairmujeeb/spring-boot-sample-projects/blob/8d0fd0c195c714adde5d22b7b247abbe3b968786/tutorials-master/jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
+          "s": "hello.java"
+        },
+        {
+          "a": "hellocli",
+          "c": "hellocli@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
+          "s": "hellocli.java"
+        },
+        {
+          "a": "jbangquarkus",
+          "c": "jbangquarkus@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
+          "s": "jbangquarkus.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ramesh1972",
+      "name": "samples-biz",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/62056258?v=4",
+      "link": "https://github.com/ramesh1972/samples-biz/blob/3817b7767886f4d1874814f3c65e24930eacfecb/samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
+          "s": "hello.java"
+        },
+        {
+          "a": "hellocli",
+          "c": "hellocli@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
+          "s": "hellocli.java"
+        },
+        {
+          "a": "jbangquarkus",
+          "c": "jbangquarkus@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
+          "s": "jbangquarkus.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "23021632NguyenQuangMinh",
+      "name": "chattest",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/160642749?v=4",
+      "link": "https://github.com/23021632NguyenQuangMinh/chattest/blob/80d58f36ee07a4e5f9f856987b41964ddc122f81/CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "tabula",
+          "c": "tabula@23021632NguyenQuangMinh/chattest~CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java",
+          "s": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar"
+        },
+        {
+          "a": "tabula",
+          "c": "tabula@23021632NguyenQuangMinh/chattest~CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java",
+          "s": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "krital",
+      "name": "mapsmessaging-jbang",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/6292523?v=4",
+      "link": "https://github.com/krital/mapsmessaging-jbang/blob/8abac5b2305728fccb137cc2bdf86d9d9ac05aeb/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mapsmessaging",
+          "c": "mapsmessaging@krital/mapsmessaging-jbang",
+          "d": "<p>MAPS Messaging Server</p>\n",
+          "s": "MAPS_Messaging.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jbanghub",
+      "name": "libgdx",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/156902772?v=4",
+      "link": "https://github.com/jbanghub/libgdx/blob/98c7a4612c5a4fbb7f71abe93ad6c69772840d63/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "gdx-liftoff",
+          "c": "gdx-liftoff@jbanghub/libgdx",
+          "s": "https://github.com/libgdx/gdx-liftoff/releases/download/v1.12.1.17/gdx-liftoff-1.12.1.17.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "gaurabhok",
+      "name": "karate-automation",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/98075537?v=4",
+      "link": "https://github.com/gaurabhok/karate-automation/blob/dae22a4de2a39e0a6a8c3be5ddef28ed3bdd7c39/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@gaurabhok/karate-automation",
+          "s": "com.intuit.karate:karate-core:1.3.1:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "jmeet",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jmeet/blob/6c1bad89dd76bc1c233e26296b87e94395a6cf8f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "run",
+          "c": "run@maxandersen/jmeet",
+          "s": "jmeet.java"
+        },
+        {
+          "a": "clearpto",
+          "c": "clearpto@maxandersen/jmeet",
+          "s": "clearpto.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "notes",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/notes/blob/d48ba62529d803af35ef255866e081ed5691f3fd/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "notes",
+          "c": "notes@garodriguezlp/notes",
+          "s": "notes.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "mikomatic",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/2025943?v=4",
+      "link": "https://github.com/mikomatic/jbang-catalog/blob/a582c15bd11aa656a40251d228c2d3249674594e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hello",
+          "c": "hello@mikomatic",
+          "d": "<p>Script that prints hello world</p>\n",
+          "s": "hello.java"
+        },
+        {
+          "a": "springPropertyDocumenter",
+          "c": "springPropertyDocumenter@mikomatic",
+          "d": "<p>Document spring boot properties based on property metadata</p>\n",
+          "s": "springPropertyDocumenter.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "worldline",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/5173767?v=4",
+      "link": "https://github.com/worldline/jbang-catalog/blob/d91d3ff764252280c598ac48363434fe8eca0851/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfxapp",
+          "c": "jfxapp@worldline",
+          "d": "<p>Single file JavaFX application. View are defined by code (no fxml)</p>\n",
+          "s": "scripts/jfxdemo.kt"
+        }
+      ],
+      "templates": [
+        {
+          "a": "jfxkt-legacy",
+          "c": "jfxkt-legacy@worldline",
+          "d": "<p>Single file JavaFX application template</p>\n"
+        },
+        {
+          "a": "jfxkt",
+          "c": "jfxkt@worldline",
+          "d": "<p>Single file JavaFX application template. View are defined by code (no fxml)</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "predic8",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1932856?v=4",
+      "link": "https://github.com/predic8/jbang-catalog/blob/2adac5d55f758c20e9d8e096358c9ed31aced5a7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "h2",
+          "c": "h2@predic8",
+          "d": "<p>Starts the h2 database server</p>\n",
+          "s": "h2.java"
+        },
+        {
+          "a": "sql",
+          "c": "sql@predic8",
+          "d": "<p>Commandline to execute SQL command</p>\n",
+          "s": "sql.java"
+        },
+        {
+          "a": "membrane",
+          "c": "membrane@predic8",
+          "d": "<p>Membrane API Gateway</p>\n",
+          "s": "org.membrane-soa:starter:5.7.0"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "robintegg-createfuture",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/197741822?v=4",
+      "link": "https://github.com/robintegg-createfuture/jbang-catalog/blob/75da0d52decd1ffcebfe92fada113c5ee4321af5/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "caniaccessprivategithubrepos",
+          "c": "caniaccessprivategithubrepos@robintegg-createfuture",
+          "d": "<p>Determine if the local environment is setup to access private GitHub repositories</p>\n",
+          "s": "caniaccessprivategithubrepos.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "adoble",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/11298180?v=4",
+      "link": "https://github.com/adoble/jbang-catalog/blob/6f3ab1122fa21652c2d1ec300435a563e8f33373/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "adr",
+          "c": "adr@adoble",
+          "s": "https://github.com/adoble/adr-j/releases/download/v3.5.0/adr-j.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "sormuras",
+      "name": "jbang",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/2319838?v=4",
+      "link": "https://github.com/sormuras/jbang/blob/d37a65d4bb010c7370e43e00dadcf93b0d4f036a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jreleaser-snapshot",
+          "c": "jreleaser-snapshot@sormuras/jbang",
+          "d": "<p>Release projects quickly and easily with JReleaser</p>\n",
+          "s": "jreleaser_snapshot.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jbanghub",
+      "name": "proguard",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/156902772?v=4",
+      "link": "https://github.com/jbanghub/proguard/blob/9f4fc823a400c6810d8ebc006a5e73090c726df7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "retrace",
+          "c": "retrace@jbanghub/proguard",
+          "s": "com.guardsquare:proguard-retrace:7.7.0"
+        },
+        {
+          "a": "proguard",
+          "c": "proguard@jbanghub/proguard",
+          "s": "com.guardsquare:proguard-base:7.7.0"
+        },
+        {
+          "a": "proguard-gui",
+          "c": "proguard-gui@jbanghub/proguard",
+          "s": "com.guardsquare:proguard-gui:7.7.0"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "banc",
+          "c": "banc@garodriguezlp",
+          "s": "https://github.com/garodriguezlp/banc/blob/main/banc.java"
+        },
+        {
+          "a": "cheo",
+          "c": "cheo@garodriguezlp",
+          "s": "https://github.com/garodriguezlp/cheo/blob/main/cheo.java"
+        },
+        {
+          "a": "notes",
+          "c": "notes@garodriguezlp",
+          "s": "https://github.com/garodriguezlp/notes/blob/main/notes.java"
+        },
+        {
+          "a": "payroll",
+          "c": "payroll@garodriguezlp",
+          "s": "https://github.com/garodriguezlp/payroll/blob/main/payroll.java"
+        },
+        {
+          "a": "irimo",
+          "c": "irimo@garodriguezlp",
+          "d": "<p>CLI tool for consolidating personal financial data</p>\n",
+          "s": "irimo.java"
+        },
+        {
+          "a": "irimo-snapshot",
+          "c": "irimo-snapshot@garodriguezlp",
+          "d": "<p>CLI tool for consolidating personal financial data</p>\n",
+          "s": "irimo_snapshot.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maciejkryger",
+      "name": "onecx-svc-generator",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/50527026?v=4",
+      "link": "https://github.com/maciejkryger/onecx-svc-generator/blob/98edad5d4494219f74debd349a688808c9d9fc59/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "onecx-svc-generator",
+          "c": "onecx-svc-generator@maciejkryger/onecx-svc-generator",
+          "d": "<p>Launcher for the OneCX SVC generator JAR</p>\n",
+          "s": "launcher/onecx_svc_generator.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "jfabric",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jfabric/blob/52024698743f88ff89e72b2c333e59f8ab480633/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "fabric",
+          "c": "fabric@maxandersen/jfabric",
+          "s": "fabric.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "oscerd",
+      "name": "sec-edgar-jbang-cli",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/5106647?v=4",
+      "link": "https://github.com/oscerd/sec-edgar-jbang-cli/blob/fe7cd6e9a0dae64d2fb688ac5a180fd5f26c14c4/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "edgar",
+          "c": "edgar@oscerd/sec-edgar-jbang-cli",
+          "d": "<p>SEC EDGAR CLI - Download Form 4, Form 13F, Form 8-K, and Form 10-K/10-Q filings</p>\n",
+          "s": "edgar.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "hal",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/4076071?v=4",
+      "link": "https://github.com/hal/jbang-catalog/blob/14d37d3d09ee80b21845fbe5030ed507a29875cb/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "hal-op",
+          "c": "hal-op@hal",
+          "d": "<p>HAL standalone console on premise</p>\n",
+          "s": "org.jboss.hal:hal-op-standalone:0.2.7:runner"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "R6Y8bihv",
+      "name": "MlJCFdY",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/112546609?v=4",
+      "link": "https://github.com/R6Y8bihv/MlJCFdY/blob/ab64d21d364ee7b77907ab192578d4f1525522e5/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "yaks",
+          "c": "yaks@R6Y8bihv/MlJCFdY",
+          "d": "<p>Run YAKS tests locally</p>\n",
+          "s": "java/tools/yaks-jbang/dist/YaksJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "59977sOnNy",
+      "name": "XrKnQfjqfY",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/198564921?v=4",
+      "link": "https://github.com/59977sOnNy/XrKnQfjqfY/blob/ee677fd54954efc22cf470a392ce93e8897233ea/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "yaks",
+          "c": "yaks@59977sOnNy/XrKnQfjqfY",
+          "d": "<p>Run YAKS tests locally</p>\n",
+          "s": "java/tools/yaks-jbang/dist/YaksJBang.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "valyc0",
+      "name": "quarkus-mcp-servers-java-docker",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/91672412?v=4",
+      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "filesystem",
+          "c": "filesystem@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-filesystem:RELEASE@fatjar"
+        },
+        {
+          "a": "jdbc",
+          "c": "jdbc@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "jdbc/.scripts/mcpjdbc.java"
+        },
+        {
+          "a": "jfx-script",
+          "c": "jfx-script@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "jfx/src/main/java/io/quarkiverse/mcp/servers/jfx/MCPServerJFX.java"
+        },
+        {
+          "a": "jfx",
+          "c": "jfx@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-jfx:RELEASE@fatjar"
+        },
+        {
+          "a": "kubernetes",
+          "c": "kubernetes@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-kubernetes:RELEASE@fatjar"
+        },
+        {
+          "a": "containers",
+          "c": "containers@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-containers:RELEASE@fatjar"
+        },
+        {
+          "a": "jvminsight",
+          "c": "jvminsight@valyc0/quarkus-mcp-servers-java-docker",
+          "s": "io.quarkiverse.mcp.servers:mcp-server-jvminsight:RELEASE@fatjar"
+        }
+      ],
+      "templates": [
+        {
+          "a": "mcp",
+          "c": "mcp@valyc0/quarkus-mcp-servers-java-docker"
+        }
+      ]
+    },
+    {
+      "owner": "maxandersen",
+      "name": "forbidden",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/forbidden/blob/dbce8c43878e53456aa5f557fb3c445a2f8a4863/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "cli",
+          "c": "cli@maxandersen/forbidden",
+          "s": "forbidden.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jasondlee",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/191616?v=4",
+      "link": "https://github.com/jasondlee/jbang-catalog/blob/2828c8f99dc14e664faf68f532bb0e99d9d1d8f4/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mvnsrch",
+          "c": "mvnsrch@jasondlee",
+          "s": "mvnsrch.java"
+        },
+        {
+          "a": "startserver",
+          "c": "startserver@jasondlee",
+          "s": "startserver.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "enola-dev",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/125940666?v=4",
+      "link": "https://github.com/enola-dev/jbang-catalog/blob/a93c67c00dd6ec7779148b675701c8c4933e5915/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "enola",
+          "c": "enola@enola-dev",
+          "s": "dev.enola:enola:0.0.1-SNAPSHOT"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "bytemanproject",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/966402?v=4",
+      "link": "https://github.com/bytemanproject/jbang-catalog/blob/d6c54683ad2564bc7ff9e72bafa256a8f68e9838/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "byteman",
+          "c": "byteman@bytemanproject",
+          "s": "org.jboss.byteman:byteman:RELEASE"
+        },
+        {
+          "a": "bmcheck",
+          "c": "bmcheck@bytemanproject",
+          "s": "org.jboss.byteman:byteman:RELEASE"
+        },
+        {
+          "a": "bminstall",
+          "c": "bminstall@bytemanproject",
+          "s": "org.jboss.byteman:byteman-install:RELEASE"
+        },
+        {
+          "a": "bmsubmit",
+          "c": "bmsubmit@bytemanproject",
+          "s": "org.jboss.byteman:byteman-submit:RELEASE"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "robin-a-meade",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1343270?v=4",
+      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "deps-to-classpath",
+          "c": "deps-to-classpath@robin-a-meade",
+          "d": "<p>resolve dependencies and print the classpath\n<code>deps-to-classpath DEP...</code>\nAlternative: <code>deps_to_classpath DEP...</code> <a rel=\"nofollow\" href=\"https://gist.github.com/robin-a-meade/a1237d7ff7cbe6dc159fa32a81c12948\">deps_to_classpath</a> is a shell script wrapper around <code>jbang info classpath</code>\nAlternative: <code>jbang jecho@robin-a-meade &quot;%{deps:$(IFS=,; echo &quot;${DEPS[*]}&quot;)}&quot;</code>, where <code>DEPS</code> is an array of dependencies.</p>\n",
+          "s": "scripts/DepsToClasspath.java"
+        },
+        {
+          "a": "firefox-profile-dir",
+          "c": "firefox-profile-dir@robin-a-meade",
+          "d": "<p>print the absolute path to the user's firefox profile directory\n<code>firefox-profile-dir</code></p>\n",
+          "s": "scripts/FirefoxProfileDir.java"
+        },
+        {
+          "a": "firefox-profile-dir-with-caching",
+          "c": "firefox-profile-dir-with-caching@robin-a-meade",
+          "d": "<p>print the absolute path of the user's firefox profile directory and cache the result for subsequent calls\n<code>firefox-profile-dir-with-caching [--fresh] [-v]</code></p>\n",
+          "s": "scripts/FirefoxProfileDirWithCaching.java"
+        },
+        {
+          "a": "jecho",
+          "c": "jecho@robin-a-meade",
+          "d": "<p>print arguments\n<code>jecho [ARG]...</code></p>\n",
+          "s": "scripts/jecho.java"
+        },
+        {
+          "a": "jargs",
+          "c": "jargs@robin-a-meade",
+          "d": "<p>print the argument count and print each argument enclosed in angle brackets\n<code>jargs [ARG]...</code></p>\n",
+          "s": "scripts/jargs.java"
+        },
+        {
+          "a": "kebab-case-demo",
+          "c": "kebab-case-demo@robin-a-meade",
+          "d": "<p>demo of jbang's support for scripts with kebab-case style name\n<code>kebab-case-demo</code></p>\n",
+          "s": "scripts/kebab-case-demo"
+        },
+        {
+          "a": "multi-source-file-demo",
+          "c": "multi-source-file-demo@robin-a-meade",
+          "d": "<p>demo of jbang's support for handling multi-source-file java programs\n<code>multi-source-file-demo [NAME]</code></p>\n",
+          "s": "scripts/multi-source-file-demo/Main.java"
+        },
+        {
+          "a": "saxonhe",
+          "c": "saxonhe@robin-a-meade",
+          "d": "<p>wrapper for launching Saxon-HE's command line interfaces for XSLT, XQuery, and the Gizmo utility\n<code>saxonhe (transform|query|gizmo) OPTIONS</code>\nThis script uses the <em>HE</em> edition of <a rel=\"nofollow\" href=\"https://www.saxonica.com\">The Saxon XSLT and XQuery Processor</a>.\nThis script bundles two HTML SAX parsers. To use them, specify the <code>-x:org.ccil.cowan.tagsoup.Parser</code> or <code>-x:nu.validator.htmlparser.sax.HtmlParser</code> option when invoking the <em>transform</em> or <em>query</em> commands.\nThis variant uses the latest in the v12.x line of releases. See the <code>saxonhe11</code> variant for v11.x.</p>\n",
+          "s": "scripts/saxonhe.java"
+        },
+        {
+          "a": "saxonhe11",
+          "c": "saxonhe11@robin-a-meade",
+          "d": "<p>simple wrapper for launching Saxon-HE v11.x command line interfaces for XSLT, XQuery, and the Gizmo utility\n<code>saxonhe11 (transform|query|gizmo) OPTIONS</code>\nThis script uses the <em>HE</em> edition of <a rel=\"nofollow\" href=\"https://www.saxonica.com\">The Saxon XSLT and XQuery Processor</a>.\nThis script bundles two HTML SAX parsers. To use them, specify the <code>-x:org.ccil.cowan.tagsoup.Parser</code> or <code>-x:nu.validator.htmlparser.sax.HtmlParser</code> option when invoking the <em>transform</em> or <em>query</em> commands.\nThis variant uses the latest in the v11.x line of releases. See the <code>saxonhe</code> variant for v12.x.</p>\n",
+          "s": "scripts/saxonhe11.java"
+        },
+        {
+          "a": "saxonheX",
+          "c": "saxonheX@robin-a-meade",
+          "d": "<p>experiment with tagsoup modifications\n<code>saxonhe-exp (transform|query|gizmo) OPTIONS</code></p>\n",
+          "s": "scripts/saxonheX.java"
+        },
+        {
+          "a": "sqlline-test",
+          "c": "sqlline-test@robin-a-meade",
+          "d": "<p>test of <em>renovate</em> dependency automation\n<code>sqlline-test [options...] [properties files...]</code></p>\n",
+          "s": "sqlline:sqlline:1.12.0"
+        },
+        {
+          "a": "tagsoup",
+          "c": "tagsoup@robin-a-meade",
+          "d": "<p>convert HTML to well-formed XML (John Cowan's tagsoup 1.2.1)\n<code>tagsoup [OPTIONS] [FILES]</code></p>\n",
+          "s": "org.ccil.cowan.tagsoup:tagsoup:1.2.1"
+        },
+        {
+          "a": "jlist",
+          "c": "jlist@robin-a-meade",
+          "d": "<p>demo\n<code>jlist [ARG]...</code></p>\n",
+          "s": "scripts/jlist.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "dlemmermann",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/9534301?v=4",
+      "link": "https://github.com/dlemmermann/jbang-catalog/blob/9d55b730702cc8dcb34f6cadad0ce17c45cab14a/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jfxcentral",
+          "c": "jfxcentral@dlemmermann",
+          "s": "https://raw.githubusercontent.com/dlemmermann/jfxcentral/master/main.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jbangdev",
+      "name": "jpaxa",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/60074102?v=4",
+      "link": "https://github.com/jbangdev/jpaxa/blob/b552ff2bcf44bbeee03920b6e01d8863a2d4bac1/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "jpaxa",
+          "c": "jpaxa@jbangdev/jpaxa",
+          "s": "jpaxa.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "reportmill",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/9698378?v=4",
+      "link": "https://github.com/reportmill/jbang-catalog/blob/825b7b756a32e4f42ef10cffad9350a5302f72e1/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "snapcode",
+          "c": "snapcode@reportmill",
+          "d": "<p>Java IDE for education on desktop and in browser</p>\n",
+          "s": "https://reportmill.com/jbang/SnapCodeAll.java"
+        },
+        {
+          "a": "snapbuilder",
+          "c": "snapbuilder@reportmill",
+          "d": "<p>Java UI builder for SnapKit</p>\n",
+          "s": "https://reportmill.com/jbang/SnapBuilder.java"
+        },
+        {
+          "a": "reportmill",
+          "c": "reportmill@reportmill",
+          "d": "<p>The ReportMill page layout application</p>\n",
+          "s": "https://reportmill.com/jbang/ReportMill.java"
+        },
+        {
+          "a": "sc",
+          "c": "sc@reportmill",
+          "d": "<p>Java IDE for education on desktop and in browser</p>\n",
+          "s": "https://reportmill.com/jbang/SnapCodeAll.java"
+        },
+        {
+          "a": "slideshow",
+          "c": "slideshow@reportmill",
+          "d": "<p>Java slide show app for desktop and in browser</p>\n",
+          "s": "https://reportmill.com/jbang/SlideShow.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "junit-team",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/874086?v=4",
+      "link": "https://github.com/junit-team/jbang-catalog/blob/68764895328a12a718e7d87dbd53a328fa06d69f/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "junit",
+          "c": "junit@junit-team",
+          "d": "<p>Launch the JUnit Platform from the console</p>\n",
+          "s": "org.junit.platform:junit-platform-console-standalone:6.0.3"
+        },
+        {
+          "a": "cli",
+          "c": "cli@junit-team",
+          "d": "<p>Launch the JUnit Platform from the console</p>\n",
+          "s": "org.junit.platform:junit-platform-console-standalone:6.0.3"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "shoplineapp",
+      "name": "karate-grpcurl",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/33741200?v=4",
+      "link": "https://github.com/shoplineapp/karate-grpcurl/blob/097a299da85170066ddc54f315433d666cca6bc3/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate-grpcurl",
+          "c": "karate-grpcurl@shoplineapp/karate-grpcurl",
+          "s": "karate-grpcurl-fatjar.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "DependencyTrack",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/40258585?v=4",
+      "link": "https://github.com/DependencyTrack/jbang-catalog/blob/aec6683399fa69983d7d0b0a650aeb7851358162/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "gen-config-docs",
+          "c": "gen-config-docs@DependencyTrack",
+          "d": "<p>Generate configuration documentation from application.properties</p>\n",
+          "s": "GenerateConfigDocs.java"
+        },
+        {
+          "a": "gen-cwe-dict",
+          "c": "gen-cwe-dict@DependencyTrack",
+          "d": "<p>Generate a Java class holding a dictionary of CWE ID -&gt; CWE Name mappings</p>\n",
+          "s": "GenerateCweDictionary.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "garodriguezlp",
+      "name": "mcp-greeting-server",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1432287?v=4",
+      "link": "https://github.com/garodriguezlp/mcp-greeting-server/blob/cf76fe2c188b235753e60c9e2ac2efb439b4353b/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "mcp-greeting",
+          "c": "mcp-greeting@garodriguezlp/mcp-greeting-server",
+          "d": "<p>Runs the MCP Greeting Server via Quarkus + JBang</p>\n",
+          "s": "McpGreetingServer.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maveniverse",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/118349365?v=4",
+      "link": "https://github.com/maveniverse/jbang-catalog/blob/3889f9d3c25a8d9d40a1eeddc1d65a22740c6788/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "toolbox",
+          "c": "toolbox@maveniverse",
+          "d": "<p>Toolbox CLI</p>\n",
+          "s": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/plugins/toolbox/0.15.8/toolbox-0.15.8-cli.jar"
+        },
+        {
+          "a": "toolbox-mcp",
+          "c": "toolbox-mcp@maveniverse",
+          "d": "<p>Toolbox MCP (use with --quiet)</p>\n",
+          "s": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/toolbox/mcp/0.15.8/mcp-0.15.8-runner.jar"
+        },
+        {
+          "a": "pilot",
+          "c": "pilot@maveniverse",
+          "d": "<p>Pilot CLI</p>\n",
+          "s": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/pilot/pilot-cli/0.2.1/pilot-cli-0.2.1.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "quarkusio",
+      "name": "quarkus-ghsa-pv6m-j4fg-qx7h",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/quarkus-ghsa-pv6m-j4fg-qx7h/blob/2c25d2f4754e7f87774bb8400bc452394a052767/.jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "revapi-update",
+          "c": "revapi-update@quarkusio/quarkus-ghsa-pv6m-j4fg-qx7h~.jbang",
+          "s": "RevapiUpdate.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "maxandersen",
+      "name": "jabtop",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/54129?v=4",
+      "link": "https://github.com/maxandersen/jabtop/blob/5b6cd41e06ee915c8295a1dd525e2e51ee7e6f26/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "abtop",
+          "c": "abtop@maxandersen/jabtop",
+          "d": "<p>AI agent monitor for your terminal \u2014 like htop, but for AI coding agents</p>\n",
+          "s": "https://github.com/maxandersen/jabtop/releases/download/early-access/jabtop-0.0.0-SNAPSHOT.jar"
+        },
+        {
+          "a": "jabtop",
+          "c": "jabtop@maxandersen/jabtop",
+          "d": "<p>AI agent monitor for your terminal \u2014 like htop, but for AI coding agents</p>\n",
+          "s": "https://github.com/maxandersen/jabtop/releases/download/early-access/jabtop-0.0.0-SNAPSHOT.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "rnett",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/32281897?v=4",
+      "link": "https://github.com/rnett/jbang-catalog/blob/659471b82bd7e81337a8fa687e4153b51b14aab7/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "gradle-mcp",
+          "c": "gradle-mcp@rnett",
+          "d": "<p>A MCP server for Gradle.</p>\n",
+          "s": "dev.rnett.gradle-mcp:gradle-mcp:+"
+        },
+        {
+          "a": "gradle-mcp-snapshot",
+          "c": "gradle-mcp-snapshot@rnett",
+          "d": "<p>A MCP server for Gradle (Snapshot).</p>\n",
+          "s": "dev.rnett.gradle-mcp:gradle-mcp:+"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "yostane",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1958676?v=4",
+      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "palcli",
+          "c": "palcli@yostane",
+          "d": "<p>Palindrome tester CLI</p>\n",
+          "s": "scripts/paltools/palcli.java"
+        },
+        {
+          "a": "palqrest",
+          "c": "palqrest@yostane",
+          "d": "<p>Palindrome tester Quarkus Rest API</p>\n",
+          "s": "scripts/paltools/palqrest.java"
+        },
+        {
+          "a": "ktor-rest",
+          "c": "ktor-rest@yostane",
+          "d": "<p>Ktor Rest API server with JSON serialization</p>\n",
+          "s": "scripts/ktor-rest-server.kt"
+        },
+        {
+          "a": "hellojfx",
+          "c": "hellojfx@yostane",
+          "d": "<p>Basic JavaFX window that shows Java and JavaFx versions</p>\n",
+          "s": "scripts/hellojfx.java"
+        },
+        {
+          "a": "javafx-presentation",
+          "c": "javafx-presentation@yostane",
+          "d": "<p>A presentation made with JavaFX</p>\n",
+          "s": "javafx-presentation/JFXPresentation.java"
+        },
+        {
+          "a": "devoxxuk-2025",
+          "c": "devoxxuk-2025@yostane",
+          "d": "<p>Devoxx UK 2025: scripting on the JVM with JBang. Content is optimized for 720p display.</p>\n",
+          "s": "jbang-devoxxuk2025/jbang_devoxxuk2025.java"
+        }
+      ],
+      "templates": [
+        {
+          "a": "implicit-main",
+          "c": "implicit-main@yostane",
+          "d": "<p>Java 24 file wiht Implicitly Declared Classes and Instance Main Method</p>\n"
+        },
+        {
+          "a": "compact-main",
+          "c": "compact-main@yostane",
+          "d": "<p>Java 25+ file wiht that uses a compact main class</p>\n"
+        },
+        {
+          "a": "ktor-rest",
+          "c": "ktor-rest@yostane",
+          "d": "<p>Ktor Rest API server with JSON serialization</p>\n"
+        },
+        {
+          "a": "javafx",
+          "c": "javafx@yostane",
+          "d": "<p>A starter JavaFX app</p>\n"
+        },
+        {
+          "a": "javafx-presentation",
+          "c": "javafx-presentation@yostane",
+          "d": "<p>A presentation made with JavaFX</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "laYN57192e",
+      "name": "FIjoz4R98Y",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/192943590?v=4",
+      "link": "https://github.com/laYN57192e/FIjoz4R98Y/blob/5b7fc535fcb8c7b2ce4072706b8eb62693e99601/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@laYN57192e/FIjoz4R98Y",
+          "s": "io.karatelabs:karate-core:1.5.0:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "SemonCat",
+      "name": "karate-grpcurl",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1814558?v=4",
+      "link": "https://github.com/SemonCat/karate-grpcurl/blob/cee506e882147ffeec0c40271eccd45117da9637/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate-grpcurl",
+          "c": "karate-grpcurl@SemonCat/karate-grpcurl",
+          "s": "karate-grpcurl-fatjar.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "quarkusio",
+      "name": "quarkus-ghsa-v3h5-jw6m-6m42",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/quarkus-ghsa-v3h5-jw6m-6m42/blob/996730b8e924f8c96b6f46c97d0fab1c0bf9b9a4/.jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "revapi-update",
+          "c": "revapi-update@quarkusio/quarkus-ghsa-v3h5-jw6m-6m42~.jbang",
+          "s": "RevapiUpdate.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "gsmet",
+      "name": "quarkus-renovate",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1279749?v=4",
+      "link": "https://github.com/gsmet/quarkus-renovate/blob/8b5aa6bf9175688d52c240c092ef82dd78c21626/.jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "revapi-update",
+          "c": "revapi-update@gsmet/quarkus-renovate~.jbang",
+          "s": "RevapiUpdate.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "brunobat",
+      "name": "private_quarkus",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/2318030?v=4",
+      "link": "https://github.com/brunobat/private_quarkus/blob/5ad2f1c6681b85b97eb1ce8f0d67163634fe7ced/.jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "revapi-update",
+          "c": "revapi-update@brunobat/private_quarkus~.jbang",
+          "s": "RevapiUpdate.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "TarekBenSalama",
+      "name": "quarkus",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/38693920?v=4",
+      "link": "https://github.com/TarekBenSalama/quarkus/blob/3f5257be5a82e7376c97b28e7dd43fc9abc03ae9/.jbang/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "revapi-update",
+          "c": "revapi-update@TarekBenSalama/quarkus~.jbang",
+          "s": "RevapiUpdate.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "RnKkOrM0",
+      "name": "RNeKl31Y",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/112608403?v=4",
+      "link": "https://github.com/RnKkOrM0/RNeKl31Y/blob/3c52fbb4b9cde12fbc7c2c770e4c86e6053b2f12/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@RnKkOrM0/RNeKl31Y",
+          "s": "io.karatelabs:karate-core:1.5.0:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "0J27VWx",
+      "name": "UNi57cV7lgY",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/112548146?v=4",
+      "link": "https://github.com/0J27VWx/UNi57cV7lgY/blob/d0739ae02ad3d2fdc306107569a6b0a5b230dd09/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@0J27VWx/UNi57cV7lgY",
+          "s": "io.karatelabs:karate-core:1.5.0:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "jJLVccUB2i",
+      "name": "NWwzXcD5Y",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/114464014?v=4",
+      "link": "https://github.com/jJLVccUB2i/NWwzXcD5Y/blob/d32de0e7dcc68a09f0c164cbae48cf6c4d02fa17/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@jJLVccUB2i/NWwzXcD5Y",
+          "s": "io.karatelabs:karate-core:1.5.0:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "hamidme101",
+      "name": "dashboard-api-automation",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/87857052?v=4",
+      "link": "https://github.com/hamidme101/dashboard-api-automation/blob/6288a27d7ec54a4fde9f5a9eccdcc2c6f6d04cf5/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "karate",
+          "c": "karate@hamidme101/dashboard-api-automation",
+          "s": "io.karatelabs:karate-core:1.5.0:all"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ParapluOU",
+      "name": "formhandle-sdk",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/175750835?v=4",
+      "link": "https://github.com/ParapluOU/formhandle-sdk/blob/d732b64d0af1f0477d30bfadcb72bbfe7c1da9b1/java/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "formhandle",
+          "c": "formhandle@ParapluOU/formhandle-sdk~java",
+          "d": "<p>CLI for FormHandle \u2014 form submissions as email</p>\n",
+          "s": "src/main/java/dev/formhandle/cli/Main.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ayagmar",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/62888618?v=4",
+      "link": "https://github.com/ayagmar/jbang-catalog/blob/266844b5f558b6a8e550b8c255d5825941c90570/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "quarkus-forge",
+          "c": "quarkus-forge@ayagmar",
+          "d": "<p>Keyboard-first Quarkus project generator TUI</p>\n",
+          "s": "https://github.com/ayagmar/quarkus-forge/releases/download/v0.6.5/quarkus-forge-jvm.jar"
+        },
+        {
+          "a": "quarkus-forge-headless",
+          "c": "quarkus-forge-headless@ayagmar",
+          "d": "<p>Quarkus project generator headless CLI (no TUI dependencies)</p>\n",
+          "s": "https://github.com/ayagmar/quarkus-forge/releases/download/v0.6.5/quarkus-forge-headless.jar"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "butelo",
+      "name": "pi-java",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/878933?v=4",
+      "link": "https://github.com/butelo/pi-java/blob/d8d444059d6bb8c87ea61efac7d1d40804096d18/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "pi-java",
+          "c": "pi-java@butelo/pi-java",
+          "d": "<p>TUI Code Agent in Java</p>\n",
+          "s": "src/main/java/com/example/pijava/App.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "pdudits",
+      "name": "jbang-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/1588543?v=4",
+      "link": "https://github.com/pdudits/jbang-catalog/blob/208cfca0c538d112def65d6d716b6512455e45a6/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "bunana",
+          "c": "bunana@pdudits",
+          "s": "bunana.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "ep-infosec",
+      "name": "33_apache_sling-whiteboard",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/120025512?v=4",
+      "link": "https://github.com/ep-infosec/33_apache_sling-whiteboard/blob/269824630144cc4fc5f78b9f9a43080e9ea245d6/jbang-catalog.json",
+      "aliases": [
+        {
+          "a": "start",
+          "c": "start@ep-infosec/33_apache_sling-whiteboard",
+          "d": "<p>Start Apache Sling</p>\n",
+          "s": "jbang/SlingStarter.java"
+        },
+        {
+          "a": "repoinitValidator",
+          "c": "repoinitValidator@ep-infosec/33_apache_sling-whiteboard",
+          "d": "<p>Validate a Repoinit script</p>\n",
+          "s": "jbang/RepoinitValidator.java"
+        },
+        {
+          "a": "jvmVersion",
+          "c": "jvmVersion@ep-infosec/33_apache_sling-whiteboard",
+          "d": "<p>Run with a specific JVM version</p>\n",
+          "s": "jbang/jvmVersion.java"
+        }
+      ],
+      "templates": []
+    },
+    {
+      "owner": "quarkusio",
+      "name": "quarkus-insights",
       "stars": 7,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jskills",
-      "alias": "jskills",
-      "description": "\u003cp\u003eThe CLI for the open agent skills ecosystem\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jskills/releases/download/early-access/jskills-0.0.0-SNAPSHOT.jar",
-      "command": "jskills@maxandersen/jskills",
-      "fullcommand": "jbang jskills@maxandersen/jskills",
-      "link": "https://github.com/maxandersen/jskills/blob/c4423eb32d88a9c19ade091647c841a3893219d8/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/47638783?v=4",
+      "link": "https://github.com/quarkusio/quarkus-insights/blob/12ce1c265a05081dd47448c2dd82e9eb755690b8/jbang-catalog.json",
+      "aliases": [],
+      "templates": [
+        {
+          "a": "ByteSize",
+          "c": "ByteSize@quarkusio/quarkus-insights",
+          "d": "<p>ByteSize example from Quarkus Insights #53 about java memory</p>\n"
+        }
+      ]
     },
     {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/1366654?v\u003d4",
-      "repoOwner": "koppor",
-      "repoName": "ghprcomment",
-      "alias": "ghprcomment",
-      "scriptRef": "ghprcomment.java",
-      "command": "ghprcomment@koppor/ghprcomment",
-      "fullcommand": "jbang ghprcomment@koppor/ghprcomment",
-      "link": "https://github.com/koppor/ghprcomment/blob/83222d22e425fed21b56a524e96f4faedbb508c2/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-minecraft",
-      "alias": "sponge",
-      "scriptRef": "sponge.java",
-      "command": "sponge@jbangdev/jbang-minecraft",
-      "fullcommand": "jbang sponge@jbangdev/jbang-minecraft",
-      "link": "https://github.com/jbangdev/jbang-minecraft/blob/befa69092fd196b911f45a034bda301668760906/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "zookeeper-shell",
-      "alias": "shell",
-      "description": "\u003cp\u003eZooKeeper Shell\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/linux-china/zookeeper-shell/releases/download/0.1.0/zookeeper-shell-0.1.0.jar",
-      "command": "shell@linux-china/zookeeper-shell",
-      "fullcommand": "jbang shell@linux-china/zookeeper-shell",
-      "link": "https://github.com/linux-china/zookeeper-shell/blob/f49001e0b2ea90b504a80f093af034ef4b54b9a2/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/9744636?v\u003d4",
-      "repoOwner": "iunera",
-      "repoName": "ypipe",
-      "alias": "ypipe",
-      "description": "\u003cp\u003eYPipe - Easy Local AI Pipeline\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/iunera/ypipe/releases/download/jar/v1.0.0/ypipe-1.0.0-cross-platform.jar",
-      "command": "ypipe@iunera/ypipe",
-      "fullcommand": "jbang ypipe@iunera/ypipe",
-      "link": "https://github.com/iunera/ypipe/blob/c416f71ba052d92bcddd9620ad31dc98bdddaa3a/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/517980?v\u003d4",
-      "repoOwner": "kiegroup",
-      "repoName": "jbang-catalog",
-      "alias": "dmn",
-      "description": "\u003cp\u003eEvaluate a DMN model using the Drools DMN Engine.\u003c/p\u003e\n",
-      "scriptRef": "dmn.java",
-      "command": "dmn@kiegroup",
-      "fullcommand": "jbang dmn@kiegroup",
-      "link": "https://github.com/kiegroup/jbang-catalog/blob/addbd6476d11b26da5a9c0b0b4d47ad5b3a385e7/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/517980?v\u003d4",
-      "repoOwner": "kiegroup",
-      "repoName": "jbang-catalog",
-      "alias": "feel",
-      "description": "\u003cp\u003eEvaluate a FEEL expression using the Drools DMN Engine.\u003c/p\u003e\n",
-      "scriptRef": "feel.java",
-      "command": "feel@kiegroup",
-      "fullcommand": "jbang feel@kiegroup",
-      "link": "https://github.com/kiegroup/jbang-catalog/blob/addbd6476d11b26da5a9c0b0b4d47ad5b3a385e7/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/517980?v\u003d4",
-      "repoOwner": "kiegroup",
-      "repoName": "jbang-catalog",
-      "alias": "optaplannerHelloWorld",
-      "description": "\u003cp\u003eOptaPlanner Hello world to solve a school timetable to assign lessons to timeslots and rooms.\u003c/p\u003e\n",
-      "scriptRef": "optaplannerHelloWorld.java",
-      "command": "optaplannerHelloWorld@kiegroup",
-      "fullcommand": "jbang optaplannerHelloWorld@kiegroup",
-      "link": "https://github.com/kiegroup/jbang-catalog/blob/addbd6476d11b26da5a9c0b0b4d47ad5b3a385e7/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/517980?v\u003d4",
-      "repoOwner": "kiegroup",
-      "repoName": "jbang-catalog",
-      "alias": "xls2dmn",
-      "description": "\u003cp\u003eJBang script proxy of the Converter for Excel (.xls/.xlsx) files containing DMN decision tables.\u003c/p\u003e\n",
-      "scriptRef": "xls2dmn.java",
-      "command": "xls2dmn@kiegroup",
-      "fullcommand": "jbang xls2dmn@kiegroup",
-      "link": "https://github.com/kiegroup/jbang-catalog/blob/addbd6476d11b26da5a9c0b0b4d47ad5b3a385e7/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/1366654?v\u003d4",
-      "repoOwner": "koppor",
-      "repoName": "magic-merge-commit",
-      "alias": "do",
-      "scriptRef": "CreatePRMergeCommit.java",
-      "command": "do@koppor/magic-merge-commit",
-      "fullcommand": "jbang do@koppor/magic-merge-commit",
-      "link": "https://github.com/koppor/magic-merge-commit/blob/76e8286e50a3219015cbb985ff2c11e7f4bc2c86/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "quarkus-reveal",
-      "alias": "quarkus-reveal",
-      "description": "\u003cp\u003eDevelop and use your Reveal.js decks easily with Quarkus\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/quarkusio/quarkus-reveal/releases/latest/download/quarkus-reveal.jar",
-      "command": "quarkus-reveal@quarkusio/quarkus-reveal",
-      "fullcommand": "jbang quarkus-reveal@quarkusio/quarkus-reveal",
-      "link": "https://github.com/quarkusio/quarkus-reveal/blob/831481bee5703909a996381999981c151605b592/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "jfr-query",
-      "alias": "jfr-query",
-      "scriptRef": "https://github.com/parttimenerd/jfr-query/releases/download/snapshot/query.jar",
-      "command": "jfr-query@parttimenerd/jfr-query",
-      "fullcommand": "jbang jfr-query@parttimenerd/jfr-query",
-      "link": "https://github.com/parttimenerd/jfr-query/blob/03f53124c2c6c9bdd6661fbeccf7173b6bed262b/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "hprof-redact",
-      "alias": "jstall",
-      "scriptRef": "https://github.com/parttimenerd/hprof-redact/releases/download/v0.2.1/hprof-redact.jar",
-      "command": "jstall@parttimenerd/hprof-redact",
-      "fullcommand": "jbang jstall@parttimenerd/hprof-redact",
-      "link": "https://github.com/parttimenerd/hprof-redact/blob/6263d6329d982ed1812ecdaf4f964e7e5b7e2e46/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "quarkusinfo",
-      "description": "\u003cp\u003eScript that collects environment info for Quarkus issue reports\u003c/p\u003e\n",
-      "scriptRef": "quarkusissue.java",
-      "command": "quarkusinfo@maxandersen",
-      "fullcommand": "jbang quarkusinfo@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jruby",
-      "description": "\u003cp\u003eRun jruby\u003c/p\u003e\n",
-      "scriptRef": "org.jruby:jruby-complete:9.2.12.0",
-      "command": "jruby@maxandersen",
-      "fullcommand": "jbang jruby@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "groovy",
-      "description": "\u003cp\u003eRun groovy\u003c/p\u003e\n",
-      "scriptRef": "org.codehaus.groovy:groovy:3.0.5",
-      "command": "groovy@maxandersen",
-      "fullcommand": "jbang groovy@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "ghview",
-      "description": "\u003cp\u003eGitHub View - based on current directory and locate the right \u0027thing\u0027 on github\u003c/p\u003e\n",
-      "scriptRef": "ghview.java",
-      "command": "ghview@maxandersen",
-      "fullcommand": "jbang ghview@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "byteman",
-      "scriptRef": "org.jboss.byteman:byteman:RELEASE",
-      "command": "byteman@maxandersen",
-      "fullcommand": "jbang byteman@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jamira",
-      "scriptRef": "jamira.java",
-      "command": "jamira@maxandersen",
-      "fullcommand": "jbang jamira@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "dashbuilder",
-      "scriptRef": "dashbuilder/dashbuilder.java",
-      "command": "dashbuilder@maxandersen",
-      "fullcommand": "jbang dashbuilder@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "prelude",
-      "scriptRef": "prelude.jsh",
-      "command": "prelude@maxandersen",
-      "fullcommand": "jbang prelude@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jackson",
-      "scriptRef": "jackson.jsh",
-      "command": "jackson@maxandersen",
-      "fullcommand": "jbang jackson@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "ap-loader",
-      "scriptRef": "https://github.com/jvm-profiling-tools/ap-loader/releases/latest/download/ap-loader-all.jar",
-      "command": "ap-loader@maxandersen",
-      "fullcommand": "jbang ap-loader@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jarkanoid",
-      "scriptRef": "https://github.com/HanSolo/jarkanoid/releases/download/17.0.7/jarkanoid-windows-x64-17.0.7.jar",
-      "command": "jarkanoid@maxandersen",
-      "fullcommand": "jbang jarkanoid@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "sqlsh",
-      "scriptRef": "org.apache.calcite:calcite-plus:RELEASE",
-      "command": "sqlsh@maxandersen",
-      "fullcommand": "jbang sqlsh@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-explain",
-      "scriptRef": "explain/explain.java",
-      "command": "quarkus-explain@maxandersen",
-      "fullcommand": "jbang quarkus-explain@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "shellscript",
-      "description": "\u003cp\u003eSimple example of how to wrap and run a shellscript using jbang catalogs.\u003c/p\u003e\n",
-      "scriptRef": "shellscripts/shellscript.java",
-      "command": "shellscript@maxandersen",
-      "fullcommand": "jbang shellscript@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "quack",
-      "scriptRef": "quack.jsh",
-      "command": "quack@maxandersen",
-      "fullcommand": "jbang quack@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "gython",
-      "scriptRef": "org.vafer:helloworld:1.0",
-      "command": "gython@maxandersen",
-      "fullcommand": "jbang gython@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "lazyslide",
-      "description": "\u003cp\u003elazyslide: render, serve, watch, and initialize AsciiDoc reveal.js decks\u003c/p\u003e\n",
-      "scriptRef": "lazyslide@maxandersen/lazyslide",
-      "command": "lazyslide@maxandersen",
-      "fullcommand": "jbang lazyslide@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "qrcode",
-      "scriptRef": "qrcode.java",
-      "command": "qrcode@maxandersen",
-      "fullcommand": "jbang qrcode@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jdbc",
-      "scriptRef": "jdbc.java",
-      "command": "jdbc@maxandersen",
-      "fullcommand": "jbang jdbc@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-edit",
-      "scriptRef": "QuarkusEdit.java",
-      "command": "quarkus-edit@maxandersen",
-      "fullcommand": "jbang quarkus-edit@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "hass-qli-early-access",
-      "scriptRef": "https://github.com/maxandersen/home-assistant-qli/releases/download/early-access/hass-qli-early-access.jar",
-      "command": "hass-qli-early-access@maxandersen",
-      "fullcommand": "jbang hass-qli-early-access@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jfr-report",
-      "scriptRef": "org.openjdk.jmc:flightrecorder.rules:8.3.1",
-      "command": "jfr-report@maxandersen",
-      "fullcommand": "jbang jfr-report@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "llmspeed",
-      "description": "\u003cp\u003eCalculate the speed of a Large Language Model using OpenAI model. The speed is measured in tokens per second based on the models own reported data.\u003c/p\u003e\n",
-      "scriptRef": "llmspeed.java",
-      "command": "llmspeed@maxandersen",
-      "fullcommand": "jbang llmspeed@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "j2xgenie",
-      "scriptRef": "j2xgenie/j2xgenie.java",
-      "command": "j2xgenie@maxandersen",
-      "fullcommand": "jbang j2xgenie@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "imgcat",
-      "scriptRef": "imgcat/imgcat.java",
-      "command": "imgcat@maxandersen",
-      "fullcommand": "jbang imgcat@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "hibernatetools",
-      "scriptRef": "hibernatetools/hibernatetools.java",
-      "command": "hibernatetools@maxandersen",
-      "fullcommand": "jbang hibernatetools@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "mcpcalculator",
-      "scriptRef": "mcpcalc/mcpcalculator.java",
-      "command": "mcpcalculator@maxandersen",
-      "fullcommand": "jbang mcpcalculator@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "tinypng",
-      "scriptRef": "tinypng-cli/tinypng.java",
-      "command": "tinypng@maxandersen",
-      "fullcommand": "jbang tinypng@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "jupyter-jbang",
-      "scriptRef": "jjbang.java",
-      "command": "jupyter-jbang@maxandersen",
-      "fullcommand": "jbang jupyter-jbang@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
+      "owner": "jbanghub",
+      "name": "jbang-catalog",
       "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/150655885?v\u003d4",
-      "repoOwner": "jupyter-java",
-      "repoName": "jbang-catalog",
-      "alias": "install-kernel",
-      "scriptRef": "installkernel.java",
-      "command": "install-kernel@jupyter-java",
-      "fullcommand": "jbang install-kernel@jupyter-java",
-      "link": "https://github.com/jupyter-java/jbang-catalog/blob/8a62bd9014481246de26d8115915a96ffa7634a5/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "execjar",
-      "alias": "jstall",
-      "scriptRef": "https://github.com/parttimenerd/execjar/releases/download/v0.3.4/jstall.jar",
-      "command": "jstall@parttimenerd/execjar",
-      "fullcommand": "jbang jstall@parttimenerd/execjar",
-      "link": "https://github.com/parttimenerd/execjar/blob/9f7e3e65327e93833caa71b3d23ce07d181449d2/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/62193161?v\u003d4",
-      "repoOwner": "jxfzzzt",
-      "repoName": "ASE2024-Magneto",
-      "alias": "karate",
-      "scriptRef": "com.intuit.karate:karate-core:1.3.0:all",
-      "command": "karate@jxfzzzt/ASE2024-Magneto~Evaluation_Data/client-apps/karate",
-      "fullcommand": "jbang karate@jxfzzzt/ASE2024-Magneto~Evaluation_Data/client-apps/karate",
-      "link": "https://github.com/jxfzzzt/ASE2024-Magneto/blob/c45e4ae037b3be3a9a04c9da24309661efa3f1c5/Evaluation_Data/client-apps/karate/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/420065?v\u003d4",
-      "repoOwner": "jamezp",
-      "repoName": "jbang-catalog",
-      "alias": "parse-surefire-report",
-      "description": "\u003cp\u003eParses surefire and failsafe XML reports and outputs a summary report. See help for more details.\u003c/p\u003e\n",
-      "scriptRef": "parsesurefire.java",
-      "command": "parse-surefire-report@jamezp",
-      "fullcommand": "jbang parse-surefire-report@jamezp",
-      "link": "https://github.com/jamezp/jbang-catalog/blob/0cd88db0317004fcfa9a9d711ccb2984d436f78a/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/420065?v\u003d4",
-      "repoOwner": "jamezp",
-      "repoName": "jbang-catalog",
-      "alias": "jdk-manager",
-      "description": "\u003cp\u003eA utility to manage JDK\u0027s for local usage.\u003c/p\u003e\n",
-      "scriptRef": "jdkmanager/jdkmanager.java",
-      "command": "jdk-manager@jamezp",
-      "fullcommand": "jbang jdk-manager@jamezp",
-      "link": "https://github.com/jamezp/jbang-catalog/blob/0cd88db0317004fcfa9a9d711ccb2984d436f78a/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/420065?v\u003d4",
-      "repoOwner": "jamezp",
-      "repoName": "jbang-catalog",
-      "alias": "echo-server",
-      "description": "\u003cp\u003eA utility which echos output from a TCP socket, UDP socket or HTTP server to stdout.\u003c/p\u003e\n",
-      "scriptRef": "EchoServer.java",
-      "command": "echo-server@jamezp",
-      "fullcommand": "jbang echo-server@jamezp",
-      "link": "https://github.com/jamezp/jbang-catalog/blob/0cd88db0317004fcfa9a9d711ccb2984d436f78a/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/420065?v\u003d4",
-      "repoOwner": "jamezp",
-      "repoName": "jbang-catalog",
-      "alias": "jira-from-pr",
-      "description": "\u003cp\u003eCreates a JIRA based on a GitHub PR. Please note this is very specific to Red Hat JIRA and GitHub.\u003c/p\u003e\n",
-      "scriptRef": "JiraFromPullRequest.java",
-      "command": "jira-from-pr@jamezp",
-      "fullcommand": "jbang jira-from-pr@jamezp",
-      "link": "https://github.com/jamezp/jbang-catalog/blob/0cd88db0317004fcfa9a9d711ccb2984d436f78a/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/420065?v\u003d4",
-      "repoOwner": "jamezp",
-      "repoName": "jbang-catalog",
-      "alias": "zip-util",
-      "description": "\u003cp\u003eA utility to query, recursively, information in a ZIP, JAR, WAR, etc. file.\u003c/p\u003e\n",
-      "scriptRef": "ziputil.java",
-      "command": "zip-util@jamezp",
-      "fullcommand": "jbang zip-util@jamezp",
-      "link": "https://github.com/jamezp/jbang-catalog/blob/0cd88db0317004fcfa9a9d711ccb2984d436f78a/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "femtojar",
-      "alias": "femtojar",
-      "scriptRef": "https://github.com/parttimenerd/femtojar/releases/download/v0.1.6/femtojar-0.1.6.jar",
-      "command": "femtojar@parttimenerd/femtojar",
-      "fullcommand": "jbang femtojar@parttimenerd/femtojar",
-      "link": "https://github.com/parttimenerd/femtojar/blob/ac1e346093bc5fef08fe86ea873dcc7ae7b38c89/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/4186933?v\u003d4",
-      "repoOwner": "glawson6",
-      "repoName": "jaiclaw",
-      "alias": "shell",
-      "description": "\u003cp\u003eJaiClaw interactive shell — personal AI assistant CLI\u003c/p\u003e\n",
-      "scriptRef": "io.jaiclaw:jaiclaw-shell:0.1.0",
-      "command": "shell@glawson6/jaiclaw",
-      "fullcommand": "jbang shell@glawson6/jaiclaw",
-      "link": "https://github.com/glawson6/jaiclaw/blob/96a9b3b7a4212ea0e69d483b9193ef69141eb2c7/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/4186933?v\u003d4",
-      "repoOwner": "glawson6",
-      "repoName": "jaiclaw",
-      "alias": "gateway",
-      "description": "\u003cp\u003eJaiClaw gateway server — REST API + WebSocket + channel adapters\u003c/p\u003e\n",
-      "scriptRef": "io.jaiclaw:jaiclaw-gateway-app:0.1.0",
-      "command": "gateway@glawson6/jaiclaw",
-      "fullcommand": "jbang gateway@glawson6/jaiclaw",
-      "link": "https://github.com/glawson6/jaiclaw/blob/96a9b3b7a4212ea0e69d483b9193ef69141eb2c7/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/4186933?v\u003d4",
-      "repoOwner": "glawson6",
-      "repoName": "jaiclaw",
-      "alias": "jaiclaw",
-      "description": "\u003cp\u003eJaiClaw launcher — start gateway, shell, or manage containers\u003c/p\u003e\n",
-      "scriptRef": "JaiClaw.java",
-      "command": "jaiclaw@glawson6/jaiclaw",
-      "fullcommand": "jbang jaiclaw@glawson6/jaiclaw",
-      "link": "https://github.com/glawson6/jaiclaw/blob/96a9b3b7a4212ea0e69d483b9193ef69141eb2c7/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "imap",
-      "scriptRef": "imap.java",
-      "command": "imap@quintesse~experimental",
-      "fullcommand": "jbang imap@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "picocli-codegen",
-      "scriptRef": "picocli-codegen.java",
-      "command": "picocli-codegen@quintesse~experimental",
-      "fullcommand": "jbang picocli-codegen@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "jfrdump",
-      "scriptRef": "jfrdump.java",
-      "command": "jfrdump@quintesse~experimental",
-      "fullcommand": "jbang jfrdump@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "kcdel",
-      "scriptRef": "kcdel.java",
-      "command": "kcdel@quintesse~experimental",
-      "fullcommand": "jbang kcdel@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "kcusers",
-      "scriptRef": "kcusers.java",
-      "command": "kcusers@quintesse~experimental",
-      "fullcommand": "jbang kcusers@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "memmap",
-      "scriptRef": "memmap.java",
-      "command": "memmap@quintesse~experimental",
-      "fullcommand": "jbang memmap@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "pmatch_instanceof",
-      "scriptRef": "pmatch_instanceof.java",
-      "command": "pmatch_instanceof@quintesse~experimental",
-      "fullcommand": "jbang pmatch_instanceof@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "switch_expr",
-      "scriptRef": "switch_expr.java",
-      "command": "switch_expr@quintesse~experimental",
-      "fullcommand": "jbang switch_expr@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "text_block",
-      "scriptRef": "text_block.java",
-      "command": "text_block@quintesse~experimental",
-      "fullcommand": "jbang text_block@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "telegram",
-      "scriptRef": "telegram.java",
-      "command": "telegram@quintesse~experimental",
-      "fullcommand": "jbang telegram@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "chelloworld16",
-      "scriptRef": "foreign/chelloworld16.java",
-      "command": "chelloworld16@quintesse~experimental",
-      "fullcommand": "jbang chelloworld16@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "chelloworld",
-      "scriptRef": "foreign/chelloworld.java",
-      "command": "chelloworld@quintesse~experimental",
-      "fullcommand": "jbang chelloworld@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "cstrlen16",
-      "scriptRef": "foreign/cstrlen16.java",
-      "command": "cstrlen16@quintesse~experimental",
-      "fullcommand": "jbang cstrlen16@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "cstrlen17",
-      "scriptRef": "foreign/cstrlen17.java",
-      "command": "cstrlen17@quintesse~experimental",
-      "fullcommand": "jbang cstrlen17@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "cstrlen",
-      "scriptRef": "foreign/cstrlen.java",
-      "command": "cstrlen@quintesse~experimental",
-      "fullcommand": "jbang cstrlen@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "guarded_switch",
-      "scriptRef": "guarded_switch.java",
-      "command": "guarded_switch@quintesse~experimental",
-      "fullcommand": "jbang guarded_switch@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "shelly",
-      "scriptRef": "shelly.java",
-      "command": "shelly@quintesse~experimental",
-      "fullcommand": "jbang shelly@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "example_server",
-      "scriptRef": "example_server/example_server.java",
-      "command": "example_server@quintesse~experimental",
-      "fullcommand": "jbang example_server@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "lanterna",
-      "scriptRef": "lanterna.java",
-      "command": "lanterna@quintesse~experimental",
-      "fullcommand": "jbang lanterna@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "quickserv",
-      "scriptRef": "quickserv.java",
-      "command": "quickserv@quintesse~experimental",
-      "fullcommand": "jbang quickserv@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "grep",
-      "scriptRef": "grep.jsh",
-      "command": "grep@quintesse~experimental",
-      "fullcommand": "jbang grep@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "terminal",
-      "scriptRef": "terminal.java",
-      "command": "terminal@quintesse~experimental",
-      "fullcommand": "jbang terminal@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "xecho",
-      "description": "\u003cp\u003eTest to see how a ref to another alias works\u003c/p\u003e\n",
-      "scriptRef": "echo@quintesse",
-      "command": "xecho@quintesse~experimental",
-      "fullcommand": "jbang xecho@quintesse~experimental",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/experimental/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/93670347?v\u003d4",
-      "repoOwner": "ZenWave360",
-      "repoName": "zenwave-playground",
-      "alias": "zw",
-      "scriptRef": "io.zenwave360.sdk:zenwave-sdk-cli:2.1.0-SNAPSHOT",
-      "command": "zw@ZenWave360/zenwave-playground~examples/kustomer-address-jpa",
-      "fullcommand": "jbang zw@ZenWave360/zenwave-playground~examples/kustomer-address-jpa",
-      "link": "https://github.com/ZenWave360/zenwave-playground/blob/ba5aab3c4c79269950194e8b7aa03f2f65212d57/examples/kustomer-address-jpa/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "hello_neo4j",
-      "description": "\u003cp\u003eGet some statistics out of your Neo4j instance.\nCall jbang hello_neo4j@neo4j --help to see the usage.\u003c/p\u003e\n",
-      "scriptRef": "hello_neo4j.java",
-      "command": "hello_neo4j@neo4j",
-      "fullcommand": "jbang hello_neo4j@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "cypher",
-      "description": "\u003cp\u003eUse Neo4j\u0027s Cypher shell to execute Cypher queries.\nInteractive shell without parameters or e.g. jbang neo4j@cypher -a \u003ca rel\u003d\"nofollow\" href\u003d\"\"\u003eneo4j://localhost:7687\u003c/a\u003e -u neo4j -p secret \u0027MATCH (n) return n\u0027\u003c/p\u003e\n",
-      "scriptRef": "cypher_shell.java",
-      "command": "cypher@neo4j",
-      "fullcommand": "jbang cypher@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "neo4j-migrations",
-      "description": "\u003cp\u003eSimple, Flyway DB inspired migrations for Neo4j.\u003c/p\u003e\n",
-      "scriptRef": "neo4j_migrations.java",
-      "command": "neo4j-migrations@neo4j",
-      "fullcommand": "jbang neo4j-migrations@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "rdbms2neo4j",
-      "description": "\u003cp\u003eImports the provided tables from an JDBC-URL (postgres, mysql drivers bundled) into Neo4j.\u003c/p\u003e\n",
-      "scriptRef": "rdbms2neo4j.java",
-      "command": "rdbms2neo4j@neo4j",
-      "fullcommand": "jbang rdbms2neo4j@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "liquibase-neo4j",
-      "description": "\u003cp\u003eManage and run your Neo4j database changes with Liquibase\u003c/p\u003e\n",
-      "scriptRef": "liquibase_neo4j.java",
-      "command": "liquibase-neo4j@neo4j",
-      "fullcommand": "jbang liquibase-neo4j@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "format-cypher",
-      "description": "\u003cp\u003ePretty print Cypher statements\u003c/p\u003e\n",
-      "scriptRef": "format_cypher.java",
-      "command": "format-cypher@neo4j",
-      "fullcommand": "jbang format-cypher@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "enforce-relationship-directions",
-      "description": "\u003cp\u003eValidates and enforces relationship directions in Cypher statements\u003c/p\u003e\n",
-      "scriptRef": "enforce_relationship_directions.java",
-      "command": "enforce-relationship-directions@neo4j",
-      "fullcommand": "jbang enforce-relationship-directions@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/558276?v\u003d4",
-      "repoOwner": "snowdrop",
-      "repoName": "rewrite-client",
-      "alias": "rewrite",
-      "description": "\u003cp\u003eQuarkus OpenRewrite client to execute recipes\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/snowdrop/rewrite-client/releases/download/early-access/client-0.3.5-SNAPSHOT-runner.jar",
-      "command": "rewrite@snowdrop/rewrite-client",
-      "fullcommand": "jbang rewrite@snowdrop/rewrite-client",
-      "link": "https://github.com/snowdrop/rewrite-client/blob/3d1aa442f78f844917a230776242bc12b023d0f6/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/47907?v\u003d4",
-      "repoOwner": "glaforge",
-      "repoName": "arxiv-mcp-server",
-      "alias": "arxiv-mcp",
-      "description": "\u003cp\u003eArXiv MCP Server\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/glaforge/arxiv-mcp-server/releases/latest/download/arxiv-mcp-server-runner.jar",
-      "command": "arxiv-mcp@glaforge/arxiv-mcp-server",
-      "fullcommand": "jbang arxiv-mcp@glaforge/arxiv-mcp-server",
-      "link": "https://github.com/glaforge/arxiv-mcp-server/blob/a5f16e522118dcc8560a15f3f08a68787228c354/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/120057?v\u003d4",
-      "repoOwner": "metacosm",
-      "repoName": "power-server",
-      "alias": "power",
-      "description": "\u003cp\u003eA command line tool to measure power consumption of processes\u003c/p\u003e\n",
-      "scriptRef": "cli/src/main/java/net/laprun/sustainability/cli/Power.java",
-      "command": "power@metacosm/power-server",
-      "fullcommand": "jbang power@metacosm/power-server",
-      "link": "https://github.com/metacosm/power-server/blob/08371c5bcba5275a781f5837e36c8925dbe84825/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "raton-loco",
-      "description": "\u003cp\u003e\u0027Raton Loco\u0027 is a Windows utility to avoid the Screensaver\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/raton-loco/blob/main/src/main/java/info/jab/utils/RatonLoco.java",
-      "command": "raton-loco@jabrena",
-      "fullcommand": "jbang raton-loco@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "setup",
-      "description": "\u003cp\u003eSetup is a command line utility designed to help developers when initializing new projects using Maven\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/setup-cli/releases/download/0.12.0/setup-0.12.0.jar",
-      "command": "setup@jabrena",
-      "fullcommand": "jbang setup@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "stopwatch-mcp",
-      "description": "\u003cp\u003eStopWatch MCP. A MCP Server designed to measure the time used by an Agent to implement a Prompt\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/stopwatch-mcp/blob/main/src/main/java/info/jab/jbang/MCPStopWatch.java",
-      "command": "stopwatch-mcp@jabrena",
-      "fullcommand": "jbang stopwatch-mcp@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "cursor-mcp-config",
-      "description": "\u003cp\u003eCursor AI MCP Cursor is a Terminal CLI to handle multiple configurations for ~/.cursor/mcp.json\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/cursor-mcp-config-cli/blob/main/src/main/java/info/jab/jbang/CursorMCPConfig.java",
-      "command": "cursor-mcp-config@jabrena",
-      "fullcommand": "jbang cursor-mcp-config@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "qr-code",
-      "description": "\u003cp\u003eGenerate a QR Code from a URL\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/qr-code-cli/blob/main/src/main/java/info/jab/cli/TerminalQRCode.java",
-      "command": "qr-code@jabrena",
-      "fullcommand": "jbang qr-code@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "puml-to-png",
-      "description": "\u003cp\u003eConvert PlantUML (.puml) files to .png format\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/plantuml-to-png-cli/releases/download/0.5.0/puml-to-png-0.5.0.jar",
-      "command": "puml-to-png@jabrena",
-      "fullcommand": "jbang puml-to-png@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "churrera",
-      "description": "\u003cp\u003eTasks like Churros! Churrera is a CLI tool designed to orchestrate Cursor Cloud Agents REST API in an easy way.\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/churrera-cli/releases/download/0.2.0/churrera-cli-0.2.0.jar",
-      "command": "churrera@jabrena",
-      "fullcommand": "jbang churrera@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "aoc",
-      "description": "\u003cp\u003eAdvent of Code CLI tool\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/aoc-cli/releases/download/0.1.0/aoc-cli-0.1.0.jar",
-      "command": "aoc@jabrena",
-      "fullcommand": "jbang aoc@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "sonar-search",
-      "description": "\u003cp\u003eSonar Search CLI tool\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/sonar-search-cli/releases/download/0.2.0-SNAPSHOT/sonar-search-0.2.0-SNAPSHOT.jar",
-      "command": "sonar-search@jabrena",
-      "fullcommand": "jbang sonar-search@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "result-json-map.0.1.0-SNAPSHOT",
-      "description": "\u003cp\u003eA CLI tool designed to help models when they return data in a structured way.\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/result-json-map-cli/releases/download/0.1.0-SNAPSHOT/result-json-map-0.1.0-SNAPSHOT.jar",
-      "command": "result-json-map.0.1.0-SNAPSHOT@jabrena",
-      "fullcommand": "jbang result-json-map.0.1.0-SNAPSHOT@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/147263?v\u003d4",
-      "repoOwner": "jabrena",
-      "repoName": "jbang-catalog",
-      "alias": "pml-to-md",
-      "description": "\u003cp\u003eA CLI tool designed to convert PML files to Markdown.\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/jabrena/pml/releases/download/0.7.0/pml-to-md-0.7.0.jar",
-      "command": "pml-to-md@jabrena",
-      "fullcommand": "jbang pml-to-md@jabrena",
-      "link": "https://github.com/jabrena/jbang-catalog/blob/464bd1cc5e70d6ba7ba09645755eaf0a31aaba2f/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "cat",
-      "description": "\u003cp\u003eSimply copies the contents of the provided files to the standard output\u003c/p\u003e\n",
-      "scriptRef": "cat.java",
-      "command": "cat@quintesse",
-      "fullcommand": "jbang cat@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "echo",
-      "description": "\u003cp\u003eJust prints out its arguments\u003c/p\u003e\n",
-      "scriptRef": "echo.java",
-      "command": "echo@quintesse",
-      "fullcommand": "jbang echo@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "hello",
-      "description": "\u003cp\u003eOur perennial demo friend\u003c/p\u003e\n",
-      "scriptRef": "hello.java",
-      "command": "hello@quintesse",
-      "fullcommand": "jbang hello@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "jget",
-      "description": "\u003cp\u003eLike a simplistic wget but written in Java\u003c/p\u003e\n",
-      "scriptRef": "jget.java",
-      "command": "jget@quintesse",
-      "fullcommand": "jbang jget@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "jvmci",
-      "description": "\u003cp\u003eChecks if JVMCI is enabled\u003c/p\u003e\n",
-      "scriptRef": "jvmci.java",
-      "command": "jvmci@quintesse",
-      "fullcommand": "jbang jvmci@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "rest",
-      "description": "\u003cp\u003eA cli tool for REST queries and transformations\u003c/p\u003e\n",
-      "scriptRef": "rest.java",
-      "command": "rest@quintesse",
-      "fullcommand": "jbang rest@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "httpd",
-      "description": "\u003cp\u003eStarts a simple HTTP server on the files in the current directory\u003c/p\u003e\n",
-      "scriptRef": "simple_httpd.java",
-      "command": "httpd@quintesse",
-      "fullcommand": "jbang httpd@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "sysenv",
-      "description": "\u003cp\u003ePrints out Java\u0027s System environment\u003c/p\u003e\n",
-      "scriptRef": "system_env.java",
-      "command": "sysenv@quintesse",
-      "fullcommand": "jbang sysenv@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "sysprops",
-      "description": "\u003cp\u003ePrints out Java\u0027s System properties\u003c/p\u003e\n",
-      "scriptRef": "system_properties.java",
-      "command": "sysprops@quintesse",
-      "fullcommand": "jbang sysprops@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "mdns",
-      "scriptRef": "mdns.java",
-      "command": "mdns@quintesse",
-      "fullcommand": "jbang mdns@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "mvn2jbang",
-      "description": "\u003cp\u003eAdds a Maven project\u0027s dependencies to a JBang script\u003c/p\u003e\n",
-      "scriptRef": "mvn2jbang.java",
-      "command": "mvn2jbang@quintesse",
-      "fullcommand": "jbang mvn2jbang@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "redir",
-      "description": "\u003cp\u003eLists and updates directives in JBang scripts\u003c/p\u003e\n",
-      "scriptRef": "redir.java",
-      "command": "redir@quintesse",
-      "fullcommand": "jbang redir@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "runall",
-      "description": "\u003cp\u003eRuns multiple commands in parallel. By default the command that is run is \u003ccode\u003ejbang\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "runall.java",
-      "command": "runall@quintesse",
-      "fullcommand": "jbang runall@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/778793?v\u003d4",
-      "repoOwner": "quintesse",
-      "repoName": "jbang-catalog",
-      "alias": "refactor",
-      "description": "\u003cp\u003eRuns Netbeans Jackpot tool for refactoring Java code\u003c/p\u003e\n",
-      "scriptRef": "org.apache.netbeans.modules.jackpot30:tool:28.0",
-      "command": "refactor@quintesse",
-      "fullcommand": "jbang refactor@quintesse",
-      "link": "https://github.com/quintesse/jbang-catalog/blob/50d4af759c2157889a52940b4e6c72a70f045b32/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/50187?v\u003d4",
-      "repoOwner": "galderz",
-      "repoName": "qollider",
-      "alias": "graal",
-      "description": "\u003cp\u003eScript to build Graal\u003c/p\u003e\n",
-      "scriptRef": "graal.java",
-      "command": "graal@galderz/qollider",
-      "fullcommand": "jbang graal@galderz/qollider",
-      "link": "https://github.com/galderz/qollider/blob/fcb74445163748ae78df8d138c7fcceb93aeb9c9/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/50187?v\u003d4",
-      "repoOwner": "galderz",
-      "repoName": "qollider",
-      "alias": "infinispan-native",
-      "description": "\u003cp\u003eScript to build Infinispan Quarkus native server\u003c/p\u003e\n",
-      "scriptRef": "infinispan_native.java",
-      "command": "infinispan-native@galderz/qollider",
-      "fullcommand": "jbang infinispan-native@galderz/qollider",
-      "link": "https://github.com/galderz/qollider/blob/fcb74445163748ae78df8d138c7fcceb93aeb9c9/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/50187?v\u003d4",
-      "repoOwner": "galderz",
-      "repoName": "qollider",
-      "alias": "jdk",
-      "description": "\u003cp\u003eScript to build a JDK\u003c/p\u003e\n",
-      "scriptRef": "jdk.java",
-      "command": "jdk@galderz/qollider",
-      "fullcommand": "jbang jdk@galderz/qollider",
-      "link": "https://github.com/galderz/qollider/blob/fcb74445163748ae78df8d138c7fcceb93aeb9c9/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/50187?v\u003d4",
-      "repoOwner": "galderz",
-      "repoName": "qollider",
-      "alias": "quarkus",
-      "description": "\u003cp\u003eScript to build Quarkus\u003c/p\u003e\n",
-      "scriptRef": "quarkus.java",
-      "command": "quarkus@galderz/qollider",
-      "fullcommand": "jbang quarkus@galderz/qollider",
-      "link": "https://github.com/galderz/qollider/blob/fcb74445163748ae78df8d138c7fcceb93aeb9c9/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/50187?v\u003d4",
-      "repoOwner": "galderz",
-      "repoName": "qollider",
-      "alias": "mandrel",
-      "description": "\u003cp\u003eScript to build Mandrel\u003c/p\u003e\n",
-      "scriptRef": "mandrel.java",
-      "command": "mandrel@galderz/qollider",
-      "fullcommand": "jbang mandrel@galderz/qollider",
-      "link": "https://github.com/galderz/qollider/blob/fcb74445163748ae78df8d138c7fcceb93aeb9c9/jbang-catalog.json"
-    },
-    {
+      "icon": "https://avatars.githubusercontent.com/u/156902772?v=4",
+      "link": "https://github.com/jbanghub/jbang-catalog/blob/fa0f2f7f0b6fa7973c6295c2c8f42d82a0229e80/jbang-catalog.json",
+      "aliases": [],
+      "templates": [
+        {
+          "a": "jbang-catalog",
+          "c": "jbang-catalog@jbanghub",
+          "d": "<p>Template for creating a new JBang catalog hosted on github with automatic renovate updates</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "linux-china",
+      "name": "jbang-spring-boot",
       "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-rsocket",
-      "alias": "ClientExample",
-      "scriptRef": "src/ClientExample.java",
-      "command": "ClientExample@linux-china/jbang-rsocket",
-      "fullcommand": "jbang ClientExample@linux-china/jbang-rsocket",
-      "link": "https://github.com/linux-china/jbang-rsocket/blob/8feb033c38a2c85ee6dd8dbee1477f2a7e0fd677/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/46711?v=4",
+      "link": "https://github.com/linux-china/jbang-spring-boot/blob/cc36d6a2a8d68868eb8aa2ae5ee0e81f797d0fd1/jbang-catalog.json",
+      "aliases": [],
+      "templates": [
+        {
+          "a": "SpringBoot2",
+          "c": "SpringBoot2@linux-china/jbang-spring-boot",
+          "d": "<p>Spring Boot 2 Java App Template</p>\n"
+        },
+        {
+          "a": "SpringBoot3",
+          "c": "SpringBoot3@linux-china/jbang-spring-boot",
+          "d": "<p>Spring Boot 3 Java App Template</p>\n"
+        },
+        {
+          "a": "SpringBoot2Kt",
+          "c": "SpringBoot2Kt@linux-china/jbang-spring-boot",
+          "d": "<p>Spring Boot 2 Kotlin App Template</p>\n"
+        },
+        {
+          "a": "SpringBoot3Kt",
+          "c": "SpringBoot3Kt@linux-china/jbang-spring-boot",
+          "d": "<p>Spring Boot 3 Kotlin App Template</p>\n"
+        }
+      ]
     },
     {
+      "owner": "debezium",
+      "name": "jbang-catalog",
       "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-rsocket",
-      "alias": "ServerExample",
-      "scriptRef": "src/ServerExample.java",
-      "command": "ServerExample@linux-china/jbang-rsocket",
-      "fullcommand": "jbang ServerExample@linux-china/jbang-rsocket",
-      "link": "https://github.com/linux-china/jbang-rsocket/blob/8feb033c38a2c85ee6dd8dbee1477f2a7e0fd677/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-rsocket",
-      "alias": "ClientExampleKt",
-      "scriptRef": "kotlin/src/RSocketClientApp.kt",
-      "command": "ClientExampleKt@linux-china/jbang-rsocket",
-      "fullcommand": "jbang ClientExampleKt@linux-china/jbang-rsocket",
-      "link": "https://github.com/linux-china/jbang-rsocket/blob/8feb033c38a2c85ee6dd8dbee1477f2a7e0fd677/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-rsocket",
-      "alias": "ServerExampleKt",
-      "scriptRef": "kotlin/src/RSocketServerApp.kt",
-      "command": "ServerExampleKt@linux-china/jbang-rsocket",
-      "fullcommand": "jbang ServerExampleKt@linux-china/jbang-rsocket",
-      "link": "https://github.com/linux-china/jbang-rsocket/blob/8feb033c38a2c85ee6dd8dbee1477f2a7e0fd677/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-rsocket",
-      "alias": "RSocketSpringBootServer",
-      "scriptRef": "src/spring/RSocketSpringBootServer.java",
-      "command": "RSocketSpringBootServer@linux-china/jbang-rsocket",
-      "fullcommand": "jbang RSocketSpringBootServer@linux-china/jbang-rsocket",
-      "link": "https://github.com/linux-china/jbang-rsocket/blob/8feb033c38a2c85ee6dd8dbee1477f2a7e0fd677/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/106387436?v\u003d4",
-      "repoOwner": "aizedevops",
-      "repoName": "spring-boot-projects",
-      "alias": "hello",
-      "scriptRef": "hello.java",
-      "command": "hello@aizedevops/spring-boot-projects~jbang",
-      "fullcommand": "jbang hello@aizedevops/spring-boot-projects~jbang",
-      "link": "https://github.com/aizedevops/spring-boot-projects/blob/44b4c4101a353183a54761b38ea203a7d9f8ee90/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/106387436?v\u003d4",
-      "repoOwner": "aizedevops",
-      "repoName": "spring-boot-projects",
-      "alias": "hellocli",
-      "scriptRef": "hellocli.java",
-      "command": "hellocli@aizedevops/spring-boot-projects~jbang",
-      "fullcommand": "jbang hellocli@aizedevops/spring-boot-projects~jbang",
-      "link": "https://github.com/aizedevops/spring-boot-projects/blob/44b4c4101a353183a54761b38ea203a7d9f8ee90/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/106387436?v\u003d4",
-      "repoOwner": "aizedevops",
-      "repoName": "spring-boot-projects",
-      "alias": "jbangquarkus",
-      "scriptRef": "jbangquarkus.java",
-      "command": "jbangquarkus@aizedevops/spring-boot-projects~jbang",
-      "fullcommand": "jbang jbangquarkus@aizedevops/spring-boot-projects~jbang",
-      "link": "https://github.com/aizedevops/spring-boot-projects/blob/44b4c4101a353183a54761b38ea203a7d9f8ee90/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "lazyslide",
-      "alias": "lazyslide",
-      "description": "\u003cp\u003elazyslide: render, serve, watch, and initialize AsciiDoc reveal.js decks\u003c/p\u003e\n",
-      "scriptRef": "lazyslide.java",
-      "command": "lazyslide@maxandersen/lazyslide",
-      "fullcommand": "jbang lazyslide@maxandersen/lazyslide",
-      "link": "https://github.com/maxandersen/lazyslide/blob/2cf557b9aa3c47e76267b4da7ee29ef07703b9a8/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/3737888?v\u003d4",
-      "repoOwner": "scratches",
-      "repoName": "jbang-catalog",
-      "alias": "spring",
-      "description": "\u003cp\u003eSpring Boot CLI\u003c/p\u003e\n",
-      "scriptRef": "org.springframework.boot:spring-boot-cli:3.3.0:full",
-      "command": "spring@scratches",
-      "fullcommand": "jbang spring@scratches",
-      "link": "https://github.com/scratches/jbang-catalog/blob/2152ed5234ebe63ccce23579318c54ffc08459d4/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/3737888?v\u003d4",
-      "repoOwner": "scratches",
-      "repoName": "jbang-catalog",
-      "alias": "script",
-      "description": "\u003cp\u003eSpring Script Runner\u003c/p\u003e\n",
-      "scriptRef": "example/SpringScript.java",
-      "command": "script@scratches",
-      "fullcommand": "jbang script@scratches",
-      "link": "https://github.com/scratches/jbang-catalog/blob/2152ed5234ebe63ccce23579318c54ffc08459d4/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/3737888?v\u003d4",
-      "repoOwner": "scratches",
-      "repoName": "jbang-catalog",
-      "alias": "springbom",
-      "description": "\u003cp\u003eSpring Bom\u003c/p\u003e\n",
-      "scriptRef": "example/SpringBom.java",
-      "command": "springbom@scratches",
-      "fullcommand": "jbang springbom@scratches",
-      "link": "https://github.com/scratches/jbang-catalog/blob/2152ed5234ebe63ccce23579318c54ffc08459d4/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/3737888?v\u003d4",
-      "repoOwner": "scratches",
-      "repoName": "jbang-catalog",
-      "alias": "generic",
-      "description": "\u003cp\u003eGeneric Spring Application\u003c/p\u003e\n",
-      "scriptRef": "example/GenericApplication.java",
-      "command": "generic@scratches",
-      "fullcommand": "jbang generic@scratches",
-      "link": "https://github.com/scratches/jbang-catalog/blob/2152ed5234ebe63ccce23579318c54ffc08459d4/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/3737888?v\u003d4",
-      "repoOwner": "scratches",
-      "repoName": "jbang-catalog",
-      "alias": "configserver",
-      "description": "\u003cp\u003eSpring Cloud Config Server with example config repo\u003c/p\u003e\n",
-      "scriptRef": "example/ConfigServerApplication.java",
-      "command": "configserver@scratches",
-      "fullcommand": "jbang configserver@scratches",
-      "link": "https://github.com/scratches/jbang-catalog/blob/2152ed5234ebe63ccce23579318c54ffc08459d4/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "liga",
-      "scriptRef": "scripts/liga.java",
-      "command": "liga@tors42/jbang-chariot",
-      "fullcommand": "jbang liga@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "nonthematic",
-      "scriptRef": "scripts/nonthematic.java",
-      "command": "nonthematic@tors42/jbang-chariot",
-      "fullcommand": "jbang nonthematic@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "membercount",
-      "scriptRef": "scripts/membercount.java",
-      "command": "membercount@tors42/jbang-chariot",
-      "fullcommand": "jbang membercount@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "opponents",
-      "scriptRef": "scripts/opponents.java",
-      "command": "opponents@tors42/jbang-chariot",
-      "fullcommand": "jbang opponents@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "flatten",
-      "scriptRef": "scripts/flatten.java",
-      "command": "flatten@tors42/jbang-chariot",
-      "fullcommand": "jbang flatten@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "evalsummary",
-      "scriptRef": "scripts/evalsummary.java",
-      "command": "evalsummary@tors42/jbang-chariot",
-      "fullcommand": "jbang evalsummary@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "autoscore",
-      "scriptRef": "scripts/autoscore.java",
-      "command": "autoscore@tors42/jbang-chariot",
-      "fullcommand": "jbang autoscore@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "uci2san",
-      "scriptRef": "scripts/uci2san.jsh",
-      "command": "uci2san@tors42/jbang-chariot",
-      "fullcommand": "jbang uci2san@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "oauth2pkce",
-      "scriptRef": "scripts/oauth2pkce.java",
-      "command": "oauth2pkce@tors42/jbang-chariot",
-      "fullcommand": "jbang oauth2pkce@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/4084220?v\u003d4",
-      "repoOwner": "tors42",
-      "repoName": "jbang-chariot",
-      "alias": "updateArena",
-      "scriptRef": "scripts/updateArena.java",
-      "command": "updateArena@tors42/jbang-chariot",
-      "fullcommand": "jbang updateArena@tors42/jbang-chariot",
-      "link": "https://github.com/tors42/jbang-chariot/blob/76584e82ac009159ff1cf6b0a061f43d283e4136/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/62888618?v\u003d4",
-      "repoOwner": "ayagmar",
-      "repoName": "quarkus-forge",
-      "alias": "quarkus-forge",
-      "description": "\u003cp\u003eKeyboard-first Quarkus project generator TUI\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/ayagmar/quarkus-forge/releases/latest/download/quarkus-forge-jvm.jar",
-      "command": "quarkus-forge@ayagmar/quarkus-forge",
-      "fullcommand": "jbang quarkus-forge@ayagmar/quarkus-forge",
-      "link": "https://github.com/ayagmar/quarkus-forge/blob/55cad9d7cc1bf25bf84fe7ee16eb9e8f5cdadab8/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/62888618?v\u003d4",
-      "repoOwner": "ayagmar",
-      "repoName": "quarkus-forge",
-      "alias": "quarkus-forge-headless",
-      "description": "\u003cp\u003eQuarkus project generator headless CLI (no TUI dependencies)\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/ayagmar/quarkus-forge/releases/latest/download/quarkus-forge-headless.jar",
-      "command": "quarkus-forge-headless@ayagmar/quarkus-forge",
-      "fullcommand": "jbang quarkus-forge-headless@ayagmar/quarkus-forge",
-      "link": "https://github.com/ayagmar/quarkus-forge/blob/55cad9d7cc1bf25bf84fe7ee16eb9e8f5cdadab8/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/179265?v\u003d4",
-      "repoOwner": "FroMage",
-      "repoName": "jbang-catalog",
-      "alias": "static-init-finder",
-      "description": "\u003cp\u003eFind static init calls to classes\u003c/p\u003e\n",
-      "scriptRef": "ListStaticInit.java",
-      "command": "static-init-finder@FroMage",
-      "fullcommand": "jbang static-init-finder@FroMage",
-      "link": "https://github.com/FroMage/jbang-catalog/blob/7aae6527207f06395ae3b30c36bc0d81b734180b/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "skills",
-      "alias": "jgccli",
-      "description": "\u003cp\u003eMinimal Google Calendar CLI (Java)\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jgccli/blob/main/src/main/java/jgccli.java",
-      "command": "jgccli@maxandersen/skills",
-      "fullcommand": "jbang jgccli@maxandersen/skills",
-      "link": "https://github.com/maxandersen/skills/blob/8f466b21f1b4f75f131ada4de7345f30a710cf1f/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "skills",
-      "alias": "jgmcli",
-      "description": "\u003cp\u003eMinimal Gmail CLI (Java)\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jgmcli/blob/main/src/main/java/jgmcli.java",
-      "command": "jgmcli@maxandersen/skills",
-      "fullcommand": "jbang jgmcli@maxandersen/skills",
-      "link": "https://github.com/maxandersen/skills/blob/8f466b21f1b4f75f131ada4de7345f30a710cf1f/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "skills",
-      "alias": "jgdcli",
-      "description": "\u003cp\u003eMinimal Google Drive CLI (Java)\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jgdcli/blob/main/src/main/java/jgdcli.java",
-      "command": "jgdcli@maxandersen/skills",
-      "fullcommand": "jbang jgdcli@maxandersen/skills",
-      "link": "https://github.com/maxandersen/skills/blob/8f466b21f1b4f75f131ada4de7345f30a710cf1f/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/63334958?v\u003d4",
-      "repoOwner": "opt-nc",
-      "repoName": "jbang-catalog",
-      "alias": "hello-optnc",
-      "scriptRef": "https://github.com/opt-nc/jbang-catalog/blob/main/hello-optnc/HelloOptNc.java",
-      "command": "hello-optnc@opt-nc",
-      "fullcommand": "jbang hello-optnc@opt-nc",
-      "link": "https://github.com/opt-nc/jbang-catalog/blob/e5b5a07a9c0af4d3b3cc944b1db9a324cdd10f22/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/63334958?v\u003d4",
-      "repoOwner": "opt-nc",
-      "repoName": "jbang-catalog",
-      "alias": "phonenumber-validator",
-      "scriptRef": "https://github.com/opt-nc/jbang-catalog/blob/main/phonenumber-validator/Validator.java",
-      "command": "phonenumber-validator@opt-nc",
-      "fullcommand": "jbang phonenumber-validator@opt-nc",
-      "link": "https://github.com/opt-nc/jbang-catalog/blob/e5b5a07a9c0af4d3b3cc944b1db9a324cdd10f22/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/413413?v\u003d4",
-      "repoOwner": "38leinaD",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-starter",
-      "description": "\u003cp\u003eScript to scaffold a Quarkus project\u003c/p\u003e\n",
-      "scriptRef": "src/QuarkusStarter.java",
-      "command": "quarkus-starter@38leinaD",
-      "fullcommand": "jbang quarkus-starter@38leinaD",
-      "link": "https://github.com/38leinaD/jbang-catalog/blob/796de69d6c4e59ebd3df39b0e293e4cc40a8318d/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/413413?v\u003d4",
-      "repoOwner": "38leinaD",
-      "repoName": "jbang-catalog",
-      "alias": "firestarter",
-      "description": "\u003cp\u003eDisplay a YouTube video on your RasPi or similar (e.g. to build a \u0027virtual fireplace\u0027). Also, simple web-ui to edit the video URL.\u003c/p\u003e\n",
-      "scriptRef": "src/firestarter.java",
-      "command": "firestarter@38leinaD",
-      "fullcommand": "jbang firestarter@38leinaD",
-      "link": "https://github.com/38leinaD/jbang-catalog/blob/796de69d6c4e59ebd3df39b0e293e4cc40a8318d/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/413413?v\u003d4",
-      "repoOwner": "38leinaD",
-      "repoName": "jbang-catalog",
-      "alias": "httpserver",
-      "description": "\u003cp\u003eMinimalist JDK-internal http-server\u003c/p\u003e\n",
-      "scriptRef": "src/httpserver.java",
-      "command": "httpserver@38leinaD",
-      "fullcommand": "jbang httpserver@38leinaD",
-      "link": "https://github.com/38leinaD/jbang-catalog/blob/796de69d6c4e59ebd3df39b0e293e4cc40a8318d/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/413413?v\u003d4",
-      "repoOwner": "38leinaD",
-      "repoName": "jbang-catalog",
-      "alias": "whisper",
-      "description": "\u003cp\u003eVoice-to-text via whisper.cpp: hold mic button to record, transcribes and pastes into focused field\u003c/p\u003e\n",
-      "scriptRef": "src/WhisperTranscribe.java",
-      "command": "whisper@38leinaD",
-      "fullcommand": "jbang whisper@38leinaD",
-      "link": "https://github.com/38leinaD/jbang-catalog/blob/796de69d6c4e59ebd3df39b0e293e4cc40a8318d/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk-releases",
-      "alias": "brokk",
-      "scriptRef": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.6/brokk-0.23.6.jar",
-      "command": "brokk@BrokkAi/brokk-releases",
-      "fullcommand": "jbang brokk@BrokkAi/brokk-releases",
-      "link": "https://github.com/BrokkAi/brokk-releases/blob/ad26e9f405a380c408ae0f2a481a3815ea58608c/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk-releases",
-      "alias": "brokk-headless",
-      "scriptRef": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.6/brokk-0.23.6.jar",
-      "command": "brokk-headless@BrokkAi/brokk-releases",
-      "fullcommand": "jbang brokk-headless@BrokkAi/brokk-releases",
-      "link": "https://github.com/BrokkAi/brokk-releases/blob/ad26e9f405a380c408ae0f2a481a3815ea58608c/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk-releases",
-      "alias": "brokk-core",
-      "scriptRef": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.6/brokk-core-0.23.6.jar",
-      "command": "brokk-core@BrokkAi/brokk-releases",
-      "fullcommand": "jbang brokk-core@BrokkAi/brokk-releases",
-      "link": "https://github.com/BrokkAi/brokk-releases/blob/ad26e9f405a380c408ae0f2a481a3815ea58608c/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk-releases",
-      "alias": "brokk-0.23.5.beta8",
-      "scriptRef": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.5.beta8/brokk-0.23.5.beta8.jar",
-      "command": "brokk-0.23.5.beta8@BrokkAi/brokk-releases",
-      "fullcommand": "jbang brokk-0.23.5.beta8@BrokkAi/brokk-releases",
-      "link": "https://github.com/BrokkAi/brokk-releases/blob/ad26e9f405a380c408ae0f2a481a3815ea58608c/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/204942796?v\u003d4",
-      "repoOwner": "BrokkAi",
-      "repoName": "brokk-releases",
-      "alias": "brokk-0.23.5.beta7",
-      "scriptRef": "https://github.com/BrokkAi/brokk-releases/releases/download/0.23.5.beta7/brokk-0.23.5.beta7.jar",
-      "command": "brokk-0.23.5.beta7@BrokkAi/brokk-releases",
-      "fullcommand": "jbang brokk-0.23.5.beta7@BrokkAi/brokk-releases",
-      "link": "https://github.com/BrokkAi/brokk-releases/blob/ad26e9f405a380c408ae0f2a481a3815ea58608c/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "jfr-redact",
-      "alias": "jfr-redact",
-      "scriptRef": "https://github.com/parttimenerd/jfr-redact/releases/download/v0.3.0/jfr-redact.jar",
-      "command": "jfr-redact@parttimenerd/jfr-redact",
-      "fullcommand": "jbang jfr-redact@parttimenerd/jfr-redact",
-      "link": "https://github.com/parttimenerd/jfr-redact/blob/8a5538d6874d003cd14d3c4933efd40ce425b773/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "intro",
-      "description": "\u003cp\u003eIntroduction for linux_china\u003c/p\u003e\n",
-      "scriptRef": "src/me/Intro.java",
-      "command": "intro@linux-china",
-      "fullcommand": "jbang intro@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "resume",
-      "description": "\u003cp\u003eResume for linux_china\u003c/p\u003e\n",
-      "scriptRef": "src/me/Resume.java",
-      "command": "resume@linux-china",
-      "fullcommand": "jbang resume@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "DemoCli",
-      "description": "\u003cp\u003eDemo CLI\u003c/p\u003e\n",
-      "scriptRef": "src/main/java/org/mvnsearch/DemoCli.java",
-      "command": "DemoCli@linux-china",
-      "fullcommand": "jbang DemoCli@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "HelloWorld",
-      "description": "\u003cp\u003eHello World\u003c/p\u003e\n",
-      "scriptRef": "src/hello/java/HelloWorld.java",
-      "command": "HelloWorld@linux-china",
-      "fullcommand": "jbang HelloWorld@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "IJSharedIndexes",
-      "description": "\u003cp\u003eGenerate project IJ Shared Indexes\u003c/p\u003e\n",
-      "scriptRef": "src/ijSharedIndexes/SharedIndexBuilder.kt",
-      "command": "IJSharedIndexes@linux-china",
-      "fullcommand": "jbang IJSharedIndexes@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "ij-shared-indexes-cli",
-      "description": "\u003cp\u003eGenerates project shared indexes and starts local server on them.\u003c/p\u003e\n",
-      "scriptRef": "com.jetbrains.intellij.indexing.shared:ij-shared-indexes-tool-cli:0.9.0",
-      "command": "ij-shared-indexes-cli@linux-china",
-      "fullcommand": "jbang ij-shared-indexes-cli@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "SpringBootApp",
-      "description": "\u003cp\u003eSpring Boot App\u003c/p\u003e\n",
-      "scriptRef": "src/springBoot/java/demo1/SpringBootApp.java",
-      "command": "SpringBootApp@linux-china",
-      "fullcommand": "jbang SpringBootApp@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "google-java-format",
-      "scriptRef": "https://github.com/google/google-java-format/releases/download/v1.13.0/google-java-format-1.13.0-all-deps.jar",
-      "command": "google-java-format@linux-china",
-      "fullcommand": "jbang google-java-format@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "pkl-cli",
-      "scriptRef": "org.pkl-lang:pkl-tools:0.25.2",
-      "command": "pkl-cli@linux-china",
-      "fullcommand": "jbang pkl-cli@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-catalog",
-      "alias": "pkl-codegen",
-      "scriptRef": "org.pkl-lang:pkl-tools:0.25.2",
-      "command": "pkl-codegen@linux-china",
-      "fullcommand": "jbang pkl-codegen@linux-china",
-      "link": "https://github.com/linux-china/jbang-catalog/blob/ade4a960fa232ec03920bf9379f25475b68e892a/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/8778468?v\u003d4",
-      "repoOwner": "nbbrd",
-      "repoName": "jbang-catalog",
-      "alias": "hello-nbbrd",
-      "description": "\u003cp\u003eHello NBBRD\u003c/p\u003e\n",
-      "scriptRef": "hello_nbbrd.java",
-      "command": "hello-nbbrd@nbbrd",
-      "fullcommand": "jbang hello-nbbrd@nbbrd",
-      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/8778468?v\u003d4",
-      "repoOwner": "nbbrd",
-      "repoName": "jbang-catalog",
-      "alias": "sdmx-dl",
-      "description": "\u003cp\u003eEasily download official statistics\u003c/p\u003e\n",
-      "scriptRef": "sdmx_dl.java",
-      "command": "sdmx-dl@nbbrd",
-      "fullcommand": "jbang sdmx-dl@nbbrd",
-      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/8778468?v\u003d4",
-      "repoOwner": "nbbrd",
-      "repoName": "jbang-catalog",
-      "alias": "heylogs",
-      "description": "\u003cp\u003eKeep-a-changelog tool\u003c/p\u003e\n",
-      "scriptRef": "heylogs.java",
-      "command": "heylogs@nbbrd",
-      "fullcommand": "jbang heylogs@nbbrd",
-      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/8778468?v\u003d4",
-      "repoOwner": "nbbrd",
-      "repoName": "jbang-catalog",
-      "alias": "hello-nbbrd-picocli",
-      "description": "\u003cp\u003eHello NBBRD\u003c/p\u003e\n",
-      "scriptRef": "hello_nbbrd_picocli.java",
-      "command": "hello-nbbrd-picocli@nbbrd",
-      "fullcommand": "jbang hello-nbbrd-picocli@nbbrd",
-      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/8778468?v\u003d4",
-      "repoOwner": "nbbrd",
-      "repoName": "jbang-catalog",
-      "alias": "sasquatch",
-      "description": "\u003cp\u003eA java reader of SAS datasets - Bill of Materials\u003c/p\u003e\n",
-      "scriptRef": "sasquatch.java",
-      "command": "sasquatch@nbbrd",
-      "fullcommand": "jbang sasquatch@nbbrd",
-      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/8778468?v\u003d4",
-      "repoOwner": "nbbrd",
-      "repoName": "jbang-catalog",
-      "alias": "sasquatchw",
-      "description": "\u003cp\u003eA java reader of SAS datasets - Bill of Materials\u003c/p\u003e\n",
-      "scriptRef": "sasquatchw.java",
-      "command": "sasquatchw@nbbrd",
-      "fullcommand": "jbang sasquatchw@nbbrd",
-      "link": "https://github.com/nbbrd/jbang-catalog/blob/6667648d3cf751136e69f75c887e1fa104c6a339/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/81020166?v\u003d4",
-      "repoOwner": "jreleaser",
-      "repoName": "jbang-catalog",
-      "alias": "jreleaser",
-      "description": "\u003cp\u003eRelease projects quickly and easily with JReleaser\u003c/p\u003e\n",
-      "scriptRef": "jreleaser.java",
-      "command": "jreleaser@jreleaser",
-      "fullcommand": "jbang jreleaser@jreleaser",
-      "link": "https://github.com/jreleaser/jbang-catalog/blob/20368c8b5c30d1b174adf9206a813975ff41e8f6/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/81020166?v\u003d4",
-      "repoOwner": "jreleaser",
-      "repoName": "jbang-catalog",
-      "alias": "jreleaser-snapshot",
-      "description": "\u003cp\u003eRelease projects quickly and easily with JReleaser\u003c/p\u003e\n",
-      "scriptRef": "jreleaser_snapshot.java",
-      "command": "jreleaser-snapshot@jreleaser",
-      "fullcommand": "jbang jreleaser-snapshot@jreleaser",
-      "link": "https://github.com/jreleaser/jbang-catalog/blob/20368c8b5c30d1b174adf9206a813975ff41e8f6/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "xam.dk",
-      "alias": "tree",
-      "scriptRef": "tree/main.java",
-      "command": "tree@maxandersen/xam.dk",
-      "fullcommand": "jbang tree@maxandersen/xam.dk",
-      "link": "https://github.com/maxandersen/xam.dk/blob/1a7796699252369e09cf967514a6c0523fdcec3c/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "xam.dk",
-      "alias": "qrcode",
-      "scriptRef": "qrcode/main.java",
-      "command": "qrcode@maxandersen/xam.dk",
-      "fullcommand": "jbang qrcode@maxandersen/xam.dk",
-      "link": "https://github.com/maxandersen/xam.dk/blob/1a7796699252369e09cf967514a6c0523fdcec3c/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/62843?v\u003d4",
-      "repoOwner": "HanSolo",
-      "repoName": "jbang-catalog",
-      "alias": "jarkanoid",
-      "scriptRef": "https://github.com/HanSolo/jarkanoid/releases/download/17.0.17/jarkanoid-mac-x64-17.0.17.jar",
-      "command": "jarkanoid@HanSolo",
-      "fullcommand": "jbang jarkanoid@HanSolo",
-      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/62843?v\u003d4",
-      "repoOwner": "HanSolo",
-      "repoName": "jbang-catalog",
-      "alias": "jdkmon",
-      "scriptRef": "https://github.com/HanSolo/JDKMon/releases/download/17.0.77/JDKMon-17.0.77-linux-x64.jar",
-      "command": "jdkmon@HanSolo",
-      "fullcommand": "jbang jdkmon@HanSolo",
-      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/62843?v\u003d4",
-      "repoOwner": "HanSolo",
-      "repoName": "jbang-catalog",
-      "alias": "jcpu",
-      "scriptRef": "https://github.com/HanSolo/jcpu/releases/download/17.0.0/jcpu-macos-x64-17.0.0.jar",
-      "command": "jcpu@HanSolo",
-      "fullcommand": "jbang jcpu@HanSolo",
-      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/62843?v\u003d4",
-      "repoOwner": "HanSolo",
-      "repoName": "jbang-catalog",
-      "alias": "discocli",
-      "scriptRef": "https://github.com/HanSolo/discocli/releases/download/17.0.15/discocli-17.0.15-fat.jar",
-      "command": "discocli@HanSolo",
-      "fullcommand": "jbang discocli@HanSolo",
-      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/62843?v\u003d4",
-      "repoOwner": "HanSolo",
-      "repoName": "jbang-catalog",
-      "alias": "javafinder",
-      "scriptRef": "https://github.com/HanSolo/javafinder/releases/download/17.0.33/javafinder-17.0.33.jar",
-      "command": "javafinder@HanSolo",
-      "fullcommand": "jbang javafinder@HanSolo",
-      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/62843?v\u003d4",
-      "repoOwner": "HanSolo",
-      "repoName": "jbang-catalog",
-      "alias": "glucostatusfx",
-      "scriptRef": "https://github.com/HanSolo/glucostatusfx/releases/download/17.0.57/GlucoStatusFX-17.0.61-linux-x64.jar",
-      "command": "glucostatusfx@HanSolo",
-      "fullcommand": "jbang glucostatusfx@HanSolo",
-      "link": "https://github.com/HanSolo/jbang-catalog/blob/390effcbf265f240bfdc229b75b57617193da067/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/202962512?v\u003d4",
-      "repoOwner": "redhat-camel",
-      "repoName": "jbang-catalog",
-      "alias": "camel",
-      "description": "\u003cp\u003eCreate and run Red Hat Build of Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "CamelJBang.java",
-      "command": "camel@redhat-camel",
-      "fullcommand": "jbang camel@redhat-camel",
-      "link": "https://github.com/redhat-camel/jbang-catalog/blob/01f62746bdc36aff06f3ce6fe050543bd0c2397b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/26224751?v\u003d4",
-      "repoOwner": "philippart-s",
-      "repoName": "jbang",
-      "alias": "jarvis-catalog",
-      "description": "\u003cp\u003eJarvis application alias\u003c/p\u003e\n",
-      "scriptRef": "Jarvis.java",
-      "command": "jarvis-catalog@philippart-s/jbang~jbang-demo",
-      "fullcommand": "jbang jarvis-catalog@philippart-s/jbang~jbang-demo",
-      "link": "https://github.com/philippart-s/jbang/blob/36fe37a6fe8c648d477cf7dfc717b1fd851eddab/jbang-demo/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/47326976?v\u003d4",
-      "repoOwner": "bmvermeer",
-      "repoName": "eventmcp",
-      "alias": "eventmcp",
-      "description": "\u003cp\u003eRun the Snyk Event MCP tool\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/bmvermeer/eventmcp/releases/latest/download/eventmcp-runner.jar",
-      "command": "eventmcp@bmvermeer/eventmcp",
-      "fullcommand": "jbang eventmcp@bmvermeer/eventmcp",
-      "link": "https://github.com/bmvermeer/eventmcp/blob/05600d29c044ce11219035e173708919de31e392/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46731024?v\u003d4",
-      "repoOwner": "Hyperfoil",
-      "repoName": "jbang-catalog",
-      "alias": "wrk2",
-      "scriptRef": "io.hyperfoil:hyperfoil-cli:0.29.1",
-      "command": "wrk2@Hyperfoil",
-      "fullcommand": "jbang wrk2@Hyperfoil",
-      "link": "https://github.com/Hyperfoil/jbang-catalog/blob/cd70d1e84b8407a80f75c5fd9f174c5f65cd326b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46731024?v\u003d4",
-      "repoOwner": "Hyperfoil",
-      "repoName": "jbang-catalog",
-      "alias": "wrk",
-      "scriptRef": "io.hyperfoil:hyperfoil-cli:0.29.1",
-      "command": "wrk@Hyperfoil",
-      "fullcommand": "jbang wrk@Hyperfoil",
-      "link": "https://github.com/Hyperfoil/jbang-catalog/blob/cd70d1e84b8407a80f75c5fd9f174c5f65cd326b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46731024?v\u003d4",
-      "repoOwner": "Hyperfoil",
-      "repoName": "jbang-catalog",
-      "alias": "cli",
-      "scriptRef": "io.hyperfoil:hyperfoil-cli:0.29.1",
-      "command": "cli@Hyperfoil",
-      "fullcommand": "jbang cli@Hyperfoil",
-      "link": "https://github.com/Hyperfoil/jbang-catalog/blob/cd70d1e84b8407a80f75c5fd9f174c5f65cd326b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46731024?v\u003d4",
-      "repoOwner": "Hyperfoil",
-      "repoName": "jbang-catalog",
-      "alias": "run",
-      "scriptRef": "io.hyperfoil:hyperfoil-cli:0.29.1",
-      "command": "run@Hyperfoil",
-      "fullcommand": "jbang run@Hyperfoil",
-      "link": "https://github.com/Hyperfoil/jbang-catalog/blob/cd70d1e84b8407a80f75c5fd9f174c5f65cd326b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46731024?v\u003d4",
-      "repoOwner": "Hyperfoil",
-      "repoName": "jbang-catalog",
-      "alias": "qDup",
-      "scriptRef": "io.hyperfoil.tools:qDup:0.11.0",
-      "command": "qDup@Hyperfoil",
-      "fullcommand": "jbang qDup@Hyperfoil",
-      "link": "https://github.com/Hyperfoil/jbang-catalog/blob/cd70d1e84b8407a80f75c5fd9f174c5f65cd326b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/558276?v\u003d4",
-      "repoOwner": "snowdrop",
-      "repoName": "migration-tool",
-      "alias": "mtool",
-      "description": "\u003cp\u003eMigration tool client to migrate Java applications\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/snowdrop/migration-tool/releases/download/early-access/migration-cli-1.0.5-SNAPSHOT-runner.jar",
-      "command": "mtool@snowdrop/migration-tool",
-      "fullcommand": "jbang mtool@snowdrop/migration-tool",
-      "link": "https://github.com/snowdrop/migration-tool/blob/8d2231d1ad70b78d2892ad001a31a7bbedaa9a7b/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/32136482?v\u003d4",
-      "repoOwner": "javatechno",
-      "repoName": "camel-4.6.2",
-      "alias": "camel",
-      "description": "\u003cp\u003eRun Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "camel@javatechno/camel-4.6.2",
-      "fullcommand": "jbang camel@javatechno/camel-4.6.2",
-      "link": "https://github.com/javatechno/camel-4.6.2/blob/e25aa994a62b2c34d6e538b71ec95121fbaefd05/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/29268941?v\u003d4",
-      "repoOwner": "Gonzivang",
-      "repoName": "SecondTry",
-      "alias": "camel",
-      "description": "\u003cp\u003eRun Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "camel@Gonzivang/SecondTry~CodeResources/Apache Camel/camel-main",
-      "fullcommand": "jbang camel@Gonzivang/SecondTry~CodeResources/Apache Camel/camel-main",
-      "link": "https://github.com/Gonzivang/SecondTry/blob/992a6661e0c116747021824e7e8bbbf3c6a49734/CodeResources/Apache%20Camel/camel-main/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "cf-explorer",
-      "alias": "cf-explorer",
-      "scriptRef": "CfExplorer.java",
-      "command": "cf-explorer@garodriguezlp/cf-explorer",
-      "fullcommand": "jbang cf-explorer@garodriguezlp/cf-explorer",
-      "link": "https://github.com/garodriguezlp/cf-explorer/blob/d4685b76febe82b56ee2c472b59af1b327051046/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "cf-explorer",
-      "alias": "mock-server",
-      "scriptRef": "wiremock/MockServer.java",
-      "command": "mock-server@garodriguezlp/cf-explorer",
-      "fullcommand": "jbang mock-server@garodriguezlp/cf-explorer",
-      "link": "https://github.com/garodriguezlp/cf-explorer/blob/d4685b76febe82b56ee2c472b59af1b327051046/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/92950547?v\u003d4",
-      "repoOwner": "CedricNdong",
-      "repoName": "springforge-tui",
-      "alias": "springforge",
-      "description": "\u003cp\u003eSpringForge TUI — Generate Spring Boot API stacks from @Entity classes\u003c/p\u003e\n",
-      "scriptRef": "dev.springforge:springforge-tui:RELEASE",
-      "command": "springforge@CedricNdong/springforge-tui",
-      "fullcommand": "jbang springforge@CedricNdong/springforge-tui",
-      "link": "https://github.com/CedricNdong/springforge-tui/blob/24f4a760fb4b1bac01433535685b662462aa72a7/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/156902772?v\u003d4",
-      "repoOwner": "jbanghub",
-      "repoName": "h2",
-      "alias": "h2",
-      "scriptRef": "com.h2database:h2:2.3.232",
-      "command": "h2@jbanghub/h2",
-      "fullcommand": "jbang h2@jbanghub/h2",
-      "link": "https://github.com/jbanghub/h2/blob/432699361f7d60cf229f060989ce5ea20313b4ae/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1939631?v\u003d4",
-      "repoOwner": "jacoco",
-      "repoName": "jbang-catalog",
-      "alias": "cli",
-      "description": "\u003cp\u003eRuns jacoco cli, see \u003ca rel\u003d\"nofollow\" href\u003d\"https://www.jacoco.org/jacoco/trunk/doc/cli.html\"\u003ehttps://www.jacoco.org/jacoco/trunk/doc/cli.html\u003c/a\u003e for documentation.\u003c/p\u003e\n",
-      "scriptRef": "org.jacoco:org.jacoco.cli:RELEASE:nodeps",
-      "command": "cli@jacoco",
-      "fullcommand": "jbang cli@jacoco",
-      "link": "https://github.com/jacoco/jbang-catalog/blob/678e949a1f87fcb1c92f0f781921e1290bc3ebde/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1939631?v\u003d4",
-      "repoOwner": "jacoco",
-      "repoName": "jbang-catalog",
-      "alias": "agent",
-      "description": "\u003cp\u003ejacoco agent, use like \u003ccode\u003ejbang --javaagent \u0026lt;script\u0026gt;\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "org.jacoco:org.jacoco.agent:RELEASE:runtime",
-      "command": "agent@jacoco",
-      "fullcommand": "jbang agent@jacoco",
-      "link": "https://github.com/jacoco/jbang-catalog/blob/678e949a1f87fcb1c92f0f781921e1290bc3ebde/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/55687?v\u003d4",
-      "repoOwner": "jruby",
-      "repoName": "jbang-catalog",
-      "alias": "run",
-      "description": "\u003cp\u003eRun a Ruby command line with JRuby\u003c/p\u003e\n",
-      "scriptRef": "org.jruby:jruby-complete:10.1.0.0",
-      "command": "run@jruby",
-      "fullcommand": "jbang run@jruby",
-      "link": "https://github.com/jruby/jbang-catalog/blob/d22a9ed3704c9d8e47a8f286175341e6b4392292/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/55687?v\u003d4",
-      "repoOwner": "jruby",
-      "repoName": "jbang-catalog",
-      "alias": "run10.0",
-      "description": "\u003cp\u003eRun a Ruby command line with JRuby\u003c/p\u003e\n",
-      "scriptRef": "org.jruby:jruby-complete:10.0.5.0",
-      "command": "run10.0@jruby",
-      "fullcommand": "jbang run10.0@jruby",
-      "link": "https://github.com/jruby/jbang-catalog/blob/d22a9ed3704c9d8e47a8f286175341e6b4392292/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/55687?v\u003d4",
-      "repoOwner": "jruby",
-      "repoName": "jbang-catalog",
-      "alias": "run9.4",
-      "description": "\u003cp\u003eRun a Ruby command line with JRuby\u003c/p\u003e\n",
-      "scriptRef": "org.jruby:jruby-complete:9.4.14.0",
-      "command": "run9.4@jruby",
-      "fullcommand": "jbang run9.4@jruby",
-      "link": "https://github.com/jruby/jbang-catalog/blob/d22a9ed3704c9d8e47a8f286175341e6b4392292/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/55687?v\u003d4",
-      "repoOwner": "jruby",
-      "repoName": "jbang-catalog",
-      "alias": "run9.3",
-      "description": "\u003cp\u003eRun a Ruby command line with JRuby\u003c/p\u003e\n",
-      "scriptRef": "org.jruby:jruby-complete:9.3.15.0",
-      "command": "run9.3@jruby",
-      "fullcommand": "jbang run9.3@jruby",
-      "link": "https://github.com/jruby/jbang-catalog/blob/d22a9ed3704c9d8e47a8f286175341e6b4392292/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/55687?v\u003d4",
-      "repoOwner": "jruby",
-      "repoName": "jbang-catalog",
-      "alias": "run9.2",
-      "description": "\u003cp\u003eRun a Ruby command line with JRuby 9.2\u003c/p\u003e\n",
-      "scriptRef": "org.jruby:jruby-complete:9.2.21.0",
-      "command": "run9.2@jruby",
-      "fullcommand": "jbang run9.2@jruby",
-      "link": "https://github.com/jruby/jbang-catalog/blob/d22a9ed3704c9d8e47a8f286175341e6b4392292/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/71858344?v\u003d4",
-      "repoOwner": "reactive-rsocket-broker",
-      "repoName": "jbang-catalog",
-      "alias": "BrokerClient",
-      "description": "\u003cp\u003eA client that connects to a broker and sends a request\u003c/p\u003e\n",
-      "scriptRef": "src/brokerSimpleClient/java/RSocketBrokerClientApp.java",
-      "command": "BrokerClient@reactive-rsocket-broker",
-      "fullcommand": "jbang BrokerClient@reactive-rsocket-broker",
-      "link": "https://github.com/reactive-rsocket-broker/jbang-catalog/blob/41b880d21e29476cd071678a270f7101fec587e3/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/71858344?v\u003d4",
-      "repoOwner": "reactive-rsocket-broker",
-      "repoName": "jbang-catalog",
-      "alias": "rsocket-broker",
-      "description": "\u003cp\u003eStart Alibaba Broker Server\u003c/p\u003e\n",
-      "scriptRef": "https://repo1.maven.org/maven2/com/alibaba/rsocket/alibaba-broker-server/1.1.3/alibaba-broker-server-1.1.3.jar",
-      "command": "rsocket-broker@reactive-rsocket-broker",
-      "fullcommand": "jbang rsocket-broker@reactive-rsocket-broker",
-      "link": "https://github.com/reactive-rsocket-broker/jbang-catalog/blob/41b880d21e29476cd071678a270f7101fec587e3/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/71858344?v\u003d4",
-      "repoOwner": "reactive-rsocket-broker",
-      "repoName": "jbang-catalog",
-      "alias": "brokerService",
-      "description": "\u003cp\u003eRSocket Broker Service Provider\u003c/p\u003e\n",
-      "scriptRef": "src/brokerService/java/demo/RSocketServiceApp.java",
-      "command": "brokerService@reactive-rsocket-broker",
-      "fullcommand": "jbang brokerService@reactive-rsocket-broker",
-      "link": "https://github.com/reactive-rsocket-broker/jbang-catalog/blob/41b880d21e29476cd071678a270f7101fec587e3/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/71858344?v\u003d4",
-      "repoOwner": "reactive-rsocket-broker",
-      "repoName": "jbang-catalog",
-      "alias": "brokerConsumer",
-      "description": "\u003cp\u003eRSocket Broker Service Consumer\u003c/p\u003e\n",
-      "scriptRef": "src/brokerConsumer/java/demo/RSocketConsumerApp.java",
-      "command": "brokerConsumer@reactive-rsocket-broker",
-      "fullcommand": "jbang brokerConsumer@reactive-rsocket-broker",
-      "link": "https://github.com/reactive-rsocket-broker/jbang-catalog/blob/41b880d21e29476cd071678a270f7101fec587e3/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/56220728?v\u003d4",
-      "repoOwner": "codejive",
-      "repoName": "twinkle",
-      "alias": "bounce",
-      "description": "\u003cp\u003eA simple TUI that demonstrates a bouncing Twinkle.\u003c/p\u003e\n",
-      "scriptRef": "examples/src/main/java/org/codejive/twinkle/demos/BouncingTwinkleDemo.java",
-      "command": "bounce@codejive/twinkle",
-      "fullcommand": "jbang bounce@codejive/twinkle",
-      "link": "https://github.com/codejive/twinkle/blob/d4b0db46a562306154f30f8b3a3cb1f5bd82f394/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/56220728?v\u003d4",
-      "repoOwner": "codejive",
-      "repoName": "twinkle",
-      "alias": "image",
-      "description": "\u003cp\u003eA simple TUI that demonstrates image rendering.\u003c/p\u003e\n",
-      "scriptRef": "examples/src/main/java/org/codejive/twinkle/demos/ImageEncoderDemo.java",
-      "command": "image@codejive/twinkle",
-      "fullcommand": "jbang image@codejive/twinkle",
-      "link": "https://github.com/codejive/twinkle/blob/d4b0db46a562306154f30f8b3a3cb1f5bd82f394/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "quarkus.ai",
-      "alias": "mcp-proxy",
-      "scriptRef": "io.quarkiverse.mcp:quarkus-mcp-stdio-sse-proxy:1.0.0.CR1@fatjar",
-      "command": "mcp-proxy@quarkusio/quarkus.ai",
-      "fullcommand": "jbang mcp-proxy@quarkusio/quarkus.ai",
-      "link": "https://github.com/quarkusio/quarkus.ai/blob/188194f732fbe3b13eb1721e23dd0e0e14bf3eda/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "NacosService",
-      "description": "\u003cp\u003eNacos Service\u003c/p\u003e\n",
-      "scriptRef": "nacos-service/src/demo/NacosServiceApp.java",
-      "command": "NacosService@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang NacosService@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "NacosClient",
-      "description": "\u003cp\u003eNacos Client\u003c/p\u003e\n",
-      "scriptRef": "nacos-client/src/demo/NacosClientApp.java",
-      "command": "NacosClient@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang NacosClient@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "RocketmqConsumer",
-      "description": "\u003cp\u003eRocketMQ Consumer\u003c/p\u003e\n",
-      "scriptRef": "rocketmq-consumer/src/demo/RocketmqConsumerApp.java",
-      "command": "RocketmqConsumer@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang RocketmqConsumer@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "RocketmqSender",
-      "description": "\u003cp\u003eRocketMQ Sender\u003c/p\u003e\n",
-      "scriptRef": "rocketmq-sender/src/RocketmqSender.java",
-      "command": "RocketmqSender@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang RocketmqSender@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "DubboServiceApp",
-      "description": "\u003cp\u003eDubbo Service Provider\u003c/p\u003e\n",
-      "scriptRef": "dubbo-demo/src/DubboServiceApp.java",
-      "command": "DubboServiceApp@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang DubboServiceApp@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "DubboClientApp",
-      "description": "\u003cp\u003eDubbo Service Consumer\u003c/p\u003e\n",
-      "scriptRef": "dubbo-demo/src/DubboClientApp.java",
-      "command": "DubboClientApp@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang DubboClientApp@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen",
-      "scriptRef": "codegen.java",
-      "command": "codegen@jOOQ",
-      "fullcommand": "jbang codegen@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen-pro",
-      "scriptRef": "codegenpro.java",
-      "command": "codegen-pro@jOOQ",
-      "fullcommand": "jbang codegen-pro@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen-pro-java-8",
-      "scriptRef": "codegenprojava8.java",
-      "command": "codegen-pro-java-8@jOOQ",
-      "fullcommand": "jbang codegen-pro-java-8@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen-pro-java-11",
-      "scriptRef": "codegenprojava11.java",
-      "command": "codegen-pro-java-11@jOOQ",
-      "fullcommand": "jbang codegen-pro-java-11@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen-trial",
-      "scriptRef": "codegentrial.java",
-      "command": "codegen-trial@jOOQ",
-      "fullcommand": "jbang codegen-trial@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen-trial-java-8",
-      "scriptRef": "codegentrialjava8.java",
-      "command": "codegen-trial-java-8@jOOQ",
-      "fullcommand": "jbang codegen-trial-java-8@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "codegen-trial-java-11",
-      "scriptRef": "codegentrialjava11.java",
-      "command": "codegen-trial-java-11@jOOQ",
-      "fullcommand": "jbang codegen-trial-java-11@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser",
-      "scriptRef": "parser.java",
-      "command": "parser@jOOQ",
-      "fullcommand": "jbang parser@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser-pro",
-      "scriptRef": "parserpro.java",
-      "command": "parser-pro@jOOQ",
-      "fullcommand": "jbang parser-pro@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser-pro-java-8",
-      "scriptRef": "parserprojava8.java",
-      "command": "parser-pro-java-8@jOOQ",
-      "fullcommand": "jbang parser-pro-java-8@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser-pro-java-11",
-      "scriptRef": "parserprojava11.java",
-      "command": "parser-pro-java-11@jOOQ",
-      "fullcommand": "jbang parser-pro-java-11@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser-trial",
-      "scriptRef": "parsertrial.java",
-      "command": "parser-trial@jOOQ",
-      "fullcommand": "jbang parser-trial@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser-trial-java-8",
-      "scriptRef": "parsertrialjava8.java",
-      "command": "parser-trial-java-8@jOOQ",
-      "fullcommand": "jbang parser-trial-java-8@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "parser-trial-java-11",
-      "scriptRef": "parsertrialjava11.java",
-      "command": "parser-trial-java-11@jOOQ",
-      "fullcommand": "jbang parser-trial-java-11@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff",
-      "scriptRef": "diff.java",
-      "command": "diff@jOOQ",
-      "fullcommand": "jbang diff@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff-pro",
-      "scriptRef": "diffpro.java",
-      "command": "diff-pro@jOOQ",
-      "fullcommand": "jbang diff-pro@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff-pro-java-8",
-      "scriptRef": "diffprojava8.java",
-      "command": "diff-pro-java-8@jOOQ",
-      "fullcommand": "jbang diff-pro-java-8@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff-pro-java-11",
-      "scriptRef": "diffprojava11.java",
-      "command": "diff-pro-java-11@jOOQ",
-      "fullcommand": "jbang diff-pro-java-11@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff-trial",
-      "scriptRef": "difftrial.java",
-      "command": "diff-trial@jOOQ",
-      "fullcommand": "jbang diff-trial@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff-trial-java-8",
-      "scriptRef": "difftrialjava8.java",
-      "command": "diff-trial-java-8@jOOQ",
-      "fullcommand": "jbang diff-trial-java-8@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/1666512?v\u003d4",
-      "repoOwner": "jOOQ",
-      "repoName": "jbang-catalog",
-      "alias": "diff-trial-java-11",
-      "scriptRef": "difftrialjava11.java",
-      "command": "diff-trial-java-11@jOOQ",
-      "fullcommand": "jbang diff-trial-java-11@jOOQ",
-      "link": "https://github.com/jOOQ/jbang-catalog/blob/d1496626cca251fa97947f2b1a1ca7a24f6fbc47/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/490655?v\u003d4",
-      "repoOwner": "parttimenerd",
-      "repoName": "jhserr",
-      "alias": "jhserr",
-      "scriptRef": "https://github.com/parttimenerd/jhserr/releases/download/v0.1.0/jhserr.jar",
-      "command": "jhserr@parttimenerd/jhserr",
-      "fullcommand": "jbang jhserr@parttimenerd/jhserr",
-      "link": "https://github.com/parttimenerd/jhserr/blob/008e9142fdd9b02f94c857946a9305eecfc77199/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/71794210?v\u003d4",
-      "repoOwner": "tgm-templates",
-      "repoName": "jbang-script",
-      "alias": "HelloWorld",
-      "scriptRef": "src/hello/HelloWorld.java",
-      "command": "HelloWorld@tgm-templates/jbang-script",
-      "fullcommand": "jbang HelloWorld@tgm-templates/jbang-script",
-      "link": "https://github.com/tgm-templates/jbang-script/blob/c092862fa2eeda74212836d80554a1a4a712476a/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/27861160?v\u003d4",
-      "repoOwner": "gomezrondon",
-      "repoName": "spring-jbang",
-      "alias": "springjbang",
-      "scriptRef": "com/gomezrondon/springjbang/Application.java",
-      "command": "springjbang@gomezrondon/spring-jbang",
-      "fullcommand": "jbang springjbang@gomezrondon/spring-jbang",
-      "link": "https://github.com/gomezrondon/spring-jbang/blob/a425bf3bb9cb2fffd61c5c1805248b08b91a6b40/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jdkdb-scraper",
-      "alias": "scraper",
-      "scriptRef": "https://github.com/jbangdev/jdkdb-scraper/releases/latest/download/jdkdb-scraper-standalone.jar",
-      "command": "scraper@jbangdev/jdkdb-scraper",
-      "fullcommand": "jbang scraper@jbangdev/jdkdb-scraper",
-      "link": "https://github.com/jbangdev/jdkdb-scraper/blob/72f05e666210ac3471d51707ea599a82c946ddc2/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "pkl-demo",
-      "alias": "pkl-cli",
-      "scriptRef": "org.pkl-lang:pkl-tools:0.27.0",
-      "command": "pkl-cli@linux-china/pkl-demo",
-      "fullcommand": "jbang pkl-cli@linux-china/pkl-demo",
-      "link": "https://github.com/linux-china/pkl-demo/blob/6edab5087fe6d0f04661a97e969eafd9a60dfef3/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "pkl-demo",
-      "alias": "pkl-codegen",
-      "scriptRef": "org.pkl-lang:pkl-tools:0.27.0",
-      "command": "pkl-codegen@linux-china/pkl-demo",
-      "fullcommand": "jbang pkl-codegen@linux-china/pkl-demo",
-      "link": "https://github.com/linux-china/pkl-demo/blob/6edab5087fe6d0f04661a97e969eafd9a60dfef3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "pgcheck",
-      "alias": "pgcheck",
-      "description": "\u003cp\u003eOne-shot PostgreSQL executor for LLM agents\u003c/p\u003e\n",
-      "scriptRef": "pgcheck.java",
-      "command": "pgcheck@garodriguezlp/pgcheck",
-      "fullcommand": "jbang pgcheck@garodriguezlp/pgcheck",
-      "link": "https://github.com/garodriguezlp/pgcheck/blob/8e7d28a57706fcf0140c77f63c529e9f5b9a8372/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/107804610?v\u003d4",
-      "repoOwner": "rodnansol",
-      "repoName": "jbang-catalog",
-      "alias": "spring-configuration-property-documenter",
-      "description": "\u003cp\u003eReads your spring-configuration-metadata.json and generates Markdown/AsciiDoc/HTML/XML based documentation from it.\u003c/p\u003e\n",
-      "scriptRef": "SpringConfigurationPropertyDocumenter.java",
-      "command": "spring-configuration-property-documenter@rodnansol",
-      "fullcommand": "jbang spring-configuration-property-documenter@rodnansol",
-      "link": "https://github.com/rodnansol/jbang-catalog/blob/e6b402f7b96e09cb13812fabfd0f54f9d7d29704/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "adventofcode",
-      "alias": "2024-1",
-      "description": "\u003cp\u003eAdvent of code 2024 day  in Kotlin\u003c/p\u003e\n",
-      "scriptRef": "2024/day1-kotlin/2024-day1.kt",
-      "command": "2024-1@yostane/adventofcode",
-      "fullcommand": "jbang 2024-1@yostane/adventofcode",
-      "link": "https://github.com/yostane/adventofcode/blob/df00369dcb0ad3765d8c7c7537d28723b7aed468/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "adventofcode",
-      "alias": "2024-2",
-      "description": "\u003cp\u003eAdvent of code 2024 day  in Kotlin\u003c/p\u003e\n",
-      "scriptRef": "2024/day1-kotlin/2024-day2.kt",
-      "command": "2024-2@yostane/adventofcode",
-      "fullcommand": "jbang 2024-2@yostane/adventofcode",
-      "link": "https://github.com/yostane/adventofcode/blob/df00369dcb0ad3765d8c7c7537d28723b7aed468/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "adventofcode",
-      "alias": "2024-3",
-      "description": "\u003cp\u003eAdvent of code 2024 day  in Kotlin\u003c/p\u003e\n",
-      "scriptRef": "2024/day1-kotlin/2024-day3.kt",
-      "command": "2024-3@yostane/adventofcode",
-      "fullcommand": "jbang 2024-3@yostane/adventofcode",
-      "link": "https://github.com/yostane/adventofcode/blob/df00369dcb0ad3765d8c7c7537d28723b7aed468/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "adventofcode",
-      "alias": "2024-4",
-      "description": "\u003cp\u003eAdvent of code 2024 day  in Kotlin\u003c/p\u003e\n",
-      "scriptRef": "2024/day1-kotlin/2024-day4.kt",
-      "command": "2024-4@yostane/adventofcode",
-      "fullcommand": "jbang 2024-4@yostane/adventofcode",
-      "link": "https://github.com/yostane/adventofcode/blob/df00369dcb0ad3765d8c7c7537d28723b7aed468/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/27861160?v\u003d4",
-      "repoOwner": "gomezrondon",
-      "repoName": "spring-in-container",
-      "alias": "cleanyaml",
-      "scriptRef": "jscript.java",
-      "command": "cleanyaml@gomezrondon/spring-in-container~script",
-      "fullcommand": "jbang cleanyaml@gomezrondon/spring-in-container~script",
-      "link": "https://github.com/gomezrondon/spring-in-container/blob/546df82c9b5bd1159c9866101c79a2fd5d3b1388/script/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/86825428?v\u003d4",
-      "repoOwner": "forest-town",
-      "repoName": "repo-2823585",
-      "alias": "camel",
-      "description": "\u003cp\u003eRun Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "camel@forest-town/repo-2823585",
-      "fullcommand": "jbang camel@forest-town/repo-2823585",
-      "link": "https://github.com/forest-town/repo-2823585/blob/b22e6473485b0c5163de12360a1b00069e9efcf9/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "splunkctl",
-      "alias": "splunk-samples",
-      "scriptRef": "support/dev-assets/SplunkSamples.java",
-      "command": "splunk-samples@garodriguezlp/splunkctl",
-      "fullcommand": "jbang splunk-samples@garodriguezlp/splunkctl",
-      "link": "https://github.com/garodriguezlp/splunkctl/blob/4711f97e92440837f4e0c6ff52974e1afddce88f/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "splunkctl",
-      "alias": "splunkctl",
-      "scriptRef": "SplunkCtl.java",
-      "command": "splunkctl@garodriguezlp/splunkctl",
-      "fullcommand": "jbang splunkctl@garodriguezlp/splunkctl",
-      "link": "https://github.com/garodriguezlp/splunkctl/blob/4711f97e92440837f4e0c6ff52974e1afddce88f/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/478604?v\u003d4",
-      "repoOwner": "base2Services",
-      "repoName": "jbang-catalog",
-      "alias": "env",
-      "description": "\u003cp\u003eDump table of Environment Variables\u003c/p\u003e\n",
-      "scriptRef": "env.java",
-      "command": "env@base2Services",
-      "fullcommand": "jbang env@base2Services",
-      "link": "https://github.com/base2Services/jbang-catalog/blob/b35b5a203947f6e6eae17d5cfd22abb04aa1bbcc/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/478604?v\u003d4",
-      "repoOwner": "base2Services",
-      "repoName": "jbang-catalog",
-      "alias": "awsssm",
-      "description": "\u003cp\u003eAWS SSM Session Manager Tunnels\u003c/p\u003e\n",
-      "scriptRef": "awsssm.java",
-      "command": "awsssm@base2Services",
-      "fullcommand": "jbang awsssm@base2Services",
-      "link": "https://github.com/base2Services/jbang-catalog/blob/b35b5a203947f6e6eae17d5cfd22abb04aa1bbcc/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "testapp2",
-      "scriptRef": "io/tulip/App.java",
-      "command": "testapp2@wfouche~testapp2",
-      "fullcommand": "jbang testapp2@wfouche~testapp2",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/testapp2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/3137042?v\u003d4",
-      "repoOwner": "asciidoctor",
-      "repoName": "jbang-catalog",
-      "alias": "asciidoctorj",
-      "description": "\u003cp\u003eRun AsciidoctorJ 3.0\u003c/p\u003e\n",
-      "scriptRef": "asciidoctorj.java",
-      "command": "asciidoctorj@asciidoctor",
-      "fullcommand": "jbang asciidoctorj@asciidoctor",
-      "link": "https://github.com/asciidoctor/jbang-catalog/blob/115d7276735a69ff421731b0693d9a031061c055/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/6860662?v\u003d4",
-      "repoOwner": "mfietz",
-      "repoName": "msr-mcp",
-      "alias": "msr-mcp",
-      "description": "\u003cp\u003eMSR MCP Server — Mining Software Repository analyses (hotspots, coupling, history) via MCP protocol\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/mfietz/msr-mcp/releases/latest/download/msr-mcp-server.jar",
-      "command": "msr-mcp@mfietz/msr-mcp",
-      "fullcommand": "jbang msr-mcp@mfietz/msr-mcp",
-      "link": "https://github.com/mfietz/msr-mcp/blob/3b7b35df84e93043eb665f354ca7c5c913a2573b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-catalog-doc-generator",
-      "alias": "cli",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.6.1.Final/quarkus-cli-2.6.1.Final-runner.jar",
-      "command": "cli@nandorholozsnyak/jbang-catalog-doc-generator",
-      "fullcommand": "jbang cli@nandorholozsnyak/jbang-catalog-doc-generator",
-      "link": "https://github.com/nandorholozsnyak/jbang-catalog-doc-generator/blob/5b0a0d3627b30fe46c51d7f1ef1dba50a5c8dd34/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-catalog-doc-generator",
-      "alias": "qs",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.6.1.Final/quarkus-cli-2.6.1.Final-runner.jar",
-      "command": "qs@nandorholozsnyak/jbang-catalog-doc-generator",
-      "fullcommand": "jbang qs@nandorholozsnyak/jbang-catalog-doc-generator",
-      "link": "https://github.com/nandorholozsnyak/jbang-catalog-doc-generator/blob/5b0a0d3627b30fe46c51d7f1ef1dba50a5c8dd34/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-catalog-doc-generator",
-      "alias": "quarkus",
-      "scriptRef": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.6.1.Final/quarkus-cli-2.6.1.Final-runner.jar",
-      "command": "quarkus@nandorholozsnyak/jbang-catalog-doc-generator",
-      "fullcommand": "jbang quarkus@nandorholozsnyak/jbang-catalog-doc-generator",
-      "link": "https://github.com/nandorholozsnyak/jbang-catalog-doc-generator/blob/5b0a0d3627b30fe46c51d7f1ef1dba50a5c8dd34/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "hello",
-      "scriptRef": "src/hello.java",
-      "command": "hello@wfouche~apps/hello/1.0.0",
-      "fullcommand": "jbang hello@wfouche~apps/hello/1.0.0",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/apps/hello/1.0.0/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91312095?v\u003d4",
-      "repoOwner": "karatelabs",
-      "repoName": "jbang-catalog",
-      "alias": "karate",
-      "scriptRef": "io.karatelabs:karate-core:1.5.2:all",
-      "command": "karate@karatelabs",
-      "fullcommand": "jbang karate@karatelabs",
-      "link": "https://github.com/karatelabs/jbang-catalog/blob/63a7884565eb689f6022407185d5d68d052d8e5e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "bookish-succotash",
-      "alias": "ring-dashboard",
-      "description": "\u003cp\u003eLive dashboard reading the C++ Tango storage-ring simulator\u003c/p\u003e\n",
-      "scriptRef": "demo/scripts/StorageRingDashboard.java",
-      "command": "ring-dashboard@Ingvord/bookish-succotash",
-      "fullcommand": "jbang ring-dashboard@Ingvord/bookish-succotash",
-      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "bookish-succotash",
-      "alias": "ring-correlation",
-      "description": "\u003cp\u003eCorrelated reads across controller and sector devices\u003c/p\u003e\n",
-      "scriptRef": "demo/scripts/CorrelatedOrbitSnapshot.java",
-      "command": "ring-correlation@Ingvord/bookish-succotash",
-      "fullcommand": "jbang ring-correlation@Ingvord/bookish-succotash",
-      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "bookish-succotash",
-      "alias": "ring-smoothing",
-      "description": "\u003cp\u003eSliding average and guarded write-back to the controller\u003c/p\u003e\n",
-      "scriptRef": "demo/scripts/SmoothedCurrentWriter.java",
-      "command": "ring-smoothing@Ingvord/bookish-succotash",
-      "fullcommand": "jbang ring-smoothing@Ingvord/bookish-succotash",
-      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "bookish-succotash",
-      "alias": "ring-interlocks",
-      "description": "\u003cp\u003eFan-in alarm stream across the sector devices\u003c/p\u003e\n",
-      "scriptRef": "demo/scripts/BeamLossInterlocks.java",
-      "command": "ring-interlocks@Ingvord/bookish-succotash",
-      "fullcommand": "jbang ring-interlocks@Ingvord/bookish-succotash",
-      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "bookish-succotash",
-      "alias": "ring-backpressure",
-      "description": "\u003cp\u003eBackpressure demo against fast sector polling\u003c/p\u003e\n",
-      "scriptRef": "demo/scripts/RingBackpressure.java",
-      "command": "ring-backpressure@Ingvord/bookish-succotash",
-      "fullcommand": "jbang ring-backpressure@Ingvord/bookish-succotash",
-      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "bookish-succotash",
-      "alias": "ring-scenario",
-      "description": "\u003cp\u003eSwitch the storage-ring simulator scenario for live fault demos\u003c/p\u003e\n",
-      "scriptRef": "demo/scripts/SetStorageRingScenario.java",
-      "command": "ring-scenario@Ingvord/bookish-succotash",
-      "fullcommand": "jbang ring-scenario@Ingvord/bookish-succotash",
-      "link": "https://github.com/Ingvord/bookish-succotash/blob/5a7dca00b6c9e492c4b24db1496eaf05bee34ba2/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-processing",
-      "alias": "pderun",
-      "scriptRef": "pderun.java",
-      "command": "pderun@maxandersen/jbang-processing",
-      "fullcommand": "jbang pderun@maxandersen/jbang-processing",
-      "link": "https://github.com/maxandersen/jbang-processing/blob/0f18d428957c7aa61a7238a6b8d2fb309e1a3574/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "read-attribute",
-      "description": "\u003cp\u003eRead one or more Tango attributes and print their values\u003c/p\u003e\n",
-      "scriptRef": "examples/ReadAttribute.java",
-      "command": "read-attribute@Ingvord/RxJTango",
-      "fullcommand": "jbang read-attribute@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "poll",
-      "description": "\u003cp\u003ePoll a Tango attribute on a fixed interval and stream the values\u003c/p\u003e\n",
-      "scriptRef": "examples/PollAttribute.java",
-      "command": "poll@Ingvord/RxJTango",
-      "fullcommand": "jbang poll@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "monitor",
-      "description": "\u003cp\u003eStream Tango attribute change events to stdout\u003c/p\u003e\n",
-      "scriptRef": "examples/MonitorAttribute.java",
-      "command": "monitor@Ingvord/RxJTango",
-      "fullcommand": "jbang monitor@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "zip",
-      "description": "\u003cp\u003ePoll and zip two attributes from (possibly different) devices\u003c/p\u003e\n",
-      "scriptRef": "examples/ZipAttributes.java",
-      "command": "zip@Ingvord/RxJTango",
-      "fullcommand": "jbang zip@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "snapshot",
-      "description": "\u003cp\u003eRead attributes from multiple devices in parallel and print a combined snapshot\u003c/p\u003e\n",
-      "scriptRef": "examples/MultiDeviceSnapshot.java",
-      "command": "snapshot@Ingvord/RxJTango",
-      "fullcommand": "jbang snapshot@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "stats",
-      "description": "\u003cp\u003eCollect N samples of double_scalar and compute min/max/mean/stddev\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestStats.java",
-      "command": "stats@Ingvord/RxJTango",
-      "fullcommand": "jbang stats@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "correlate",
-      "description": "\u003cp\u003eRead double_scalar and long_scalar in parallel on each tick, print both with their difference\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestCorrelate.java",
-      "command": "correlate@Ingvord/RxJTango",
-      "fullcommand": "jbang correlate@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "calibrate",
-      "description": "\u003cp\u003eRead-transform-write pipeline with linear calibration (gain * value + offset)\u003c/p\u003e\n",
-      "scriptRef": "examples/CalibrationPipeline.java",
-      "command": "calibrate@Ingvord/RxJTango",
-      "fullcommand": "jbang calibrate@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "alarm",
-      "description": "\u003cp\u003eFan-in alarm monitor: merge N polling streams, alert when threshold is exceeded\u003c/p\u003e\n",
-      "scriptRef": "examples/AlarmMonitor.java",
-      "command": "alarm@Ingvord/RxJTango",
-      "fullcommand": "jbang alarm@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "pipeline",
-      "description": "\u003cp\u003e6-step fluent TangoClient pipeline on TangoTest: read → command → calibrate → command → write → read-back\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestPipeline.java",
-      "command": "pipeline@Ingvord/RxJTango",
-      "fullcommand": "jbang pipeline@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "throttle",
-      "description": "\u003cp\u003ePoll at high frequency, display at low rate via throttleLast — shows Rx rate control\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestThrottle.java",
-      "command": "throttle@Ingvord/RxJTango",
-      "fullcommand": "jbang throttle@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "sliding-avg",
-      "description": "\u003cp\u003eRolling average over a sliding window of N samples using buffer(N, 1)\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestSlidingAverage.java",
-      "command": "sliding-avg@Ingvord/RxJTango",
-      "fullcommand": "jbang sliding-avg@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "running-stats",
-      "description": "\u003cp\u003eLive streaming min/max/mean/stddev using scan() — O(1) memory, Welford algorithm\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestRunningStats.java",
-      "command": "running-stats@Ingvord/RxJTango",
-      "fullcommand": "jbang running-stats@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "backpressure",
-      "description": "\u003cp\u003eFast producer vs slow consumer: demonstrate onBackpressureLatest/Drop/Buffer strategies\u003c/p\u003e\n",
-      "scriptRef": "examples/TangoTestBackpressure.java",
-      "command": "backpressure@Ingvord/RxJTango",
-      "fullcommand": "jbang backpressure@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11678364?v\u003d4",
-      "repoOwner": "Ingvord",
-      "repoName": "RxJTango",
-      "alias": "verify-spec",
-      "description": "\u003cp\u003eRun the reactive-streams TCK against RxTangoAttribute\u003c/p\u003e\n",
-      "scriptRef": "examples/VerifySpec.java",
-      "command": "verify-spec@Ingvord/RxJTango",
-      "fullcommand": "jbang verify-spec@Ingvord/RxJTango",
-      "link": "https://github.com/Ingvord/RxJTango/blob/dbb48c1a804497d23a965055b2afef024eb0e4c3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/2537804?v\u003d4",
-      "repoOwner": "zemiak",
-      "repoName": "jbang-catalog",
-      "alias": "letnecesty2025",
-      "scriptRef": "letnecesty2025/main.java",
-      "command": "letnecesty2025@zemiak",
-      "fullcommand": "jbang letnecesty2025@zemiak",
-      "link": "https://github.com/zemiak/jbang-catalog/blob/2e21ec821ce53c3ba3b10d96abf68c8dfcef9c8d/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/2537804?v\u003d4",
-      "repoOwner": "zemiak",
-      "repoName": "jbang-catalog",
-      "alias": "letnecesty2025_sharkix",
-      "scriptRef": "letnecesty2025_sharkix/main.java",
-      "command": "letnecesty2025_sharkix@zemiak",
-      "fullcommand": "jbang letnecesty2025_sharkix@zemiak",
-      "link": "https://github.com/zemiak/jbang-catalog/blob/2e21ec821ce53c3ba3b10d96abf68c8dfcef9c8d/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jarkata-data-quarkus-jbang",
-      "alias": "h2console",
-      "scriptRef": "h2@jbanghub/h2",
-      "command": "h2console@maxandersen/jarkata-data-quarkus-jbang",
-      "fullcommand": "jbang h2console@maxandersen/jarkata-data-quarkus-jbang",
-      "link": "https://github.com/maxandersen/jarkata-data-quarkus-jbang/blob/e6d79d0178deab3739005bbddf8fc91364054e64/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/7559962?v\u003d4",
-      "repoOwner": "SimonScholz",
-      "repoName": "jbang-catalog",
-      "alias": "qr-code-app",
-      "description": "\u003cp\u003eQR code with logo app by Simon Scholz\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/SimonScholz/qr-code-with-logo/releases/download/0.4.0/qr-code-app-all.jar",
-      "command": "qr-code-app@SimonScholz",
-      "fullcommand": "jbang qr-code-app@SimonScholz",
-      "link": "https://github.com/SimonScholz/jbang-catalog/blob/2cc41ee6e972c583ecf4f1e23178b51b9e443ae0/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/96721872?v\u003d4",
-      "repoOwner": "yaodahua",
-      "repoName": "fuxian_ChatTester",
-      "alias": "tabula",
-      "scriptRef": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar",
-      "command": "tabula@yaodahua/fuxian_ChatTester~Repos/tabulapdf_tabula-java",
-      "fullcommand": "jbang tabula@yaodahua/fuxian_ChatTester~Repos/tabulapdf_tabula-java",
-      "link": "https://github.com/yaodahua/fuxian_ChatTester/blob/eb4c78ff31049765a9e28a6803c71e621ead32a9/Repos/tabulapdf_tabula-java/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "camel",
-      "scriptRef": "../CamelJBang.java",
-      "command": "camel@wfouche~apps/camel/4.17.0",
-      "fullcommand": "jbang camel@wfouche~apps/camel/4.17.0",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/apps/camel/4.17.0/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/921666?v\u003d4",
-      "repoOwner": "jlengrand",
-      "repoName": "jbang-catalog",
-      "alias": "app-snapshot",
-      "description": "\u003cp\u003ehelidon-quickstart-se\u003c/p\u003e\n",
-      "scriptRef": "app_snapshot.java",
-      "command": "app-snapshot@jlengrand",
-      "fullcommand": "jbang app-snapshot@jlengrand",
-      "link": "https://github.com/jlengrand/jbang-catalog/blob/20a69fcc6aa072afa05c23ca478693ccf367b382/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/921666?v\u003d4",
-      "repoOwner": "jlengrand",
-      "repoName": "jbang-catalog",
-      "alias": "helidon-quickstart-se-snapshot",
-      "description": "\u003cp\u003ehelidon-quickstart-se\u003c/p\u003e\n",
-      "scriptRef": "helidon_quickstart_se_snapshot.java",
-      "command": "helidon-quickstart-se-snapshot@jlengrand",
-      "fullcommand": "jbang helidon-quickstart-se-snapshot@jlengrand",
-      "link": "https://github.com/jlengrand/jbang-catalog/blob/20a69fcc6aa072afa05c23ca478693ccf367b382/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "jobops",
-      "description": "\u003cp\u003eAI motivation letter daemon with web crawling\u003c/p\u003e\n",
-      "scriptRef": "jobops/JobOps.java",
-      "command": "jobops@codesapienbe/jbang-tools",
-      "fullcommand": "jbang jobops@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "instyper",
-      "description": "\u003cp\u003eUltra-low latency speech-to-text conversion\u003c/p\u003e\n",
-      "scriptRef": "instyper/Instyper.java",
-      "command": "instyper@codesapienbe/jbang-tools",
-      "fullcommand": "jbang instyper@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "offlan",
-      "description": "\u003cp\u003eCompletely offline translator (90+ languages)\u003c/p\u003e\n",
-      "scriptRef": "offlan/Offlan.java",
-      "command": "offlan@codesapienbe/jbang-tools",
-      "fullcommand": "jbang offlan@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "inspeak",
-      "description": "\u003cp\u003eInstant text-to-speech with file monitoring\u003c/p\u003e\n",
-      "scriptRef": "inspeak/Inspeak.java",
-      "command": "inspeak@codesapienbe/jbang-tools",
-      "fullcommand": "jbang inspeak@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "qproj",
-      "description": "\u003cp\u003eProject generator with 100k+ templates\u003c/p\u003e\n",
-      "scriptRef": "qproj/Qproj.java",
-      "command": "qproj@codesapienbe/jbang-tools",
-      "fullcommand": "jbang qproj@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "pertun",
-      "description": "\u003cp\u003ePerformance tuning and OS optimization\u003c/p\u003e\n",
-      "scriptRef": "pertun/Pertun.java",
-      "command": "pertun@codesapienbe/jbang-tools",
-      "fullcommand": "jbang pertun@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "sysmon",
-      "description": "\u003cp\u003eComprehensive system monitoring with AI predictions\u003c/p\u003e\n",
-      "scriptRef": "sysmon/Sysmon.java",
-      "command": "sysmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang sysmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "netwatch",
-      "description": "\u003cp\u003eNetwork traffic monitoring with threat detection\u003c/p\u003e\n",
-      "scriptRef": "netwatch/Netwatch.java",
-      "command": "netwatch@codesapienbe/jbang-tools",
-      "fullcommand": "jbang netwatch@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "procman",
-      "description": "\u003cp\u003eAdvanced process manager with AI recommendations\u003c/p\u003e\n",
-      "scriptRef": "procman/Procman.java",
-      "command": "procman@codesapienbe/jbang-tools",
-      "fullcommand": "jbang procman@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "diskman",
-      "description": "\u003cp\u003eIntelligent disk analyzer with smart cleanup\u003c/p\u003e\n",
-      "scriptRef": "diskman/Diskman.java",
-      "command": "diskman@codesapienbe/jbang-tools",
-      "fullcommand": "jbang diskman@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "powmon",
-      "description": "\u003cp\u003eBattery and power management with learning optimization\u003c/p\u003e\n",
-      "scriptRef": "powmon/Powmon.java",
-      "command": "powmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang powmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "lazyme",
-      "description": "\u003cp\u003eCross-platform face recognition authentication\u003c/p\u003e\n",
-      "scriptRef": "lazyme/Lazyme.java",
-      "command": "lazyme@codesapienbe/jbang-tools",
-      "fullcommand": "jbang lazyme@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "safeclip",
-      "description": "\u003cp\u003eAI-powered clipboard security scanner\u003c/p\u003e\n",
-      "scriptRef": "safeclip/Safeclip.java",
-      "command": "safeclip@codesapienbe/jbang-tools",
-      "fullcommand": "jbang safeclip@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "mahrem",
-      "description": "\u003cp\u003eUniversal end-to-end message encryption\u003c/p\u003e\n",
-      "scriptRef": "mahrem/Mahrem.java",
-      "command": "mahrem@codesapienbe/jbang-tools",
-      "fullcommand": "jbang mahrem@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "vaultray",
-      "description": "\u003cp\u003eLightweight password manager with tray integration\u003c/p\u003e\n",
-      "scriptRef": "vaultray/Vaultray.java",
-      "command": "vaultray@codesapienbe/jbang-tools",
-      "fullcommand": "jbang vaultray@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "screengrab",
-      "description": "\u003cp\u003eProfessional screen capture with AI annotation\u003c/p\u003e\n",
-      "scriptRef": "screengrab/Screengrab.java",
-      "command": "screengrab@codesapienbe/jbang-tools",
-      "fullcommand": "jbang screengrab@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "medilook",
-      "description": "\u003cp\u003eAI-powered video content search\u003c/p\u003e\n",
-      "scriptRef": "medilook/Medilook.java",
-      "command": "medilook@codesapienbe/jbang-tools",
-      "fullcommand": "jbang medilook@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "newlook",
-      "description": "\u003cp\u003eReal-time appearance modification with computer vision\u003c/p\u003e\n",
-      "scriptRef": "newlook/Newlook.java",
-      "command": "newlook@codesapienbe/jbang-tools",
-      "fullcommand": "jbang newlook@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "audioctl",
-      "description": "\u003cp\u003eAdvanced audio control with device switching\u003c/p\u003e\n",
-      "scriptRef": "audioctl/Audioctl.java",
-      "command": "audioctl@codesapienbe/jbang-tools",
-      "fullcommand": "jbang audioctl@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "clipstack",
-      "description": "\u003cp\u003eAdvanced clipboard manager with AI categorization\u003c/p\u003e\n",
-      "scriptRef": "clipstack/Clipstack.java",
-      "command": "clipstack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang clipstack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "quickfile",
-      "description": "\u003cp\u003eLightning-fast file search with learning algorithms\u003c/p\u003e\n",
-      "scriptRef": "quickfile/Quickfile.java",
-      "command": "quickfile@codesapienbe/jbang-tools",
-      "fullcommand": "jbang quickfile@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "filewatch",
-      "description": "\u003cp\u003eReal-time file system monitoring with anomaly detection\u003c/p\u003e\n",
-      "scriptRef": "filewatch/Filewatch.java",
-      "command": "filewatch@codesapienbe/jbang-tools",
-      "fullcommand": "jbang filewatch@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "syncmate",
-      "description": "\u003cp\u003eIntelligent file synchronization with smart conflict resolution\u003c/p\u003e\n",
-      "scriptRef": "syncmate/Syncmate.java",
-      "command": "syncmate@codesapienbe/jbang-tools",
-      "fullcommand": "jbang syncmate@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "winman",
-      "description": "\u003cp\u003eAdvanced window manager with learning-based layouts\u003c/p\u003e\n",
-      "scriptRef": "winman/Winman.java",
-      "command": "winman@codesapienbe/jbang-tools",
-      "fullcommand": "jbang winman@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "trayorg",
-      "description": "\u003cp\u003eSystem tray organizer with AI importance ranking\u003c/p\u003e\n",
-      "scriptRef": "trayorg/Trayorg.java",
-      "command": "trayorg@codesapienbe/jbang-tools",
-      "fullcommand": "jbang trayorg@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "displayctl",
-      "description": "\u003cp\u003eAdvanced display control with adaptive ML settings\u003c/p\u003e\n",
-      "scriptRef": "displayctl/Displayctl.java",
-      "command": "displayctl@codesapienbe/jbang-tools",
-      "fullcommand": "jbang displayctl@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "quickset",
-      "description": "\u003cp\u003eRapid system settings access with contextual suggestions\u003c/p\u003e\n",
-      "scriptRef": "quickset/Quickset.java",
-      "command": "quickset@codesapienbe/jbang-tools",
-      "fullcommand": "jbang quickset@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "servicectl",
-      "description": "\u003cp\u003eSystem service manager with predictive failure detection\u003c/p\u003e\n",
-      "scriptRef": "servicectl/Servicectl.java",
-      "command": "servicectl@codesapienbe/jbang-tools",
-      "fullcommand": "jbang servicectl@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "voicebytes",
-      "description": "\u003cp\u003eAudio analysis with real-time speaker isolation\u003c/p\u003e\n",
-      "scriptRef": "voicebytes/Voicebytes.java",
-      "command": "voicebytes@codesapienbe/jbang-tools",
-      "fullcommand": "jbang voicebytes@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "netguard",
-      "description": "\u003cp\u003eNetwork security monitor with ML threat detection\u003c/p\u003e\n",
-      "scriptRef": "netguard/Netguard.java",
-      "command": "netguard@codesapienbe/jbang-tools",
-      "fullcommand": "jbang netguard@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "vpnmon",
-      "description": "\u003cp\u003eVPN connection monitor with intelligent server selection\u003c/p\u003e\n",
-      "scriptRef": "vpnmon/Vpnmon.java",
-      "command": "vpnmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang vpnmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "pingmon",
-      "description": "\u003cp\u003eNetwork connectivity monitor with predictive issue detection\u003c/p\u003e\n",
-      "scriptRef": "pingmon/Pingmon.java",
-      "command": "pingmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang pingmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "facebytes",
-      "description": "\u003cp\u003eEvent photo management with privacy features\u003c/p\u003e\n",
-      "scriptRef": "facebytes/Facebytes.java",
-      "command": "facebytes@codesapienbe/jbang-tools",
-      "fullcommand": "jbang facebytes@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "visiplay",
-      "description": "\u003cp\u003eTouchless gaming platform using hand-tracking\u003c/p\u003e\n",
-      "scriptRef": "visiplay/Visiplay.java",
-      "command": "visiplay@codesapienbe/jbang-tools",
-      "fullcommand": "jbang visiplay@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "feedme",
-      "description": "\u003cp\u003eAI-powered food inspection and nutrition analysis\u003c/p\u003e\n",
-      "scriptRef": "feedme/Feedme.java",
-      "command": "feedme@codesapienbe/jbang-tools",
-      "fullcommand": "jbang feedme@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "codewatch",
-      "description": "\u003cp\u003eReal-time code quality monitor that analyzes your codebase continuously, detecting code smells, security vulnerabilities, and performance bottlenecks with AI-powered suggestions for improvement.\u003c/p\u003e\n",
-      "scriptRef": "codewatch/CodeWatch.java",
-      "command": "codewatch@codesapienbe/jbang-tools",
-      "fullcommand": "jbang codewatch@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "gitflow",
-      "description": "\u003cp\u003eAdvanced Git workflow manager with visual branch management, automated conflict resolution, intelligent merge strategies, and team collaboration insights with productivity analytics.\u003c/p\u003e\n",
-      "scriptRef": "gitflow/GitFlow.java",
-      "command": "gitflow@codesapienbe/jbang-tools",
-      "fullcommand": "jbang gitflow@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "apitest",
-      "description": "\u003cp\u003eComprehensive API testing framework with automated test generation from OpenAPI specs, performance benchmarking, load testing, and real-time monitoring with alerting.\u003c/p\u003e\n",
-      "scriptRef": "apitest/ApiTest.java",
-      "command": "apitest@codesapienbe/jbang-tools",
-      "fullcommand": "jbang apitest@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "docgen",
-      "description": "\u003cp\u003eIntelligent documentation generator that creates comprehensive API docs, README files, and technical specifications from code comments, structure analysis, and usage patterns.\u003c/p\u003e\n",
-      "scriptRef": "docgen/DocGen.java",
-      "command": "docgen@codesapienbe/jbang-tools",
-      "fullcommand": "jbang docgen@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "depcheck",
-      "description": "\u003cp\u003eDependency vulnerability scanner and updater that monitors security issues, license compliance, version compatibility, and provides automated update suggestions with impact analysis.\u003c/p\u003e\n",
-      "scriptRef": "depcheck/DepCheck.java",
-      "command": "depcheck@codesapienbe/jbang-tools",
-      "fullcommand": "jbang depcheck@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "buildopt",
-      "description": "\u003cp\u003eBuild optimization analyzer that identifies bottlenecks in compilation processes, suggests performance improvements, and provides detailed metrics for faster development cycles.\u003c/p\u003e\n",
-      "scriptRef": "buildopt/BuildOpt.java",
-      "command": "buildopt@codesapienbe/jbang-tools",
-      "fullcommand": "jbang buildopt@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "testgen",
-      "description": "\u003cp\u003eAI-powered unit test generator that creates comprehensive test suites based on code analysis, coverage requirements, and best practices with mutation testing support.\u003c/p\u003e\n",
-      "scriptRef": "testgen/TestGen.java",
-      "command": "testgen@codesapienbe/jbang-tools",
-      "fullcommand": "jbang testgen@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "logview",
-      "description": "\u003cp\u003eAdvanced log analyzer with pattern recognition, anomaly detection, intelligent filtering, and real-time debugging assistance for complex distributed applications.\u003c/p\u003e\n",
-      "scriptRef": "logview/LogView.java",
-      "command": "logview@codesapienbe/jbang-tools",
-      "fullcommand": "jbang logview@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "perfmon",
-      "description": "\u003cp\u003eReal-time application performance monitor with memory profiling, CPU usage analysis, database query optimization, and performance bottleneck identification.\u003c/p\u003e\n",
-      "scriptRef": "perfmon/PerfMon.java",
-      "command": "perfmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang perfmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "coderev",
-      "description": "\u003cp\u003eAI-powered code review assistant that provides instant feedback on code quality, security vulnerabilities, performance optimizations, and adherence to coding standards.\u003c/p\u003e\n",
-      "scriptRef": "coderev/CodeRev.java",
-      "command": "coderev@codesapienbe/jbang-tools",
-      "fullcommand": "jbang coderev@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "dbtools",
-      "description": "\u003cp\u003eDatabase management toolkit with query optimization, schema analysis, data migration tools, and performance monitoring across multiple database engines.\u003c/p\u003e\n",
-      "scriptRef": "dbtools/DbTools.java",
-      "command": "dbtools@codesapienbe/jbang-tools",
-      "fullcommand": "jbang dbtools@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "envman",
-      "description": "\u003cp\u003eEnvironment management tool that handles configuration across development, staging, and production environments with secret management and deployment automation.\u003c/p\u003e\n",
-      "scriptRef": "envman/EnvMan.java",
-      "command": "envman@codesapienbe/jbang-tools",
-      "fullcommand": "jbang envman@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "mockgen",
-      "description": "\u003cp\u003eAPI mocking service generator that creates realistic mock APIs from specifications, supports dynamic responses, and provides testing scenarios.\u003c/p\u003e\n",
-      "scriptRef": "mockgen/MockGen.java",
-      "command": "mockgen@codesapienbe/jbang-tools",
-      "fullcommand": "jbang mockgen@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "refactor",
-      "description": "\u003cp\u003eIntelligent code refactoring assistant that suggests improvements, automates common refactoring patterns, and ensures code quality during transformations.\u003c/p\u003e\n",
-      "scriptRef": "refactor/Refactor.java",
-      "command": "refactor@codesapienbe/jbang-tools",
-      "fullcommand": "jbang refactor@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "metrics",
-      "description": "\u003cp\u003eDevelopment metrics dashboard that tracks productivity, code quality, deployment frequency, and team performance with actionable insights.\u003c/p\u003e\n",
-      "scriptRef": "metrics/Metrics.java",
-      "command": "metrics@codesapienbe/jbang-tools",
-      "fullcommand": "jbang metrics@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "exptrack",
-      "description": "\u003cp\u003eAdvanced expense tracking with receipt scanning using OCR, automatic categorization with AI, tax preparation support, and multi-currency handling with real-time exchange rates.\u003c/p\u003e\n",
-      "scriptRef": "exptrack/ExpTrack.java",
-      "command": "exptrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang exptrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "invoicegen",
-      "description": "\u003cp\u003eProfessional invoice generator with customizable templates, payment tracking, client management, automated reminders, and integration with accounting systems.\u003c/p\u003e\n",
-      "scriptRef": "invoicegen/InvoiceGen.java",
-      "command": "invoicegen@codesapienbe/jbang-tools",
-      "fullcommand": "jbang invoicegen@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "budgetplan",
-      "description": "\u003cp\u003eIntelligent budget planning tool with expense forecasting, goal tracking, financial health analysis, and investment recommendations based on spending patterns.\u003c/p\u003e\n",
-      "scriptRef": "budgetplan/BudgetPlan.java",
-      "command": "budgetplan@codesapienbe/jbang-tools",
-      "fullcommand": "jbang budgetplan@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "taxcalc",
-      "description": "\u003cp\u003eMulti-jurisdiction tax calculator with deduction optimization, filing assistance, audit support, and real-time tax law updates with compliance checking.\u003c/p\u003e\n",
-      "scriptRef": "taxcalc/TaxCalc.java",
-      "command": "taxcalc@codesapienbe/jbang-tools",
-      "fullcommand": "jbang taxcalc@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "cryptotrack",
-      "description": "\u003cp\u003eCryptocurrency portfolio tracker with real-time prices, profit/loss analysis, tax reporting, DeFi integration, and market sentiment analysis.\u003c/p\u003e\n",
-      "scriptRef": "cryptotrack/CryptoTrack.java",
-      "command": "cryptotrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang cryptotrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "stockmon",
-      "description": "\u003cp\u003eStock market monitor with portfolio tracking, alert systems, technical analysis tools, and AI-powered trading insights with risk assessment.\u003c/p\u003e\n",
-      "scriptRef": "stockmon/StockMon.java",
-      "command": "stockmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang stockmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "bizplan",
-      "description": "\u003cp\u003eBusiness plan generator with financial projections, market analysis, presentation templates, and investor pitch deck creation with industry benchmarks.\u003c/p\u003e\n",
-      "scriptRef": "bizplan/BizPlan.java",
-      "command": "bizplan@codesapienbe/jbang-tools",
-      "fullcommand": "jbang bizplan@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "leadmgr",
-      "description": "\u003cp\u003eLead management system with contact tracking, follow-up scheduling, conversion analysis, and sales pipeline optimization with CRM integration.\u003c/p\u003e\n",
-      "scriptRef": "leadmgr/LeadMgr.java",
-      "command": "leadmgr@codesapienbe/jbang-tools",
-      "fullcommand": "jbang leadmgr@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "contractmgr",
-      "description": "\u003cp\u003eContract management with template library, renewal tracking, compliance monitoring, and automated workflow management with legal review assistance.\u003c/p\u003e\n",
-      "scriptRef": "contractmgr/ContractMgr.java",
-      "command": "contractmgr@codesapienbe/jbang-tools",
-      "fullcommand": "jbang contractmgr@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "payroll",
-      "description": "\u003cp\u003ePayroll management system with tax calculations, benefit administration, time tracking integration, and compliance reporting across multiple jurisdictions.\u003c/p\u003e\n",
-      "scriptRef": "payroll/Payroll.java",
-      "command": "payroll@codesapienbe/jbang-tools",
-      "fullcommand": "jbang payroll@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "imgproc",
-      "description": "\u003cp\u003eBatch image processor with AI-powered optimization, format conversion, quality enhancement, watermarking, and metadata management with cloud storage integration.\u003c/p\u003e\n",
-      "scriptRef": "imgproc/ImgProc.java",
-      "command": "imgproc@codesapienbe/jbang-tools",
-      "fullcommand": "jbang imgproc@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "vidconv",
-      "description": "\u003cp\u003eVideo converter with format optimization, compression algorithms, batch processing, subtitle management, and quality preservation with GPU acceleration.\u003c/p\u003e\n",
-      "scriptRef": "vidconv/VidConv.java",
-      "command": "vidconv@codesapienbe/jbang-tools",
-      "fullcommand": "jbang vidconv@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "audiocut",
-      "description": "\u003cp\u003eAudio editor with noise reduction, format conversion, automated podcast processing, voice enhancement, and multi-track editing capabilities.\u003c/p\u003e\n",
-      "scriptRef": "audiocut/AudioCut.java",
-      "command": "audiocut@codesapienbe/jbang-tools",
-      "fullcommand": "jbang audiocut@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "pdftools",
-      "description": "\u003cp\u003eComprehensive PDF toolkit with merging, splitting, OCR, form processing, digital signatures, and batch operations with security features.\u003c/p\u003e\n",
-      "scriptRef": "pdftools/PdfTools.java",
-      "command": "pdftools@codesapienbe/jbang-tools",
-      "fullcommand": "jbang pdftools@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "markconv",
-      "description": "\u003cp\u003eMarkdown converter with multiple output formats, template support, automated styling, and integration with documentation platforms.\u003c/p\u003e\n",
-      "scriptRef": "markconv/MarkConv.java",
-      "command": "markconv@codesapienbe/jbang-tools",
-      "fullcommand": "jbang markconv@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "codebeaut",
-      "description": "\u003cp\u003eCode beautifier and formatter supporting 100+ programming languages with customizable style guides, team standards, and automated formatting.\u003c/p\u003e\n",
-      "scriptRef": "codebeaut/CodeBeaut.java",
-      "command": "codebeaut@codesapienbe/jbang-tools",
-      "fullcommand": "jbang codebeaut@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "thumbgen",
-      "description": "\u003cp\u003eThumbnail generator for videos and images with batch processing, customizable templates, and automated optimization for different platforms.\u003c/p\u003e\n",
-      "scriptRef": "thumbgen/ThumbGen.java",
-      "command": "thumbgen@codesapienbe/jbang-tools",
-      "fullcommand": "jbang thumbgen@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "watermark",
-      "description": "\u003cp\u003eBatch watermarking tool with customizable overlays, transparency control, position management, and copyright protection features.\u003c/p\u003e\n",
-      "scriptRef": "watermark/Watermark.java",
-      "command": "watermark@codesapienbe/jbang-tools",
-      "fullcommand": "jbang watermark@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "fontmgr",
-      "description": "\u003cp\u003eFont management tool with preview capabilities, installation automation, collection organization, and licensing compliance tracking.\u003c/p\u003e\n",
-      "scriptRef": "fontmgr/FontMgr.java",
-      "command": "fontmgr@codesapienbe/jbang-tools",
-      "fullcommand": "jbang fontmgr@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "colorpal",
-      "description": "\u003cp\u003eColor palette generator and manager with accessibility checking, brand consistency tools, and design system integration.\u003c/p\u003e\n",
-      "scriptRef": "colorpal/ColorPal.java",
-      "command": "colorpal@codesapienbe/jbang-tools",
-      "fullcommand": "jbang colorpal@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "designkit",
-      "description": "\u003cp\u003eDesign toolkit with asset management, style guide generation, mockup creation, and collaboration features for design teams.\u003c/p\u003e\n",
-      "scriptRef": "designkit/DesignKit.java",
-      "command": "designkit@codesapienbe/jbang-tools",
-      "fullcommand": "jbang designkit@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "brandkit",
-      "description": "\u003cp\u003eBrand management tool with logo variations, color schemes, typography guidelines, and asset distribution with usage tracking.\u003c/p\u003e\n",
-      "scriptRef": "brandkit/BrandKit.java",
-      "command": "brandkit@codesapienbe/jbang-tools",
-      "fullcommand": "jbang brandkit@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "healthlog",
-      "description": "\u003cp\u003eComprehensive health tracking with symptom logging, medication reminders, doctor appointment scheduling, and health trend analysis with AI insights.\u003c/p\u003e\n",
-      "scriptRef": "healthlog/HealthLog.java",
-      "command": "healthlog@codesapienbe/jbang-tools",
-      "fullcommand": "jbang healthlog@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "fittrack",
-      "description": "\u003cp\u003eFitness tracker with workout planning, progress monitoring, nutrition guidance, and integration with wearable devices and health platforms.\u003c/p\u003e\n",
-      "scriptRef": "fittrack/FitTrack.java",
-      "command": "fittrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang fittrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "sleepmon",
-      "description": "\u003cp\u003eSleep monitor with pattern analysis, quality assessment, improvement recommendations, and integration with smart home devices for optimization.\u003c/p\u003e\n",
-      "scriptRef": "sleepmon/SleepMon.java",
-      "command": "sleepmon@codesapienbe/jbang-tools",
-      "fullcommand": "jbang sleepmon@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "moodtrack",
-      "description": "\u003cp\u003eMood tracking with pattern recognition, trigger identification, wellness suggestions, and mental health resources with professional referrals.\u003c/p\u003e\n",
-      "scriptRef": "moodtrack/MoodTrack.java",
-      "command": "moodtrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang moodtrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "waterrem",
-      "description": "\u003cp\u003eWater intake reminder with consumption tracking, hydration goals, health insights, and personalized recommendations based on activity levels.\u003c/p\u003e\n",
-      "scriptRef": "waterrem/WaterRem.java",
-      "command": "waterrem@codesapienbe/jbang-tools",
-      "fullcommand": "jbang waterrem@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "breathe",
-      "description": "\u003cp\u003eBreathing exercise guide with stress reduction techniques, meditation timers, relaxation programs, and biometric feedback integration.\u003c/p\u003e\n",
-      "scriptRef": "breathe/Breathe.java",
-      "command": "breathe@codesapienbe/jbang-tools",
-      "fullcommand": "jbang breathe@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "eyecare",
-      "description": "\u003cp\u003eEye care reminder with break scheduling, exercise routines, blue light monitoring, and vision health tracking with professional recommendations.\u003c/p\u003e\n",
-      "scriptRef": "eyecare/EyeCare.java",
-      "command": "eyecare@codesapienbe/jbang-tools",
-      "fullcommand": "jbang eyecare@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "posture",
-      "description": "\u003cp\u003ePosture monitoring with correction reminders, exercise suggestions, ergonomic assessments, and workplace optimization recommendations.\u003c/p\u003e\n",
-      "scriptRef": "posture/Posture.java",
-      "command": "posture@codesapienbe/jbang-tools",
-      "fullcommand": "jbang posture@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "langlearn",
-      "description": "\u003cp\u003eLanguage learning platform with spaced repetition, pronunciation practice, progress tracking, and cultural context integration with native speaker connections.\u003c/p\u003e\n",
-      "scriptRef": "langlearn/LangLearn.java",
-      "command": "langlearn@codesapienbe/jbang-tools",
-      "fullcommand": "jbang langlearn@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "skilltrack",
-      "description": "\u003cp\u003eSkill development tracker with learning paths, progress monitoring, certification management, and career advancement recommendations.\u003c/p\u003e\n",
-      "scriptRef": "skilltrack/SkillTrack.java",
-      "command": "skilltrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang skilltrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "studyplan",
-      "description": "\u003cp\u003eStudy planner with schedule optimization, progress tracking, performance analytics, and adaptive learning algorithms with peer collaboration.\u003c/p\u003e\n",
-      "scriptRef": "studyplan/StudyPlan.java",
-      "command": "studyplan@codesapienbe/jbang-tools",
-      "fullcommand": "jbang studyplan@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "flashcard",
-      "description": "\u003cp\u003eIntelligent flashcard system with spaced repetition algorithms, multimedia support, and collaborative study groups with performance analytics.\u003c/p\u003e\n",
-      "scriptRef": "flashcard/FlashCard.java",
-      "command": "flashcard@codesapienbe/jbang-tools",
-      "fullcommand": "jbang flashcard@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "quizgen",
-      "description": "\u003cp\u003eQuiz generator with automatic question creation, difficulty adjustment, performance analysis, and adaptive testing with learning insights.\u003c/p\u003e\n",
-      "scriptRef": "quizgen/QuizGen.java",
-      "command": "quizgen@codesapienbe/jbang-tools",
-      "fullcommand": "jbang quizgen@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "mindmap",
-      "description": "\u003cp\u003eMind mapping tool with collaborative features, export options, template libraries, and integration with note-taking and project management tools.\u003c/p\u003e\n",
-      "scriptRef": "mindmap/MindMap.java",
-      "command": "mindmap@codesapienbe/jbang-tools",
-      "fullcommand": "jbang mindmap@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "readtrack",
-      "description": "\u003cp\u003eReading tracker with progress monitoring, goal setting, recommendation systems, and book club integration with social features.\u003c/p\u003e\n",
-      "scriptRef": "readtrack/ReadTrack.java",
-      "command": "readtrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang readtrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "notelink",
-      "description": "\u003cp\u003eNote-taking system with intelligent linking, knowledge graphs, search capabilities, and cross-platform synchronization with AI organization.\u003c/p\u003e\n",
-      "scriptRef": "notelink/NoteLink.java",
-      "command": "notelink@codesapienbe/jbang-tools",
-      "fullcommand": "jbang notelink@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "certtrack",
-      "description": "\u003cp\u003eCertification tracker with renewal reminders, study planning, career path guidance, and industry requirement monitoring.\u003c/p\u003e\n",
-      "scriptRef": "certtrack/CertTrack.java",
-      "command": "certtrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang certtrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "knowbase",
-      "description": "\u003cp\u003eKnowledge base manager with AI-powered search, content organization, collaboration features, and expert system integration.\u003c/p\u003e\n",
-      "scriptRef": "knowbase/KnowBase.java",
-      "command": "knowbase@codesapienbe/jbang-tools",
-      "fullcommand": "jbang knowbase@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "gamelib",
-      "description": "\u003cp\u003eGame library manager with playtime tracking, achievement monitoring, recommendation systems, and social features with performance analytics.\u003c/p\u003e\n",
-      "scriptRef": "gamelib/GameLib.java",
-      "command": "gamelib@codesapienbe/jbang-tools",
-      "fullcommand": "jbang gamelib@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "movietrack",
-      "description": "\u003cp\u003eMovie and TV show tracker with watchlist management, rating systems, recommendation engines, and social sharing with review aggregation.\u003c/p\u003e\n",
-      "scriptRef": "movietrack/MovieTrack.java",
-      "command": "movietrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang movietrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "bookclub",
-      "description": "\u003cp\u003eBook club organizer with reading schedules, discussion forums, progress tracking, and author event integration with social features.\u003c/p\u003e\n",
-      "scriptRef": "bookclub/BookClub.java",
-      "command": "bookclub@codesapienbe/jbang-tools",
-      "fullcommand": "jbang bookclub@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "recipemgr",
-      "description": "\u003cp\u003eRecipe manager with meal planning, shopping list generation, nutritional analysis, and dietary restriction support with cooking timers.\u003c/p\u003e\n",
-      "scriptRef": "recipemgr/RecipeMgr.java",
-      "command": "recipemgr@codesapienbe/jbang-tools",
-      "fullcommand": "jbang recipemgr@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "travelplan",
-      "description": "\u003cp\u003eTravel planner with itinerary management, budget tracking, local recommendations, and real-time updates with emergency assistance.\u003c/p\u003e\n",
-      "scriptRef": "travelplan/TravelPlan.java",
-      "command": "travelplan@codesapienbe/jbang-tools",
-      "fullcommand": "jbang travelplan@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "hobbytrack",
-      "description": "\u003cp\u003eHobby tracker with project management, progress monitoring, community features, and skill development with tutorial integration.\u003c/p\u003e\n",
-      "scriptRef": "hobbytrack/HobbyTrack.java",
-      "command": "hobbytrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang hobbytrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "eventplan",
-      "description": "\u003cp\u003eEvent planner with guest management, budget tracking, timeline coordination, and vendor management with automated reminders.\u003c/p\u003e\n",
-      "scriptRef": "eventplan/EventPlan.java",
-      "command": "eventplan@codesapienbe/jbang-tools",
-      "fullcommand": "jbang eventplan@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "gifttrack",
-      "description": "\u003cp\u003eGift tracker with occasion reminders, budget management, recipient preferences, and purchase history with recommendation engine.\u003c/p\u003e\n",
-      "scriptRef": "gifttrack/GiftTrack.java",
-      "command": "gifttrack@codesapienbe/jbang-tools",
-      "fullcommand": "jbang gifttrack@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "petcare",
-      "description": "\u003cp\u003ePet care manager with health tracking, appointment scheduling, care reminders, and veterinary integration with emergency contacts.\u003c/p\u003e\n",
-      "scriptRef": "petcare/PetCare.java",
-      "command": "petcare@codesapienbe/jbang-tools",
-      "fullcommand": "jbang petcare@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124777905?v\u003d4",
-      "repoOwner": "codesapienbe",
-      "repoName": "jbang-tools",
-      "alias": "plantcare",
-      "description": "\u003cp\u003ePlant care assistant with watering schedules, growth tracking, care instructions, and disease identification with expert consultation.\u003c/p\u003e\n",
-      "scriptRef": "plantcare/PlantCare.java",
-      "command": "plantcare@codesapienbe/jbang-tools",
-      "fullcommand": "jbang plantcare@codesapienbe/jbang-tools",
-      "link": "https://github.com/codesapienbe/jbang-tools/blob/f2141d349333e0952f3b1842f17f4fd33b6344fb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/59115480?v\u003d4",
-      "repoOwner": "kordamp",
-      "repoName": "jbang-catalog",
-      "alias": "pomchecker",
-      "description": "\u003cp\u003eChecks POM files may be uploaded to Maven Central\u003c/p\u003e\n",
-      "scriptRef": "pomchecker.java",
-      "command": "pomchecker@kordamp",
-      "fullcommand": "jbang pomchecker@kordamp",
-      "link": "https://github.com/kordamp/jbang-catalog/blob/8cb01f2e6c5d97886b75f4060afa9098fae6e6ee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/59115480?v\u003d4",
-      "repoOwner": "kordamp",
-      "repoName": "jbang-catalog",
-      "alias": "pomchecker-snapshot",
-      "description": "\u003cp\u003eChecks POM files may be uploaded to Maven Central\u003c/p\u003e\n",
-      "scriptRef": "pomchecker_snapshot.java",
-      "command": "pomchecker-snapshot@kordamp",
-      "fullcommand": "jbang pomchecker-snapshot@kordamp",
-      "link": "https://github.com/kordamp/jbang-catalog/blob/8cb01f2e6c5d97886b75f4060afa9098fae6e6ee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/59115480?v\u003d4",
-      "repoOwner": "kordamp",
-      "repoName": "jbang-catalog",
-      "alias": "jarviz-snapshot",
-      "description": "\u003cp\u003eJAR file analyzer\u003c/p\u003e\n",
-      "scriptRef": "jarviz_snapshot.java",
-      "command": "jarviz-snapshot@kordamp",
-      "fullcommand": "jbang jarviz-snapshot@kordamp",
-      "link": "https://github.com/kordamp/jbang-catalog/blob/8cb01f2e6c5d97886b75f4060afa9098fae6e6ee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/59115480?v\u003d4",
-      "repoOwner": "kordamp",
-      "repoName": "jbang-catalog",
-      "alias": "jarviz",
-      "description": "\u003cp\u003eJAR file analyzer\u003c/p\u003e\n",
-      "scriptRef": "jarviz.java",
-      "command": "jarviz@kordamp",
-      "fullcommand": "jbang jarviz@kordamp",
-      "link": "https://github.com/kordamp/jbang-catalog/blob/8cb01f2e6c5d97886b75f4060afa9098fae6e6ee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/59115480?v\u003d4",
-      "repoOwner": "kordamp",
-      "repoName": "jbang-catalog",
-      "alias": "naum-snapshot",
-      "description": "\u003cp\u003eJava binary compatibility checking tool\u003c/p\u003e\n",
-      "scriptRef": "naum_snapshot.java",
-      "command": "naum-snapshot@kordamp",
-      "fullcommand": "jbang naum-snapshot@kordamp",
-      "link": "https://github.com/kordamp/jbang-catalog/blob/8cb01f2e6c5d97886b75f4060afa9098fae6e6ee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "jafar-shell",
-      "description": "\u003cp\u003eInteractive CLI for exploring and analyzing Java Flight Recorder files with JfrPath query language\u003c/p\u003e\n",
-      "scriptRef": "io.btrace:jafar-shell:0.21.8",
-      "command": "jafar-shell@btraceio",
-      "fullcommand": "jbang jafar-shell@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "jafar-shell-latest",
-      "description": "\u003cp\u003eJFR Shell latest development version\u003c/p\u003e\n",
-      "scriptRef": "jafar-shell-latest.java",
-      "command": "jafar-shell-latest@btraceio",
-      "fullcommand": "jbang jafar-shell-latest@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "jfr-shell",
-      "description": "\u003cp\u003eLegacy alias for jafar-shell (use jafar-shell instead)\u003c/p\u003e\n",
-      "scriptRef": "jafar-shell.java",
-      "command": "jfr-shell@btraceio",
-      "fullcommand": "jbang jfr-shell@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "jfr-mcp",
-      "description": "\u003cp\u003eJFR MCP Server; snapshot version\u003c/p\u003e\n",
-      "scriptRef": "io.btrace:jfr-mcp:0.21.8",
-      "command": "jfr-mcp@btraceio",
-      "fullcommand": "jbang jfr-mcp@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "jfr-mcp-latest",
-      "description": "\u003cp\u003eJFR MCP Server latest development version\u003c/p\u003e\n",
-      "scriptRef": "jfr-mcp-latest.java",
-      "command": "jfr-mcp-latest@btraceio",
-      "fullcommand": "jbang jfr-mcp-latest@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "btrace",
-      "description": "\u003cp\u003eBTrace client launcher\u003c/p\u003e\n",
-      "scriptRef": "btrace.java",
-      "command": "btrace@btraceio",
-      "fullcommand": "jbang btrace@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/16762720?v\u003d4",
-      "repoOwner": "btraceio",
-      "repoName": "jbang-catalog",
-      "alias": "btrace-latest",
-      "description": "\u003cp\u003eBTrace client launcher (latest snapshot)\u003c/p\u003e\n",
-      "scriptRef": "btrace-latest.java",
-      "command": "btrace-latest@btraceio",
-      "fullcommand": "jbang btrace-latest@btraceio",
-      "link": "https://github.com/btraceio/jbang-catalog/blob/a77d2c414b468976996bde902ffe26a419a38593/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "grep",
-      "description": "\u003cp\u003eFind substring like grep\u003c/p\u003e\n",
-      "scriptRef": "find_grep.java",
-      "command": "grep@a-services",
-      "fullcommand": "jbang grep@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "csv",
-      "description": "\u003cp\u003eExport CSV file from database table\u003c/p\u003e\n",
-      "scriptRef": "csv_from_db.java",
-      "command": "csv@a-services",
-      "fullcommand": "jbang csv@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "images2pdf",
-      "description": "\u003cp\u003eCreate PDF from images\u003c/p\u003e\n",
-      "scriptRef": "images2pdf.java",
-      "command": "images2pdf@a-services",
-      "fullcommand": "jbang images2pdf@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "strapdownjs",
-      "description": "\u003cp\u003eCreate HTML from markdown using strapdownjs\u003c/p\u003e\n",
-      "scriptRef": "strapdownjs.java",
-      "command": "strapdownjs@a-services",
-      "fullcommand": "jbang strapdownjs@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "folder_sizes",
-      "description": "\u003cp\u003eRead and write CSV with folder sizes\u003c/p\u003e\n",
-      "scriptRef": "folder_sizes.java",
-      "command": "folder_sizes@a-services",
-      "fullcommand": "jbang folder_sizes@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "find_cordova",
-      "description": "\u003cp\u003eSearch Cordova 8.x docs\u003c/p\u003e\n",
-      "scriptRef": "find_cordova.java",
-      "command": "find_cordova@a-services",
-      "fullcommand": "jbang find_cordova@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "paste_log",
-      "description": "\u003cp\u003ePaste log from clipboard to file\u003c/p\u003e\n",
-      "scriptRef": "paste_log.java",
-      "command": "paste_log@a-services",
-      "fullcommand": "jbang paste_log@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "ts_imports",
-      "description": "\u003cp\u003eFind list of TypeScript imports in folder\u003c/p\u003e\n",
-      "scriptRef": "ts_imports.java",
-      "command": "ts_imports@a-services",
-      "fullcommand": "jbang ts_imports@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "exc",
-      "description": "\u003cp\u003eChecking for exceptions in log file\u003c/p\u003e\n",
-      "scriptRef": "exc.java",
-      "command": "exc@a-services",
-      "fullcommand": "jbang exc@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "yml_table",
-      "description": "\u003cp\u003eConvert YAML list to HTML\u003c/p\u003e\n",
-      "scriptRef": "yml_table.java",
-      "command": "yml_table@a-services",
-      "fullcommand": "jbang yml_table@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "calibre_page",
-      "description": "\u003cp\u003eExtract page from HTML created by Calibre\u003c/p\u003e\n",
-      "scriptRef": "calibre_page.java",
-      "command": "calibre_page@a-services",
-      "fullcommand": "jbang calibre_page@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "fix_chapters",
-      "description": "\u003cp\u003eFix numbers in markdown chapters\u003c/p\u003e\n",
-      "scriptRef": "fix_chapters.java",
-      "command": "fix_chapters@a-services",
-      "fullcommand": "jbang fix_chapters@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "svg_icons",
-      "description": "\u003cp\u003eCreate set of png icons from svg file\u003c/p\u003e\n",
-      "scriptRef": "svg_icons.java",
-      "command": "svg_icons@a-services",
-      "fullcommand": "jbang svg_icons@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "har2postman",
-      "description": "\u003cp\u003eConvert HAR file with HTTP requests exported from Chrome to Postman collection\u003c/p\u003e\n",
-      "scriptRef": "har2postman.java",
-      "command": "har2postman@a-services",
-      "fullcommand": "jbang har2postman@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "file_index",
-      "description": "\u003cp\u003eGenerate index of files for current folder\u003c/p\u003e\n",
-      "scriptRef": "file_index.java",
-      "command": "file_index@a-services",
-      "fullcommand": "jbang file_index@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "p_stats",
-      "description": "\u003cp\u003eCalculate project stats\u003c/p\u003e\n",
-      "scriptRef": "p_stats.java",
-      "command": "p_stats@a-services",
-      "fullcommand": "jbang p_stats@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "extract_html_headers",
-      "description": "\u003cp\u003eExtract header tags from html file as indented text to create table of contents\u003c/p\u003e\n",
-      "scriptRef": "extract_html_headers.java",
-      "command": "extract_html_headers@a-services",
-      "fullcommand": "jbang extract_html_headers@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "bookserver",
-      "description": "\u003cp\u003eHTTP server that serves markdown files from folder which name ends with \u003ccode\u003e Book\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "bookserver.java",
-      "command": "bookserver@a-services",
-      "fullcommand": "jbang bookserver@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "udemy_html_toc",
-      "description": "\u003cp\u003eParse html file with Udemy course TOC\u003c/p\u003e\n",
-      "scriptRef": "udemy_html_toc.java",
-      "command": "udemy_html_toc@a-services",
-      "fullcommand": "jbang udemy_html_toc@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "remove_html",
-      "description": "\u003cp\u003eRemove html tags from markdown file\u003c/p\u003e\n",
-      "scriptRef": "remove_html.java",
-      "command": "remove_html@a-services",
-      "fullcommand": "jbang remove_html@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "replace_br",
-      "description": "\u003cp\u003eReplace \u0026lt;br\u0026gt; tags with newlines\u003c/p\u003e\n",
-      "scriptRef": "replace_br.java",
-      "command": "replace_br@a-services",
-      "fullcommand": "jbang replace_br@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "cmp_tstamps",
-      "description": "\u003cp\u003eCompare timestamps in two folders\u003c/p\u003e\n",
-      "scriptRef": "cmp_tstamps.java",
-      "command": "cmp_tstamps@a-services",
-      "fullcommand": "jbang cmp_tstamps@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "obsidian_folder",
-      "description": "\u003cp\u003eConvert Obsidian folder to HTML\u003c/p\u003e\n",
-      "scriptRef": "obsidian_folder.java",
-      "command": "obsidian_folder@a-services",
-      "fullcommand": "jbang obsidian_folder@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "git_changes",
-      "description": "\u003cp\u003eCopy added/changed files from git to backup folder\u003c/p\u003e\n",
-      "scriptRef": "git_changes.java",
-      "command": "git_changes@a-services",
-      "fullcommand": "jbang git_changes@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "tommy",
-      "description": "\u003cp\u003eTomcat - Create Windows Deployment Scripts\u003c/p\u003e\n",
-      "scriptRef": "tommy.java",
-      "command": "tommy@a-services",
-      "fullcommand": "jbang tommy@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "README",
-      "description": "\u003cp\u003eGenerate \u003ccode\u003eREADME.adoc\u003c/code\u003e from \u003ccode\u003ejbang-catalog.json\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "README.java",
-      "command": "README@a-services",
-      "fullcommand": "jbang README@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "ai_note",
-      "description": "\u003cp\u003eRunning OpenAI prompts\u003c/p\u003e\n",
-      "scriptRef": "ai_note.java",
-      "command": "ai_note@a-services",
-      "fullcommand": "jbang ai_note@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "maven_deps",
-      "description": "\u003cp\u003eExtract maven dependency tree for each project in current folder\u003c/p\u003e\n",
-      "scriptRef": "maven_deps.java",
-      "command": "maven_deps@a-services",
-      "fullcommand": "jbang maven_deps@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "o_ed",
-      "description": "\u003cp\u003eObsidian Web Editor\u003c/p\u003e\n",
-      "scriptRef": "o_ed.java",
-      "command": "o_ed@a-services",
-      "fullcommand": "jbang o_ed@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "tree",
-      "description": "\u003cp\u003eDirectory tree in ASCII symbols up to a specified depth\u003c/p\u003e\n",
-      "scriptRef": "tree.java",
-      "command": "tree@a-services",
-      "fullcommand": "jbang tree@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "insert_files",
-      "description": "\u003cp\u003eReplace file names with the contents of the respective files\u003c/p\u003e\n",
-      "scriptRef": "insert_files.java",
-      "command": "insert_files@a-services",
-      "fullcommand": "jbang insert_files@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "copy_box",
-      "description": "\u003cp\u003eCopy binary file to clipboard or paste it back from clipboard to binary file.\u003c/p\u003e\n",
-      "scriptRef": "copy_box.java",
-      "command": "copy_box@a-services",
-      "fullcommand": "jbang copy_box@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/26920499?v\u003d4",
-      "repoOwner": "a-services",
-      "repoName": "jbang-catalog",
-      "alias": "grafana_log",
-      "description": "\u003cp\u003eExtracts JSON \u0027body\u0027 field from the CSV \u0027Line\u0027 column into a .log file.\u003c/p\u003e\n",
-      "scriptRef": "grafana_log.java",
-      "command": "grafana_log@a-services",
-      "fullcommand": "jbang grafana_log@a-services",
-      "link": "https://github.com/a-services/jbang-catalog/blob/e971f8d8b4397c5eb6b450f2f6a5b97159cbc65c/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "pgcheck-mcp",
-      "alias": "pgcheck-mcp",
-      "description": "\u003cp\u003ePostgreSQL MCP Server with connection pooling\u003c/p\u003e\n",
-      "scriptRef": "PgcheckMcpServer.java",
-      "command": "pgcheck-mcp@garodriguezlp/pgcheck-mcp",
-      "fullcommand": "jbang pgcheck-mcp@garodriguezlp/pgcheck-mcp",
-      "link": "https://github.com/garodriguezlp/pgcheck-mcp/blob/2c752df0259bbb94a60866ae79beaf1cd425e757/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/76028870?v\u003d4",
-      "repoOwner": "Maps-Messaging",
-      "repoName": "mapsmessaging-jbang",
-      "alias": "mapsmessaging",
-      "description": "\u003cp\u003eMAPS Messaging Server\u003c/p\u003e\n",
-      "scriptRef": "MAPS_Messaging.java",
-      "command": "mapsmessaging@Maps-Messaging/mapsmessaging-jbang",
-      "fullcommand": "jbang mapsmessaging@Maps-Messaging/mapsmessaging-jbang",
-      "link": "https://github.com/Maps-Messaging/mapsmessaging-jbang/blob/1a3a78fec009029e8bf55bac912f9303e11844c9/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "hello",
-      "scriptRef": "hello.jsh",
-      "command": "hello@aswiniqaconsultants/jbangdev~itests",
-      "fullcommand": "jbang hello@aswiniqaconsultants/jbangdev~itests",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "echo",
-      "description": "\u003cp\u003eecho echo echo description\u003c/p\u003e\n",
-      "scriptRef": "echo.java",
-      "command": "echo@aswiniqaconsultants/jbangdev~itests",
-      "fullcommand": "jbang echo@aswiniqaconsultants/jbangdev~itests",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "resource",
-      "scriptRef": "res/resource.java",
-      "command": "resource@aswiniqaconsultants/jbangdev~itests",
-      "fullcommand": "jbang resource@aswiniqaconsultants/jbangdev~itests",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/3914421?v\u003d4",
-      "repoOwner": "JabRef",
-      "repoName": "jbang-catalog",
-      "alias": "jabkit",
-      "scriptRef": "https://github.com/JabRef/jabref/blob/main/.jbang/JabKitLauncher.java",
-      "command": "jabkit@JabRef",
-      "fullcommand": "jbang jabkit@JabRef",
-      "link": "https://github.com/JabRef/jbang-catalog/blob/c512c0c05e303fa82862001a042dd3d078b24e6b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/3914421?v\u003d4",
-      "repoOwner": "JabRef",
-      "repoName": "jbang-catalog",
-      "alias": "jabls",
-      "scriptRef": "https://github.com/JabRef/jabref/blob/main/.jbang/JabLsLauncher.java",
-      "command": "jabls@JabRef",
-      "fullcommand": "jbang jabls@JabRef",
-      "link": "https://github.com/JabRef/jbang-catalog/blob/c512c0c05e303fa82862001a042dd3d078b24e6b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/3914421?v\u003d4",
-      "repoOwner": "JabRef",
-      "repoName": "jbang-catalog",
-      "alias": "jabsrv",
-      "scriptRef": "https://github.com/JabRef/jabref/blob/main/.jbang/JabSrvLauncher.java",
-      "command": "jabsrv@JabRef",
-      "fullcommand": "jbang jabsrv@JabRef",
-      "link": "https://github.com/JabRef/jbang-catalog/blob/c512c0c05e303fa82862001a042dd3d078b24e6b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/335133?v\u003d4",
-      "repoOwner": "sebastienblanc",
-      "repoName": "limit-request",
-      "alias": "kubectl-limit",
-      "scriptRef": "src/kubectl-limit",
-      "command": "kubectl-limit@sebastienblanc/limit-request",
-      "fullcommand": "jbang kubectl-limit@sebastienblanc/limit-request",
-      "link": "https://github.com/sebastienblanc/limit-request/blob/010bc8d7617ddfec40ca609cc0e29234735600b0/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1005263?v\u003d4",
-      "repoOwner": "dotCMS",
-      "repoName": "jbang-catalog",
-      "alias": "qcli-jbang",
-      "description": "\u003cp\u003eapp -- Sample Quarkus CLI application\u003c/p\u003e\n",
-      "scriptRef": "qcli_jbang.java",
-      "command": "qcli-jbang@dotCMS",
-      "fullcommand": "jbang qcli-jbang@dotCMS",
-      "link": "https://github.com/dotCMS/jbang-catalog/blob/27796bbff9fe53ff9bde15ba1ca37dbf991ab064/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1005263?v\u003d4",
-      "repoOwner": "dotCMS",
-      "repoName": "jbang-catalog",
-      "alias": "jreleaser-cli-snapshot",
-      "description": "\u003cp\u003eapp -- Sample Quarkus CLI application\u003c/p\u003e\n",
-      "scriptRef": "jreleaser_cli_snapshot.java",
-      "command": "jreleaser-cli-snapshot@dotCMS",
-      "fullcommand": "jbang jreleaser-cli-snapshot@dotCMS",
-      "link": "https://github.com/dotCMS/jbang-catalog/blob/27796bbff9fe53ff9bde15ba1ca37dbf991ab064/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1005263?v\u003d4",
-      "repoOwner": "dotCMS",
-      "repoName": "jbang-catalog",
-      "alias": "dotcms-cli-snapshot",
-      "description": "\u003cp\u003eapp -- DotCMS CLI\u003c/p\u003e\n",
-      "scriptRef": "dotcms_cli_snapshot.java",
-      "command": "dotcms-cli-snapshot@dotCMS",
-      "fullcommand": "jbang dotcms-cli-snapshot@dotCMS",
-      "link": "https://github.com/dotCMS/jbang-catalog/blob/27796bbff9fe53ff9bde15ba1ca37dbf991ab064/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1005263?v\u003d4",
-      "repoOwner": "dotCMS",
-      "repoName": "jbang-catalog",
-      "alias": "dotcms-cli",
-      "description": "\u003cp\u003eapp -- DotCMS CLI\u003c/p\u003e\n",
-      "scriptRef": "dotcms_cli.java",
-      "command": "dotcms-cli@dotCMS",
-      "fullcommand": "jbang dotcms-cli@dotCMS",
-      "link": "https://github.com/dotCMS/jbang-catalog/blob/27796bbff9fe53ff9bde15ba1ca37dbf991ab064/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1853182?v\u003d4",
-      "repoOwner": "Lewik",
-      "repoName": "mcp-tools-proxy",
-      "alias": "mcpproxy",
-      "description": "\u003cp\u003eMCP Tools Proxy CLI\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/Lewik/mcp-tools-proxy/releases/download/v0.1.5/mcp-tools-proxy.jar",
-      "command": "mcpproxy@Lewik/mcp-tools-proxy",
-      "fullcommand": "jbang mcpproxy@Lewik/mcp-tools-proxy",
-      "link": "https://github.com/Lewik/mcp-tools-proxy/blob/1e16bd45674b86a560497bdb7a1e3bdbbb436744/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124075?v\u003d4",
-      "repoOwner": "dsyer",
-      "repoName": "java-jupyter",
-      "alias": "app",
-      "description": "\u003cp\u003eApplication\u003c/p\u003e\n",
-      "scriptRef": "src/main/java/com/example/Application.java",
-      "command": "app@dsyer/java-jupyter",
-      "fullcommand": "jbang app@dsyer/java-jupyter",
-      "link": "https://github.com/dsyer/java-jupyter/blob/569585edb509bf1218600c9457807d31850fd093/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/124075?v\u003d4",
-      "repoOwner": "dsyer",
-      "repoName": "java-jupyter",
-      "alias": "db",
-      "description": "\u003cp\u003eH2 Database\u003c/p\u003e\n",
-      "scriptRef": "h2@jbanghub/h2",
-      "command": "db@dsyer/java-jupyter",
-      "fullcommand": "jbang db@dsyer/java-jupyter",
-      "link": "https://github.com/dsyer/java-jupyter/blob/569585edb509bf1218600c9457807d31850fd093/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/37168181?v\u003d4",
-      "repoOwner": "ArjunSai",
-      "repoName": "camel",
-      "alias": "CamelJBang",
-      "description": "\u003cp\u003eRun Apache Camel routes easily (deprecated - use camel instead)\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "CamelJBang@ArjunSai/camel",
-      "fullcommand": "jbang CamelJBang@ArjunSai/camel",
-      "link": "https://github.com/ArjunSai/camel/blob/2c1451aab95bc2ee232e4b20ca27e6ebd613ea62/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/37168181?v\u003d4",
-      "repoOwner": "ArjunSai",
-      "repoName": "camel",
-      "alias": "camel",
-      "description": "\u003cp\u003eRun Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "camel@ArjunSai/camel",
-      "fullcommand": "jbang camel@ArjunSai/camel",
-      "link": "https://github.com/ArjunSai/camel/blob/2c1451aab95bc2ee232e4b20ca27e6ebd613ea62/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "asciidoc",
-      "scriptRef": "src/asciidoc.java",
-      "command": "asciidoc@wfouche",
-      "fullcommand": "jbang asciidoc@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "asciidoctorj",
-      "scriptRef": "src/asciidoctorj.java",
-      "command": "asciidoctorj@wfouche",
-      "fullcommand": "jbang asciidoctorj@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "asciidoctorj-cli",
-      "scriptRef": "src/asciidoctorj_cli.java",
-      "command": "asciidoctorj-cli@wfouche",
-      "fullcommand": "jbang asciidoctorj-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "camel",
-      "scriptRef": "camel@wfouche~/apps/camel/4.16.0",
-      "command": "camel@wfouche",
-      "fullcommand": "jbang camel@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "camel2",
-      "scriptRef": "camel@apps/camel/4.17.0/jbang-catalog.json",
-      "command": "camel2@wfouche",
-      "fullcommand": "jbang camel2@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "clojure",
-      "scriptRef": "src/Clojure.java",
-      "command": "clojure@wfouche",
-      "fullcommand": "jbang clojure@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "command-dev",
-      "scriptRef": "src/Command.java",
-      "command": "command-dev@wfouche",
-      "fullcommand": "jbang command-dev@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "command",
-      "scriptRef": "src/Command/1/Command.java",
-      "command": "command@wfouche",
-      "fullcommand": "jbang command@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "deps",
-      "scriptRef": "src/deps.java",
-      "command": "deps@wfouche",
-      "fullcommand": "jbang deps@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "java-cli",
-      "scriptRef": "src/JavaCli.java",
-      "command": "java-cli@wfouche",
-      "fullcommand": "jbang java-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "jgit",
-      "scriptRef": "src/jgit.java",
-      "command": "jgit@wfouche",
-      "fullcommand": "jbang jgit@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "jython-jpm",
-      "scriptRef": "src/JythonJpm.java",
-      "command": "jython-jpm@wfouche",
-      "fullcommand": "jbang jython-jpm@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "hello",
-      "scriptRef": "src/hello.java",
-      "command": "hello@wfouche",
-      "fullcommand": "jbang hello@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "import",
-      "scriptRef": "src/JBangImport.java",
-      "command": "import@wfouche",
-      "fullcommand": "jbang import@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "kwrk-dev",
-      "scriptRef": "src/kwrk.kt",
-      "command": "kwrk-dev@wfouche",
-      "fullcommand": "jbang kwrk-dev@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "kwrk",
-      "scriptRef": "src/kwrk/1/kwrk.kt",
-      "command": "kwrk@wfouche",
-      "fullcommand": "jbang kwrk@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "situi",
-      "scriptRef": "apps/situi/0.1.1/spring-initializr-tui-0.1.1.jar",
-      "command": "situi@wfouche",
-      "fullcommand": "jbang situi@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "snapshot-cli-dev",
-      "scriptRef": "src/SnapshotCli.java",
-      "command": "snapshot-cli-dev@wfouche",
-      "fullcommand": "jbang snapshot-cli-dev@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "snapshot-cli",
-      "scriptRef": "src/SnapshotCli/1/SnapshotCli.java",
-      "command": "snapshot-cli@wfouche",
-      "fullcommand": "jbang snapshot-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "testapp",
-      "scriptRef": "src/testapp/io/tulip/App.java",
-      "command": "testapp@wfouche",
-      "fullcommand": "jbang testapp@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "tulip-cli-dev",
-      "scriptRef": "src/TulipCli.java",
-      "command": "tulip-cli-dev@wfouche",
-      "fullcommand": "jbang tulip-cli-dev@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "tulip-cli",
-      "scriptRef": "src/TulipCli/1/TulipCli.java",
-      "command": "tulip-cli@wfouche",
-      "fullcommand": "jbang tulip-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "timestamp",
-      "scriptRef": "src/timestamp.java",
-      "command": "timestamp@wfouche",
-      "fullcommand": "jbang timestamp@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "wrapper-cli",
-      "scriptRef": "src/WrapperCli.java",
-      "command": "wrapper-cli@wfouche",
-      "fullcommand": "jbang wrapper-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "pong",
-      "scriptRef": "src/Pong.java",
-      "command": "pong@wfouche",
-      "fullcommand": "jbang pong@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "python-jvm-dev",
-      "scriptRef": "src/python_jvm.java",
-      "command": "python-jvm-dev@wfouche",
-      "fullcommand": "jbang python-jvm-dev@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "python-jvm",
-      "scriptRef": "src/python_jvm/1/python_jvm.java",
-      "command": "python-jvm@wfouche",
-      "fullcommand": "jbang python-jvm@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "python-cli",
-      "scriptRef": "src/python_cli.java",
-      "command": "python-cli@wfouche",
-      "fullcommand": "jbang python-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "jython-cli",
-      "scriptRef": "src/JythonCli.java",
-      "command": "jython-cli@wfouche",
-      "fullcommand": "jbang jython-cli@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "jython-java-fmt",
-      "description": "\u003cp\u003eFormats Java Source Code in src folder\u003c/p\u003e\n",
-      "scriptRef": "jbang-fmt@jbangdev/jbang-fmt",
-      "command": "jython-java-fmt@wfouche",
-      "fullcommand": "jbang jython-java-fmt@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "schemaspy",
-      "scriptRef": "src/SchemaSpy.java",
-      "command": "schemaspy@wfouche",
-      "fullcommand": "jbang schemaspy@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "show-version",
-      "scriptRef": "src/ShowVersion.java",
-      "command": "show-version@wfouche",
-      "fullcommand": "jbang show-version@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "camel-dev",
-      "scriptRef": "src/CamelJBang.java",
-      "command": "camel-dev@wfouche",
-      "fullcommand": "jbang camel-dev@wfouche",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "situi",
-      "scriptRef": "./spring-initializr-tui-0.1.1.jar",
-      "command": "situi@wfouche~apps/situi/0.1.1",
-      "fullcommand": "jbang situi@wfouche~apps/situi/0.1.1",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/apps/situi/0.1.1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/4481387?v\u003d4",
-      "repoOwner": "aucampia",
-      "repoName": "issues",
-      "alias": "datahub-protobuf-old",
-      "scriptRef": "https://raw.githubusercontent.com/datahub-project/datahub/b9068ffd2ef527a2b24b5d3828a9cc6c0f23b4fb/metadata-integration/java/datahub-protobuf-example/libs/datahub-protobuf.jar",
-      "command": "datahub-protobuf-old@aucampia/issues~20220908-datahub-protobuf",
-      "fullcommand": "jbang datahub-protobuf-old@aucampia/issues~20220908-datahub-protobuf",
-      "link": "https://github.com/aucampia/issues/blob/1fe5785fea45c6641b7d2daa221bef0bc11833bb/20220908-datahub-protobuf/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/4481387?v\u003d4",
-      "repoOwner": "aucampia",
-      "repoName": "issues",
-      "alias": "datahub-protobuf",
-      "scriptRef": "io.acryl:datahub-protobuf:0.8.44-2rc1",
-      "command": "datahub-protobuf@aucampia/issues~20220908-datahub-protobuf",
-      "fullcommand": "jbang datahub-protobuf@aucampia/issues~20220908-datahub-protobuf",
-      "link": "https://github.com/aucampia/issues/blob/1fe5785fea45c6641b7d2daa221bef0bc11833bb/20220908-datahub-protobuf/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/148698?v\u003d4",
-      "repoOwner": "fbricon",
-      "repoName": "jbang-catalog",
-      "alias": "lastweek",
-      "description": "\u003cp\u003eScript listing the commits that were published in my favourite repos for the past 7 days\u003c/p\u003e\n",
-      "scriptRef": "lastweek.java",
-      "command": "lastweek@fbricon",
-      "fullcommand": "jbang lastweek@fbricon",
-      "link": "https://github.com/fbricon/jbang-catalog/blob/ee8fc4c84a0f35a645bcdf008600a58753e872f0/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/56220728?v\u003d4",
-      "repoOwner": "codejive",
-      "repoName": "jbang-catalog",
-      "alias": "jpm",
-      "description": "\u003cp\u003eA simple command line tool, taking inspiration from Node\u0027s npm, to manage Maven dependencies for Java projects that are not using build systems like Maven or Gradle. See \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/codejive/java-jpm\"\u003eJpm website\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "org.codejive.jpm:jpm:0.6.4",
-      "command": "jpm@codejive",
-      "fullcommand": "jbang jpm@codejive",
-      "link": "https://github.com/codejive/jbang-catalog/blob/3afc11a8c108eb0089a46e34a1b9a68d1bfe600e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/56220728?v\u003d4",
-      "repoOwner": "codejive",
-      "repoName": "jbang-catalog",
-      "alias": "jpm-latest",
-      "description": "\u003cp\u003e[latest development version] A simple command line tool, taking inspiration from Node\u0027s npm, to manage Maven dependencies for Java projects that are not using build systems like Maven or Gradle. See \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/codejive/java-jpm\"\u003eJpm website\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/codejive/java-jpm/blob/main/src/main/java/org/codejive/jpm/Main.java",
-      "command": "jpm-latest@codejive",
-      "fullcommand": "jbang jpm-latest@codejive",
-      "link": "https://github.com/codejive/jbang-catalog/blob/3afc11a8c108eb0089a46e34a1b9a68d1bfe600e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/56220728?v\u003d4",
-      "repoOwner": "codejive",
-      "repoName": "jbang-catalog",
-      "alias": "jvm",
-      "description": "\u003cp\u003eA command line tool that helps you install and manage multiple Java versions on your machine. See \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/codejive/java-jvm\"\u003eJvm website\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "org.codejive.jvm:jvm:0.1.0",
-      "command": "jvm@codejive",
-      "fullcommand": "jbang jvm@codejive",
-      "link": "https://github.com/codejive/jbang-catalog/blob/3afc11a8c108eb0089a46e34a1b9a68d1bfe600e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/56220728?v\u003d4",
-      "repoOwner": "codejive",
-      "repoName": "jbang-catalog",
-      "alias": "jvm-latest",
-      "description": "\u003cp\u003e[latest development version] A command line tool that helps you install and manage multiple Java versions on your machine. See \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/codejive/java-jvm\"\u003eJvm website\u003c/a\u003e\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/codejive/java-jvm/blob/main/src/main/java/org/codejive/jvm/Main.java",
-      "command": "jvm-latest@codejive",
-      "fullcommand": "jbang jvm-latest@codejive",
-      "link": "https://github.com/codejive/jbang-catalog/blob/3afc11a8c108eb0089a46e34a1b9a68d1bfe600e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/69006381?v\u003d4",
-      "repoOwner": "redis-developer",
-      "repoName": "jbang-catalog",
-      "alias": "riot-snapshot",
-      "description": "\u003cp\u003eGet data in and out of Redis with RIOT\u003c/p\u003e\n",
-      "scriptRef": "riot_snapshot.java",
-      "command": "riot-snapshot@redis-developer",
-      "fullcommand": "jbang riot-snapshot@redis-developer",
-      "link": "https://github.com/redis-developer/jbang-catalog/blob/aa4b66671235f1c6a2b916edca57ada4b2de8c22/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/69006381?v\u003d4",
-      "repoOwner": "redis-developer",
-      "repoName": "jbang-catalog",
-      "alias": "riot",
-      "description": "\u003cp\u003eGet data in and out of Redis with RIOT\u003c/p\u003e\n",
-      "scriptRef": "riot.java",
-      "command": "riot@redis-developer",
-      "fullcommand": "jbang riot@redis-developer",
-      "link": "https://github.com/redis-developer/jbang-catalog/blob/aa4b66671235f1c6a2b916edca57ada4b2de8c22/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "hello",
-      "scriptRef": "hello.jsh",
-      "command": "hello@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang hello@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "helloworld",
-      "scriptRef": "helloworld.java",
-      "command": "helloworld@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang helloworld@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "echo",
-      "description": "\u003cp\u003eecho echo echo description\u003c/p\u003e\n",
-      "scriptRef": "echo.java",
-      "command": "echo@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang echo@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "resource",
-      "scriptRef": "res/resource.java",
-      "command": "resource@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang resource@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "alltags",
-      "description": "\u003cp\u003etwodesc\u003c/p\u003e\n",
-      "scriptRef": "alltags.java",
-      "command": "alltags@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang alltags@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "hellojar",
-      "description": "\u003cp\u003etwodesc\u003c/p\u003e\n",
-      "scriptRef": "hellojar.jar",
-      "command": "hellojar@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang hellojar@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "pgmgav",
-      "description": "\u003cp\u003etwodesc\u003c/p\u003e\n",
-      "scriptRef": "org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r",
-      "command": "pgmgav@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang pgmgav@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/32136482?v\u003d4",
-      "repoOwner": "javatechno",
-      "repoName": "camel",
-      "alias": "camel",
-      "description": "\u003cp\u003eRun Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "camel@javatechno/camel",
-      "fullcommand": "jbang camel@javatechno/camel",
-      "link": "https://github.com/javatechno/camel/blob/6e9c0299a5cc44b110c758cee99d06ea8a99ef22/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/191113961?v\u003d4",
-      "repoOwner": "comute",
-      "repoName": "CamelPMD",
-      "alias": "camel",
-      "description": "\u003cp\u003eRun Apache Camel routes easily\u003c/p\u003e\n",
-      "scriptRef": "dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java",
-      "command": "camel@comute/CamelPMD",
-      "fullcommand": "jbang camel@comute/CamelPMD",
-      "link": "https://github.com/comute/CamelPMD/blob/820f7a6febe04773d0524848c7a1558227a4dddb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/52125841?v\u003d4",
-      "repoOwner": "TheShubham-K",
-      "repoName": "getting-started-with-springboot",
-      "alias": "hello",
-      "scriptRef": "hello.java",
-      "command": "hello@TheShubham-K/getting-started-with-springboot~jbang",
-      "fullcommand": "jbang hello@TheShubham-K/getting-started-with-springboot~jbang",
-      "link": "https://github.com/TheShubham-K/getting-started-with-springboot/blob/7c1d7f60541f1d6fead15de987107c135a1914ee/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/52125841?v\u003d4",
-      "repoOwner": "TheShubham-K",
-      "repoName": "getting-started-with-springboot",
-      "alias": "hellocli",
-      "scriptRef": "hellocli.java",
-      "command": "hellocli@TheShubham-K/getting-started-with-springboot~jbang",
-      "fullcommand": "jbang hellocli@TheShubham-K/getting-started-with-springboot~jbang",
-      "link": "https://github.com/TheShubham-K/getting-started-with-springboot/blob/7c1d7f60541f1d6fead15de987107c135a1914ee/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/52125841?v\u003d4",
-      "repoOwner": "TheShubham-K",
-      "repoName": "getting-started-with-springboot",
-      "alias": "jbangquarkus",
-      "scriptRef": "jbangquarkus.java",
-      "command": "jbangquarkus@TheShubham-K/getting-started-with-springboot~jbang",
-      "fullcommand": "jbang jbangquarkus@TheShubham-K/getting-started-with-springboot~jbang",
-      "link": "https://github.com/TheShubham-K/getting-started-with-springboot/blob/7c1d7f60541f1d6fead15de987107c135a1914ee/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/34202657?v\u003d4",
-      "repoOwner": "addagadavasubabu",
-      "repoName": "devops-tasks",
-      "alias": "hello",
-      "scriptRef": "hello.java",
-      "command": "hello@addagadavasubabu/devops-tasks~jbang",
-      "fullcommand": "jbang hello@addagadavasubabu/devops-tasks~jbang",
-      "link": "https://github.com/addagadavasubabu/devops-tasks/blob/0c109237a3c66a178873991c67d4aab73e8ca3d6/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/34202657?v\u003d4",
-      "repoOwner": "addagadavasubabu",
-      "repoName": "devops-tasks",
-      "alias": "hellocli",
-      "scriptRef": "hellocli.java",
-      "command": "hellocli@addagadavasubabu/devops-tasks~jbang",
-      "fullcommand": "jbang hellocli@addagadavasubabu/devops-tasks~jbang",
-      "link": "https://github.com/addagadavasubabu/devops-tasks/blob/0c109237a3c66a178873991c67d4aab73e8ca3d6/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/34202657?v\u003d4",
-      "repoOwner": "addagadavasubabu",
-      "repoName": "devops-tasks",
-      "alias": "jbangquarkus",
-      "scriptRef": "jbangquarkus.java",
-      "command": "jbangquarkus@addagadavasubabu/devops-tasks~jbang",
-      "fullcommand": "jbang jbangquarkus@addagadavasubabu/devops-tasks~jbang",
-      "link": "https://github.com/addagadavasubabu/devops-tasks/blob/0c109237a3c66a178873991c67d4aab73e8ca3d6/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/31179784?v\u003d4",
-      "repoOwner": "zubairmujeeb",
-      "repoName": "spring-boot-sample-projects",
-      "alias": "hello",
-      "scriptRef": "hello.java",
-      "command": "hello@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
-      "fullcommand": "jbang hello@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
-      "link": "https://github.com/zubairmujeeb/spring-boot-sample-projects/blob/8d0fd0c195c714adde5d22b7b247abbe3b968786/tutorials-master/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/31179784?v\u003d4",
-      "repoOwner": "zubairmujeeb",
-      "repoName": "spring-boot-sample-projects",
-      "alias": "hellocli",
-      "scriptRef": "hellocli.java",
-      "command": "hellocli@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
-      "fullcommand": "jbang hellocli@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
-      "link": "https://github.com/zubairmujeeb/spring-boot-sample-projects/blob/8d0fd0c195c714adde5d22b7b247abbe3b968786/tutorials-master/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/31179784?v\u003d4",
-      "repoOwner": "zubairmujeeb",
-      "repoName": "spring-boot-sample-projects",
-      "alias": "jbangquarkus",
-      "scriptRef": "jbangquarkus.java",
-      "command": "jbangquarkus@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
-      "fullcommand": "jbang jbangquarkus@zubairmujeeb/spring-boot-sample-projects~tutorials-master/jbang",
-      "link": "https://github.com/zubairmujeeb/spring-boot-sample-projects/blob/8d0fd0c195c714adde5d22b7b247abbe3b968786/tutorials-master/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/62056258?v\u003d4",
-      "repoOwner": "ramesh1972",
-      "repoName": "samples-biz",
-      "alias": "hello",
-      "scriptRef": "hello.java",
-      "command": "hello@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
-      "fullcommand": "jbang hello@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
-      "link": "https://github.com/ramesh1972/samples-biz/blob/3817b7767886f4d1874814f3c65e24930eacfecb/samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/62056258?v\u003d4",
-      "repoOwner": "ramesh1972",
-      "repoName": "samples-biz",
-      "alias": "hellocli",
-      "scriptRef": "hellocli.java",
-      "command": "hellocli@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
-      "fullcommand": "jbang hellocli@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
-      "link": "https://github.com/ramesh1972/samples-biz/blob/3817b7767886f4d1874814f3c65e24930eacfecb/samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/62056258?v\u003d4",
-      "repoOwner": "ramesh1972",
-      "repoName": "samples-biz",
-      "alias": "jbangquarkus",
-      "scriptRef": "jbangquarkus.java",
-      "command": "jbangquarkus@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
-      "fullcommand": "jbang jbangquarkus@ramesh1972/samples-biz~samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang",
-      "link": "https://github.com/ramesh1972/samples-biz/blob/3817b7767886f4d1874814f3c65e24930eacfecb/samples-tech-stack/java_samples/langchain4j/eugenp/tutorials/jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/96721872?v\u003d4",
-      "repoOwner": "yaodahua",
-      "repoName": "fuxian_ChatTester",
-      "alias": "tabula",
-      "scriptRef": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar",
-      "command": "tabula@yaodahua/fuxian_ChatTester~CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java",
-      "fullcommand": "jbang tabula@yaodahua/fuxian_ChatTester~CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java",
-      "link": "https://github.com/yaodahua/fuxian_ChatTester/blob/eb4c78ff31049765a9e28a6803c71e621ead32a9/CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/160642749?v\u003d4",
-      "repoOwner": "23021632NguyenQuangMinh",
-      "repoName": "chattest",
-      "alias": "tabula",
-      "scriptRef": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar",
-      "command": "tabula@23021632NguyenQuangMinh/chattest~CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java",
-      "fullcommand": "jbang tabula@23021632NguyenQuangMinh/chattest~CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java",
-      "link": "https://github.com/23021632NguyenQuangMinh/chattest/blob/80d58f36ee07a4e5f9f856987b41964ddc122f81/CoverageCal/ProjectResult/ChatTester/tabulapdf_tabula-java/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/96721872?v\u003d4",
-      "repoOwner": "yaodahua",
-      "repoName": "fuxian_ChatTester",
-      "alias": "tabula",
-      "scriptRef": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar",
-      "command": "tabula@yaodahua/fuxian_ChatTester~CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java",
-      "fullcommand": "jbang tabula@yaodahua/fuxian_ChatTester~CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java",
-      "link": "https://github.com/yaodahua/fuxian_ChatTester/blob/eb4c78ff31049765a9e28a6803c71e621ead32a9/CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/160642749?v\u003d4",
-      "repoOwner": "23021632NguyenQuangMinh",
-      "repoName": "chattest",
-      "alias": "tabula",
-      "scriptRef": "https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar",
-      "command": "tabula@23021632NguyenQuangMinh/chattest~CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java",
-      "fullcommand": "jbang tabula@23021632NguyenQuangMinh/chattest~CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java",
-      "link": "https://github.com/23021632NguyenQuangMinh/chattest/blob/80d58f36ee07a4e5f9f856987b41964ddc122f81/CoverageCal/ProjectResult/Evosuite_first/tabulapdf_tabula-java/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/6292523?v\u003d4",
-      "repoOwner": "krital",
-      "repoName": "mapsmessaging-jbang",
-      "alias": "mapsmessaging",
-      "description": "\u003cp\u003eMAPS Messaging Server\u003c/p\u003e\n",
-      "scriptRef": "MAPS_Messaging.java",
-      "command": "mapsmessaging@krital/mapsmessaging-jbang",
-      "fullcommand": "jbang mapsmessaging@krital/mapsmessaging-jbang",
-      "link": "https://github.com/krital/mapsmessaging-jbang/blob/8abac5b2305728fccb137cc2bdf86d9d9ac05aeb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/156902772?v\u003d4",
-      "repoOwner": "jbanghub",
-      "repoName": "libgdx",
-      "alias": "gdx-liftoff",
-      "scriptRef": "https://github.com/libgdx/gdx-liftoff/releases/download/v1.12.1.17/gdx-liftoff-1.12.1.17.jar",
-      "command": "gdx-liftoff@jbanghub/libgdx",
-      "fullcommand": "jbang gdx-liftoff@jbanghub/libgdx",
-      "link": "https://github.com/jbanghub/libgdx/blob/98c7a4612c5a4fbb7f71abe93ad6c69772840d63/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/98075537?v\u003d4",
-      "repoOwner": "gaurabhok",
-      "repoName": "karate-automation",
-      "alias": "karate",
-      "scriptRef": "com.intuit.karate:karate-core:1.3.1:all",
-      "command": "karate@gaurabhok/karate-automation",
-      "fullcommand": "jbang karate@gaurabhok/karate-automation",
-      "link": "https://github.com/gaurabhok/karate-automation/blob/dae22a4de2a39e0a6a8c3be5ddef28ed3bdd7c39/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "hello",
-      "scriptRef": "src/hello.java",
-      "command": "hello@wfouche~apps/hello/1.0.1",
-      "fullcommand": "jbang hello@wfouche~apps/hello/1.0.1",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/apps/hello/1.0.1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jmeet",
-      "alias": "run",
-      "scriptRef": "jmeet.java",
-      "command": "run@maxandersen/jmeet",
-      "fullcommand": "jbang run@maxandersen/jmeet",
-      "link": "https://github.com/maxandersen/jmeet/blob/6c1bad89dd76bc1c233e26296b87e94395a6cf8f/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jmeet",
-      "alias": "clearpto",
-      "scriptRef": "clearpto.java",
-      "command": "clearpto@maxandersen/jmeet",
-      "fullcommand": "jbang clearpto@maxandersen/jmeet",
-      "link": "https://github.com/maxandersen/jmeet/blob/6c1bad89dd76bc1c233e26296b87e94395a6cf8f/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "notes",
-      "alias": "notes",
-      "scriptRef": "notes.java",
-      "command": "notes@garodriguezlp/notes",
-      "fullcommand": "jbang notes@garodriguezlp/notes",
-      "link": "https://github.com/garodriguezlp/notes/blob/d48ba62529d803af35ef255866e081ed5691f3fd/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/2025943?v\u003d4",
-      "repoOwner": "mikomatic",
-      "repoName": "jbang-catalog",
-      "alias": "hello",
-      "description": "\u003cp\u003eScript that prints hello world\u003c/p\u003e\n",
-      "scriptRef": "hello.java",
-      "command": "hello@mikomatic",
-      "fullcommand": "jbang hello@mikomatic",
-      "link": "https://github.com/mikomatic/jbang-catalog/blob/a582c15bd11aa656a40251d228c2d3249674594e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/2025943?v\u003d4",
-      "repoOwner": "mikomatic",
-      "repoName": "jbang-catalog",
-      "alias": "springPropertyDocumenter",
-      "description": "\u003cp\u003eDocument spring boot properties based on property metadata\u003c/p\u003e\n",
-      "scriptRef": "springPropertyDocumenter.java",
-      "command": "springPropertyDocumenter@mikomatic",
-      "fullcommand": "jbang springPropertyDocumenter@mikomatic",
-      "link": "https://github.com/mikomatic/jbang-catalog/blob/a582c15bd11aa656a40251d228c2d3249674594e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/5173767?v\u003d4",
-      "repoOwner": "worldline",
-      "repoName": "jbang-catalog",
-      "alias": "jfxapp",
-      "description": "\u003cp\u003eSingle file JavaFX application. View are defined by code (no fxml)\u003c/p\u003e\n",
-      "scriptRef": "scripts/jfxdemo.kt",
-      "command": "jfxapp@worldline",
-      "fullcommand": "jbang jfxapp@worldline",
-      "link": "https://github.com/worldline/jbang-catalog/blob/d91d3ff764252280c598ac48363434fe8eca0851/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1932856?v\u003d4",
-      "repoOwner": "predic8",
-      "repoName": "jbang-catalog",
-      "alias": "h2",
-      "description": "\u003cp\u003eStarts the h2 database server\u003c/p\u003e\n",
-      "scriptRef": "h2.java",
-      "command": "h2@predic8",
-      "fullcommand": "jbang h2@predic8",
-      "link": "https://github.com/predic8/jbang-catalog/blob/2adac5d55f758c20e9d8e096358c9ed31aced5a7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1932856?v\u003d4",
-      "repoOwner": "predic8",
-      "repoName": "jbang-catalog",
-      "alias": "sql",
-      "description": "\u003cp\u003eCommandline to execute SQL command\u003c/p\u003e\n",
-      "scriptRef": "sql.java",
-      "command": "sql@predic8",
-      "fullcommand": "jbang sql@predic8",
-      "link": "https://github.com/predic8/jbang-catalog/blob/2adac5d55f758c20e9d8e096358c9ed31aced5a7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1932856?v\u003d4",
-      "repoOwner": "predic8",
-      "repoName": "jbang-catalog",
-      "alias": "membrane",
-      "description": "\u003cp\u003eMembrane API Gateway\u003c/p\u003e\n",
-      "scriptRef": "org.membrane-soa:starter:5.7.0",
-      "command": "membrane@predic8",
-      "fullcommand": "jbang membrane@predic8",
-      "link": "https://github.com/predic8/jbang-catalog/blob/2adac5d55f758c20e9d8e096358c9ed31aced5a7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/197741822?v\u003d4",
-      "repoOwner": "robintegg-createfuture",
-      "repoName": "jbang-catalog",
-      "alias": "caniaccessprivategithubrepos",
-      "description": "\u003cp\u003eDetermine if the local environment is setup to access private GitHub repositories\u003c/p\u003e\n",
-      "scriptRef": "caniaccessprivategithubrepos.java",
-      "command": "caniaccessprivategithubrepos@robintegg-createfuture",
-      "fullcommand": "jbang caniaccessprivategithubrepos@robintegg-createfuture",
-      "link": "https://github.com/robintegg-createfuture/jbang-catalog/blob/75da0d52decd1ffcebfe92fada113c5ee4321af5/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11298180?v\u003d4",
-      "repoOwner": "adoble",
-      "repoName": "jbang-catalog",
-      "alias": "adr",
-      "scriptRef": "https://github.com/adoble/adr-j/releases/download/v3.5.0/adr-j.jar",
-      "command": "adr@adoble",
-      "fullcommand": "jbang adr@adoble",
-      "link": "https://github.com/adoble/jbang-catalog/blob/6f3ab1122fa21652c2d1ec300435a563e8f33373/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/2319838?v\u003d4",
-      "repoOwner": "sormuras",
-      "repoName": "jbang",
-      "alias": "jreleaser-snapshot",
-      "description": "\u003cp\u003eRelease projects quickly and easily with JReleaser\u003c/p\u003e\n",
-      "scriptRef": "jreleaser_snapshot.java",
-      "command": "jreleaser-snapshot@sormuras/jbang",
-      "fullcommand": "jbang jreleaser-snapshot@sormuras/jbang",
-      "link": "https://github.com/sormuras/jbang/blob/d37a65d4bb010c7370e43e00dadcf93b0d4f036a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/156902772?v\u003d4",
-      "repoOwner": "jbanghub",
-      "repoName": "proguard",
-      "alias": "retrace",
-      "scriptRef": "com.guardsquare:proguard-retrace:7.7.0",
-      "command": "retrace@jbanghub/proguard",
-      "fullcommand": "jbang retrace@jbanghub/proguard",
-      "link": "https://github.com/jbanghub/proguard/blob/9f4fc823a400c6810d8ebc006a5e73090c726df7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/156902772?v\u003d4",
-      "repoOwner": "jbanghub",
-      "repoName": "proguard",
-      "alias": "proguard",
-      "scriptRef": "com.guardsquare:proguard-base:7.7.0",
-      "command": "proguard@jbanghub/proguard",
-      "fullcommand": "jbang proguard@jbanghub/proguard",
-      "link": "https://github.com/jbanghub/proguard/blob/9f4fc823a400c6810d8ebc006a5e73090c726df7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/156902772?v\u003d4",
-      "repoOwner": "jbanghub",
-      "repoName": "proguard",
-      "alias": "proguard-gui",
-      "scriptRef": "com.guardsquare:proguard-gui:7.7.0",
-      "command": "proguard-gui@jbanghub/proguard",
-      "fullcommand": "jbang proguard-gui@jbanghub/proguard",
-      "link": "https://github.com/jbanghub/proguard/blob/9f4fc823a400c6810d8ebc006a5e73090c726df7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/13682850?v\u003d4",
-      "repoOwner": "wfouche",
-      "repoName": "jbang-catalog",
-      "alias": "camel",
-      "scriptRef": "../CamelJBang.java",
-      "command": "camel@wfouche~apps/camel/4.16.0",
-      "fullcommand": "jbang camel@wfouche~apps/camel/4.16.0",
-      "link": "https://github.com/wfouche/jbang-catalog/blob/1616de4ff102d333a59acd17e186ac13631adcee/apps/camel/4.16.0/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "jbang-catalog",
-      "alias": "banc",
-      "scriptRef": "https://github.com/garodriguezlp/banc/blob/main/banc.java",
-      "command": "banc@garodriguezlp",
-      "fullcommand": "jbang banc@garodriguezlp",
-      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "jbang-catalog",
-      "alias": "cheo",
-      "scriptRef": "https://github.com/garodriguezlp/cheo/blob/main/cheo.java",
-      "command": "cheo@garodriguezlp",
-      "fullcommand": "jbang cheo@garodriguezlp",
-      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "jbang-catalog",
-      "alias": "notes",
-      "scriptRef": "https://github.com/garodriguezlp/notes/blob/main/notes.java",
-      "command": "notes@garodriguezlp",
-      "fullcommand": "jbang notes@garodriguezlp",
-      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "jbang-catalog",
-      "alias": "payroll",
-      "scriptRef": "https://github.com/garodriguezlp/payroll/blob/main/payroll.java",
-      "command": "payroll@garodriguezlp",
-      "fullcommand": "jbang payroll@garodriguezlp",
-      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "jbang-catalog",
-      "alias": "irimo",
-      "description": "\u003cp\u003eCLI tool for consolidating personal financial data\u003c/p\u003e\n",
-      "scriptRef": "irimo.java",
-      "command": "irimo@garodriguezlp",
-      "fullcommand": "jbang irimo@garodriguezlp",
-      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "jbang-catalog",
-      "alias": "irimo-snapshot",
-      "description": "\u003cp\u003eCLI tool for consolidating personal financial data\u003c/p\u003e\n",
-      "scriptRef": "irimo_snapshot.java",
-      "command": "irimo-snapshot@garodriguezlp",
-      "fullcommand": "jbang irimo-snapshot@garodriguezlp",
-      "link": "https://github.com/garodriguezlp/jbang-catalog/blob/b5d096a36d56a0207a4bcf1cbc93667053cbf27b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/50527026?v\u003d4",
-      "repoOwner": "maciejkryger",
-      "repoName": "onecx-svc-generator",
-      "alias": "onecx-svc-generator",
-      "description": "\u003cp\u003eLauncher for the OneCX SVC generator JAR\u003c/p\u003e\n",
-      "scriptRef": "launcher/onecx_svc_generator.java",
-      "command": "onecx-svc-generator@maciejkryger/onecx-svc-generator",
-      "fullcommand": "jbang onecx-svc-generator@maciejkryger/onecx-svc-generator",
-      "link": "https://github.com/maciejkryger/onecx-svc-generator/blob/98edad5d4494219f74debd349a688808c9d9fc59/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jfabric",
-      "alias": "fabric",
-      "scriptRef": "fabric.java",
-      "command": "fabric@maxandersen/jfabric",
-      "fullcommand": "jbang fabric@maxandersen/jfabric",
-      "link": "https://github.com/maxandersen/jfabric/blob/52024698743f88ff89e72b2c333e59f8ab480633/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/5106647?v\u003d4",
-      "repoOwner": "oscerd",
-      "repoName": "sec-edgar-jbang-cli",
-      "alias": "edgar",
-      "description": "\u003cp\u003eSEC EDGAR CLI - Download Form 4, Form 13F, Form 8-K, and Form 10-K/10-Q filings\u003c/p\u003e\n",
-      "scriptRef": "edgar.java",
-      "command": "edgar@oscerd/sec-edgar-jbang-cli",
-      "fullcommand": "jbang edgar@oscerd/sec-edgar-jbang-cli",
-      "link": "https://github.com/oscerd/sec-edgar-jbang-cli/blob/fe7cd6e9a0dae64d2fb688ac5a180fd5f26c14c4/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/4076071?v\u003d4",
-      "repoOwner": "hal",
-      "repoName": "jbang-catalog",
-      "alias": "hal-op",
-      "description": "\u003cp\u003eHAL standalone console on premise\u003c/p\u003e\n",
-      "scriptRef": "org.jboss.hal:hal-op-standalone:0.2.7:runner",
-      "command": "hal-op@hal",
-      "fullcommand": "jbang hal-op@hal",
-      "link": "https://github.com/hal/jbang-catalog/blob/14d37d3d09ee80b21845fbe5030ed507a29875cb/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/112546609?v\u003d4",
-      "repoOwner": "R6Y8bihv",
-      "repoName": "MlJCFdY",
-      "alias": "yaks",
-      "description": "\u003cp\u003eRun YAKS tests locally\u003c/p\u003e\n",
-      "scriptRef": "java/tools/yaks-jbang/dist/YaksJBang.java",
-      "command": "yaks@R6Y8bihv/MlJCFdY",
-      "fullcommand": "jbang yaks@R6Y8bihv/MlJCFdY",
-      "link": "https://github.com/R6Y8bihv/MlJCFdY/blob/ab64d21d364ee7b77907ab192578d4f1525522e5/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/198564921?v\u003d4",
-      "repoOwner": "59977sOnNy",
-      "repoName": "XrKnQfjqfY",
-      "alias": "yaks",
-      "description": "\u003cp\u003eRun YAKS tests locally\u003c/p\u003e\n",
-      "scriptRef": "java/tools/yaks-jbang/dist/YaksJBang.java",
-      "command": "yaks@59977sOnNy/XrKnQfjqfY",
-      "fullcommand": "jbang yaks@59977sOnNy/XrKnQfjqfY",
-      "link": "https://github.com/59977sOnNy/XrKnQfjqfY/blob/ee677fd54954efc22cf470a392ce93e8897233ea/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "filesystem",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-filesystem:RELEASE@fatjar",
-      "command": "filesystem@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang filesystem@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "jdbc",
-      "scriptRef": "jdbc/.scripts/mcpjdbc.java",
-      "command": "jdbc@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang jdbc@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "jfx-script",
-      "scriptRef": "jfx/src/main/java/io/quarkiverse/mcp/servers/jfx/MCPServerJFX.java",
-      "command": "jfx-script@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang jfx-script@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "jfx",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-jfx:RELEASE@fatjar",
-      "command": "jfx@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang jfx@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "kubernetes",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-kubernetes:RELEASE@fatjar",
-      "command": "kubernetes@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang kubernetes@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "containers",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-containers:RELEASE@fatjar",
-      "command": "containers@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang containers@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "jvminsight",
-      "scriptRef": "io.quarkiverse.mcp.servers:mcp-server-jvminsight:RELEASE@fatjar",
-      "command": "jvminsight@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang jvminsight@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "forbidden",
-      "alias": "cli",
-      "scriptRef": "forbidden.java",
-      "command": "cli@maxandersen/forbidden",
-      "fullcommand": "jbang cli@maxandersen/forbidden",
-      "link": "https://github.com/maxandersen/forbidden/blob/dbce8c43878e53456aa5f557fb3c445a2f8a4863/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/191616?v\u003d4",
-      "repoOwner": "jasondlee",
-      "repoName": "jbang-catalog",
-      "alias": "mvnsrch",
-      "scriptRef": "mvnsrch.java",
-      "command": "mvnsrch@jasondlee",
-      "fullcommand": "jbang mvnsrch@jasondlee",
-      "link": "https://github.com/jasondlee/jbang-catalog/blob/2828c8f99dc14e664faf68f532bb0e99d9d1d8f4/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/191616?v\u003d4",
-      "repoOwner": "jasondlee",
-      "repoName": "jbang-catalog",
-      "alias": "startserver",
-      "scriptRef": "startserver.java",
-      "command": "startserver@jasondlee",
-      "fullcommand": "jbang startserver@jasondlee",
-      "link": "https://github.com/jasondlee/jbang-catalog/blob/2828c8f99dc14e664faf68f532bb0e99d9d1d8f4/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/125940666?v\u003d4",
-      "repoOwner": "enola-dev",
-      "repoName": "jbang-catalog",
-      "alias": "enola",
-      "scriptRef": "dev.enola:enola:0.0.1-SNAPSHOT",
-      "command": "enola@enola-dev",
-      "fullcommand": "jbang enola@enola-dev",
-      "link": "https://github.com/enola-dev/jbang-catalog/blob/a93c67c00dd6ec7779148b675701c8c4933e5915/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/966402?v\u003d4",
-      "repoOwner": "bytemanproject",
-      "repoName": "jbang-catalog",
-      "alias": "byteman",
-      "scriptRef": "org.jboss.byteman:byteman:RELEASE",
-      "command": "byteman@bytemanproject",
-      "fullcommand": "jbang byteman@bytemanproject",
-      "link": "https://github.com/bytemanproject/jbang-catalog/blob/d6c54683ad2564bc7ff9e72bafa256a8f68e9838/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/966402?v\u003d4",
-      "repoOwner": "bytemanproject",
-      "repoName": "jbang-catalog",
-      "alias": "bmcheck",
-      "scriptRef": "org.jboss.byteman:byteman:RELEASE",
-      "command": "bmcheck@bytemanproject",
-      "fullcommand": "jbang bmcheck@bytemanproject",
-      "link": "https://github.com/bytemanproject/jbang-catalog/blob/d6c54683ad2564bc7ff9e72bafa256a8f68e9838/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/966402?v\u003d4",
-      "repoOwner": "bytemanproject",
-      "repoName": "jbang-catalog",
-      "alias": "bminstall",
-      "scriptRef": "org.jboss.byteman:byteman-install:RELEASE",
-      "command": "bminstall@bytemanproject",
-      "fullcommand": "jbang bminstall@bytemanproject",
-      "link": "https://github.com/bytemanproject/jbang-catalog/blob/d6c54683ad2564bc7ff9e72bafa256a8f68e9838/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/966402?v\u003d4",
-      "repoOwner": "bytemanproject",
-      "repoName": "jbang-catalog",
-      "alias": "bmsubmit",
-      "scriptRef": "org.jboss.byteman:byteman-submit:RELEASE",
-      "command": "bmsubmit@bytemanproject",
-      "fullcommand": "jbang bmsubmit@bytemanproject",
-      "link": "https://github.com/bytemanproject/jbang-catalog/blob/d6c54683ad2564bc7ff9e72bafa256a8f68e9838/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "deps-to-classpath",
-      "description": "\u003cp\u003eresolve dependencies and print the classpath\n\u003ccode\u003edeps-to-classpath DEP...\u003c/code\u003e\nAlternative: \u003ccode\u003edeps_to_classpath DEP...\u003c/code\u003e \u003ca rel\u003d\"nofollow\" href\u003d\"https://gist.github.com/robin-a-meade/a1237d7ff7cbe6dc159fa32a81c12948\"\u003edeps_to_classpath\u003c/a\u003e is a shell script wrapper around \u003ccode\u003ejbang info classpath\u003c/code\u003e\nAlternative: \u003ccode\u003ejbang jecho@robin-a-meade \u0026quot;%{deps:$(IFS\u003d,; echo \u0026quot;${DEPS[*]}\u0026quot;)}\u0026quot;\u003c/code\u003e, where \u003ccode\u003eDEPS\u003c/code\u003e is an array of dependencies.\u003c/p\u003e\n",
-      "scriptRef": "scripts/DepsToClasspath.java",
-      "command": "deps-to-classpath@robin-a-meade",
-      "fullcommand": "jbang deps-to-classpath@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "firefox-profile-dir",
-      "description": "\u003cp\u003eprint the absolute path to the user\u0027s firefox profile directory\n\u003ccode\u003efirefox-profile-dir\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/FirefoxProfileDir.java",
-      "command": "firefox-profile-dir@robin-a-meade",
-      "fullcommand": "jbang firefox-profile-dir@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "firefox-profile-dir-with-caching",
-      "description": "\u003cp\u003eprint the absolute path of the user\u0027s firefox profile directory and cache the result for subsequent calls\n\u003ccode\u003efirefox-profile-dir-with-caching [--fresh] [-v]\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/FirefoxProfileDirWithCaching.java",
-      "command": "firefox-profile-dir-with-caching@robin-a-meade",
-      "fullcommand": "jbang firefox-profile-dir-with-caching@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "jecho",
-      "description": "\u003cp\u003eprint arguments\n\u003ccode\u003ejecho [ARG]...\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/jecho.java",
-      "command": "jecho@robin-a-meade",
-      "fullcommand": "jbang jecho@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "jargs",
-      "description": "\u003cp\u003eprint the argument count and print each argument enclosed in angle brackets\n\u003ccode\u003ejargs [ARG]...\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/jargs.java",
-      "command": "jargs@robin-a-meade",
-      "fullcommand": "jbang jargs@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "kebab-case-demo",
-      "description": "\u003cp\u003edemo of jbang\u0027s support for scripts with kebab-case style name\n\u003ccode\u003ekebab-case-demo\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/kebab-case-demo",
-      "command": "kebab-case-demo@robin-a-meade",
-      "fullcommand": "jbang kebab-case-demo@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "multi-source-file-demo",
-      "description": "\u003cp\u003edemo of jbang\u0027s support for handling multi-source-file java programs\n\u003ccode\u003emulti-source-file-demo [NAME]\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/multi-source-file-demo/Main.java",
-      "command": "multi-source-file-demo@robin-a-meade",
-      "fullcommand": "jbang multi-source-file-demo@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "saxonhe",
-      "description": "\u003cp\u003ewrapper for launching Saxon-HE\u0027s command line interfaces for XSLT, XQuery, and the Gizmo utility\n\u003ccode\u003esaxonhe (transform|query|gizmo) OPTIONS\u003c/code\u003e\nThis script uses the \u003cem\u003eHE\u003c/em\u003e edition of \u003ca rel\u003d\"nofollow\" href\u003d\"https://www.saxonica.com\"\u003eThe Saxon XSLT and XQuery Processor\u003c/a\u003e.\nThis script bundles two HTML SAX parsers. To use them, specify the \u003ccode\u003e-x:org.ccil.cowan.tagsoup.Parser\u003c/code\u003e or \u003ccode\u003e-x:nu.validator.htmlparser.sax.HtmlParser\u003c/code\u003e option when invoking the \u003cem\u003etransform\u003c/em\u003e or \u003cem\u003equery\u003c/em\u003e commands.\nThis variant uses the latest in the v12.x line of releases. See the \u003ccode\u003esaxonhe11\u003c/code\u003e variant for v11.x.\u003c/p\u003e\n",
-      "scriptRef": "scripts/saxonhe.java",
-      "command": "saxonhe@robin-a-meade",
-      "fullcommand": "jbang saxonhe@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "saxonhe11",
-      "description": "\u003cp\u003esimple wrapper for launching Saxon-HE v11.x command line interfaces for XSLT, XQuery, and the Gizmo utility\n\u003ccode\u003esaxonhe11 (transform|query|gizmo) OPTIONS\u003c/code\u003e\nThis script uses the \u003cem\u003eHE\u003c/em\u003e edition of \u003ca rel\u003d\"nofollow\" href\u003d\"https://www.saxonica.com\"\u003eThe Saxon XSLT and XQuery Processor\u003c/a\u003e.\nThis script bundles two HTML SAX parsers. To use them, specify the \u003ccode\u003e-x:org.ccil.cowan.tagsoup.Parser\u003c/code\u003e or \u003ccode\u003e-x:nu.validator.htmlparser.sax.HtmlParser\u003c/code\u003e option when invoking the \u003cem\u003etransform\u003c/em\u003e or \u003cem\u003equery\u003c/em\u003e commands.\nThis variant uses the latest in the v11.x line of releases. See the \u003ccode\u003esaxonhe\u003c/code\u003e variant for v12.x.\u003c/p\u003e\n",
-      "scriptRef": "scripts/saxonhe11.java",
-      "command": "saxonhe11@robin-a-meade",
-      "fullcommand": "jbang saxonhe11@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "saxonheX",
-      "description": "\u003cp\u003eexperiment with tagsoup modifications\n\u003ccode\u003esaxonhe-exp (transform|query|gizmo) OPTIONS\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/saxonheX.java",
-      "command": "saxonheX@robin-a-meade",
-      "fullcommand": "jbang saxonheX@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "sqlline-test",
-      "description": "\u003cp\u003etest of \u003cem\u003erenovate\u003c/em\u003e dependency automation\n\u003ccode\u003esqlline-test [options...] [properties files...]\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "sqlline:sqlline:1.12.0",
-      "command": "sqlline-test@robin-a-meade",
-      "fullcommand": "jbang sqlline-test@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "tagsoup",
-      "description": "\u003cp\u003econvert HTML to well-formed XML (John Cowan\u0027s tagsoup 1.2.1)\n\u003ccode\u003etagsoup [OPTIONS] [FILES]\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "org.ccil.cowan.tagsoup:tagsoup:1.2.1",
-      "command": "tagsoup@robin-a-meade",
-      "fullcommand": "jbang tagsoup@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1343270?v\u003d4",
-      "repoOwner": "robin-a-meade",
-      "repoName": "jbang-catalog",
-      "alias": "jlist",
-      "description": "\u003cp\u003edemo\n\u003ccode\u003ejlist [ARG]...\u003c/code\u003e\u003c/p\u003e\n",
-      "scriptRef": "scripts/jlist.java",
-      "command": "jlist@robin-a-meade",
-      "fullcommand": "jbang jlist@robin-a-meade",
-      "link": "https://github.com/robin-a-meade/jbang-catalog/blob/0afd30005be4fa9fa50cc27b83497cf7f106581a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/9534301?v\u003d4",
-      "repoOwner": "dlemmermann",
-      "repoName": "jbang-catalog",
-      "alias": "jfxcentral",
-      "scriptRef": "https://raw.githubusercontent.com/dlemmermann/jfxcentral/master/main.java",
-      "command": "jfxcentral@dlemmermann",
-      "fullcommand": "jbang jfxcentral@dlemmermann",
-      "link": "https://github.com/dlemmermann/jbang-catalog/blob/9d55b730702cc8dcb34f6cadad0ce17c45cab14a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jpaxa",
-      "alias": "jpaxa",
-      "scriptRef": "jpaxa.java",
-      "command": "jpaxa@jbangdev/jpaxa",
-      "fullcommand": "jbang jpaxa@jbangdev/jpaxa",
-      "link": "https://github.com/jbangdev/jpaxa/blob/b552ff2bcf44bbeee03920b6e01d8863a2d4bac1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/9698378?v\u003d4",
-      "repoOwner": "reportmill",
-      "repoName": "jbang-catalog",
-      "alias": "snapcode",
-      "description": "\u003cp\u003eJava IDE for education on desktop and in browser\u003c/p\u003e\n",
-      "scriptRef": "https://reportmill.com/jbang/SnapCodeAll.java",
-      "command": "snapcode@reportmill",
-      "fullcommand": "jbang snapcode@reportmill",
-      "link": "https://github.com/reportmill/jbang-catalog/blob/825b7b756a32e4f42ef10cffad9350a5302f72e1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/9698378?v\u003d4",
-      "repoOwner": "reportmill",
-      "repoName": "jbang-catalog",
-      "alias": "snapbuilder",
-      "description": "\u003cp\u003eJava UI builder for SnapKit\u003c/p\u003e\n",
-      "scriptRef": "https://reportmill.com/jbang/SnapBuilder.java",
-      "command": "snapbuilder@reportmill",
-      "fullcommand": "jbang snapbuilder@reportmill",
-      "link": "https://github.com/reportmill/jbang-catalog/blob/825b7b756a32e4f42ef10cffad9350a5302f72e1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/9698378?v\u003d4",
-      "repoOwner": "reportmill",
-      "repoName": "jbang-catalog",
-      "alias": "reportmill",
-      "description": "\u003cp\u003eThe ReportMill page layout application\u003c/p\u003e\n",
-      "scriptRef": "https://reportmill.com/jbang/ReportMill.java",
-      "command": "reportmill@reportmill",
-      "fullcommand": "jbang reportmill@reportmill",
-      "link": "https://github.com/reportmill/jbang-catalog/blob/825b7b756a32e4f42ef10cffad9350a5302f72e1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/9698378?v\u003d4",
-      "repoOwner": "reportmill",
-      "repoName": "jbang-catalog",
-      "alias": "sc",
-      "description": "\u003cp\u003eJava IDE for education on desktop and in browser\u003c/p\u003e\n",
-      "scriptRef": "https://reportmill.com/jbang/SnapCodeAll.java",
-      "command": "sc@reportmill",
-      "fullcommand": "jbang sc@reportmill",
-      "link": "https://github.com/reportmill/jbang-catalog/blob/825b7b756a32e4f42ef10cffad9350a5302f72e1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/9698378?v\u003d4",
-      "repoOwner": "reportmill",
-      "repoName": "jbang-catalog",
-      "alias": "slideshow",
-      "description": "\u003cp\u003eJava slide show app for desktop and in browser\u003c/p\u003e\n",
-      "scriptRef": "https://reportmill.com/jbang/SlideShow.java",
-      "command": "slideshow@reportmill",
-      "fullcommand": "jbang slideshow@reportmill",
-      "link": "https://github.com/reportmill/jbang-catalog/blob/825b7b756a32e4f42ef10cffad9350a5302f72e1/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/874086?v\u003d4",
-      "repoOwner": "junit-team",
-      "repoName": "jbang-catalog",
-      "alias": "junit",
-      "description": "\u003cp\u003eLaunch the JUnit Platform from the console\u003c/p\u003e\n",
-      "scriptRef": "org.junit.platform:junit-platform-console-standalone:6.0.3",
-      "command": "junit@junit-team",
-      "fullcommand": "jbang junit@junit-team",
-      "link": "https://github.com/junit-team/jbang-catalog/blob/68764895328a12a718e7d87dbd53a328fa06d69f/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/874086?v\u003d4",
-      "repoOwner": "junit-team",
-      "repoName": "jbang-catalog",
-      "alias": "cli",
-      "description": "\u003cp\u003eLaunch the JUnit Platform from the console\u003c/p\u003e\n",
-      "scriptRef": "org.junit.platform:junit-platform-console-standalone:6.0.3",
-      "command": "cli@junit-team",
-      "fullcommand": "jbang cli@junit-team",
-      "link": "https://github.com/junit-team/jbang-catalog/blob/68764895328a12a718e7d87dbd53a328fa06d69f/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/33741200?v\u003d4",
-      "repoOwner": "shoplineapp",
-      "repoName": "karate-grpcurl",
-      "alias": "karate-grpcurl",
-      "scriptRef": "karate-grpcurl-fatjar.jar",
-      "command": "karate-grpcurl@shoplineapp/karate-grpcurl",
-      "fullcommand": "jbang karate-grpcurl@shoplineapp/karate-grpcurl",
-      "link": "https://github.com/shoplineapp/karate-grpcurl/blob/097a299da85170066ddc54f315433d666cca6bc3/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/40258585?v\u003d4",
-      "repoOwner": "DependencyTrack",
-      "repoName": "jbang-catalog",
-      "alias": "gen-config-docs",
-      "description": "\u003cp\u003eGenerate configuration documentation from application.properties\u003c/p\u003e\n",
-      "scriptRef": "GenerateConfigDocs.java",
-      "command": "gen-config-docs@DependencyTrack",
-      "fullcommand": "jbang gen-config-docs@DependencyTrack",
-      "link": "https://github.com/DependencyTrack/jbang-catalog/blob/aec6683399fa69983d7d0b0a650aeb7851358162/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/40258585?v\u003d4",
-      "repoOwner": "DependencyTrack",
-      "repoName": "jbang-catalog",
-      "alias": "gen-cwe-dict",
-      "description": "\u003cp\u003eGenerate a Java class holding a dictionary of CWE ID -\u0026gt; CWE Name mappings\u003c/p\u003e\n",
-      "scriptRef": "GenerateCweDictionary.java",
-      "command": "gen-cwe-dict@DependencyTrack",
-      "fullcommand": "jbang gen-cwe-dict@DependencyTrack",
-      "link": "https://github.com/DependencyTrack/jbang-catalog/blob/aec6683399fa69983d7d0b0a650aeb7851358162/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1432287?v\u003d4",
-      "repoOwner": "garodriguezlp",
-      "repoName": "mcp-greeting-server",
-      "alias": "mcp-greeting",
-      "description": "\u003cp\u003eRuns the MCP Greeting Server via Quarkus + JBang\u003c/p\u003e\n",
-      "scriptRef": "McpGreetingServer.java",
-      "command": "mcp-greeting@garodriguezlp/mcp-greeting-server",
-      "fullcommand": "jbang mcp-greeting@garodriguezlp/mcp-greeting-server",
-      "link": "https://github.com/garodriguezlp/mcp-greeting-server/blob/cf76fe2c188b235753e60c9e2ac2efb439b4353b/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/118349365?v\u003d4",
-      "repoOwner": "maveniverse",
-      "repoName": "jbang-catalog",
-      "alias": "toolbox",
-      "description": "\u003cp\u003eToolbox CLI\u003c/p\u003e\n",
-      "scriptRef": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/plugins/toolbox/0.15.8/toolbox-0.15.8-cli.jar",
-      "command": "toolbox@maveniverse",
-      "fullcommand": "jbang toolbox@maveniverse",
-      "link": "https://github.com/maveniverse/jbang-catalog/blob/3889f9d3c25a8d9d40a1eeddc1d65a22740c6788/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/118349365?v\u003d4",
-      "repoOwner": "maveniverse",
-      "repoName": "jbang-catalog",
-      "alias": "toolbox-mcp",
-      "description": "\u003cp\u003eToolbox MCP (use with --quiet)\u003c/p\u003e\n",
-      "scriptRef": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/toolbox/mcp/0.15.8/mcp-0.15.8-runner.jar",
-      "command": "toolbox-mcp@maveniverse",
-      "fullcommand": "jbang toolbox-mcp@maveniverse",
-      "link": "https://github.com/maveniverse/jbang-catalog/blob/3889f9d3c25a8d9d40a1eeddc1d65a22740c6788/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/118349365?v\u003d4",
-      "repoOwner": "maveniverse",
-      "repoName": "jbang-catalog",
-      "alias": "pilot",
-      "description": "\u003cp\u003ePilot CLI\u003c/p\u003e\n",
-      "scriptRef": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/pilot/pilot-cli/0.2.1/pilot-cli-0.2.1.jar",
-      "command": "pilot@maveniverse",
-      "fullcommand": "jbang pilot@maveniverse",
-      "link": "https://github.com/maveniverse/jbang-catalog/blob/3889f9d3c25a8d9d40a1eeddc1d65a22740c6788/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "quarkus-ghsa-pv6m-j4fg-qx7h",
-      "alias": "revapi-update",
-      "scriptRef": "RevapiUpdate.java",
-      "command": "revapi-update@quarkusio/quarkus-ghsa-pv6m-j4fg-qx7h~.jbang",
-      "fullcommand": "jbang revapi-update@quarkusio/quarkus-ghsa-pv6m-j4fg-qx7h~.jbang",
-      "link": "https://github.com/quarkusio/quarkus-ghsa-pv6m-j4fg-qx7h/blob/2c25d2f4754e7f87774bb8400bc452394a052767/.jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jabtop",
-      "alias": "abtop",
-      "description": "\u003cp\u003eAI agent monitor for your terminal — like htop, but for AI coding agents\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jabtop/releases/download/early-access/jabtop-0.0.0-SNAPSHOT.jar",
-      "command": "abtop@maxandersen/jabtop",
-      "fullcommand": "jbang abtop@maxandersen/jabtop",
-      "link": "https://github.com/maxandersen/jabtop/blob/5b6cd41e06ee915c8295a1dd525e2e51ee7e6f26/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jabtop",
-      "alias": "jabtop",
-      "description": "\u003cp\u003eAI agent monitor for your terminal — like htop, but for AI coding agents\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/maxandersen/jabtop/releases/download/early-access/jabtop-0.0.0-SNAPSHOT.jar",
-      "command": "jabtop@maxandersen/jabtop",
-      "fullcommand": "jbang jabtop@maxandersen/jabtop",
-      "link": "https://github.com/maxandersen/jabtop/blob/5b6cd41e06ee915c8295a1dd525e2e51ee7e6f26/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/32281897?v\u003d4",
-      "repoOwner": "rnett",
-      "repoName": "jbang-catalog",
-      "alias": "gradle-mcp",
-      "description": "\u003cp\u003eA MCP server for Gradle.\u003c/p\u003e\n",
-      "scriptRef": "dev.rnett.gradle-mcp:gradle-mcp:+",
-      "command": "gradle-mcp@rnett",
-      "fullcommand": "jbang gradle-mcp@rnett",
-      "link": "https://github.com/rnett/jbang-catalog/blob/659471b82bd7e81337a8fa687e4153b51b14aab7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/32281897?v\u003d4",
-      "repoOwner": "rnett",
-      "repoName": "jbang-catalog",
-      "alias": "gradle-mcp-snapshot",
-      "description": "\u003cp\u003eA MCP server for Gradle (Snapshot).\u003c/p\u003e\n",
-      "scriptRef": "dev.rnett.gradle-mcp:gradle-mcp:+",
-      "command": "gradle-mcp-snapshot@rnett",
-      "fullcommand": "jbang gradle-mcp-snapshot@rnett",
-      "link": "https://github.com/rnett/jbang-catalog/blob/659471b82bd7e81337a8fa687e4153b51b14aab7/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "palcli",
-      "description": "\u003cp\u003ePalindrome tester CLI\u003c/p\u003e\n",
-      "scriptRef": "scripts/paltools/palcli.java",
-      "command": "palcli@yostane",
-      "fullcommand": "jbang palcli@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "palqrest",
-      "description": "\u003cp\u003ePalindrome tester Quarkus Rest API\u003c/p\u003e\n",
-      "scriptRef": "scripts/paltools/palqrest.java",
-      "command": "palqrest@yostane",
-      "fullcommand": "jbang palqrest@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "ktor-rest",
-      "description": "\u003cp\u003eKtor Rest API server with JSON serialization\u003c/p\u003e\n",
-      "scriptRef": "scripts/ktor-rest-server.kt",
-      "command": "ktor-rest@yostane",
-      "fullcommand": "jbang ktor-rest@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "hellojfx",
-      "description": "\u003cp\u003eBasic JavaFX window that shows Java and JavaFx versions\u003c/p\u003e\n",
-      "scriptRef": "scripts/hellojfx.java",
-      "command": "hellojfx@yostane",
-      "fullcommand": "jbang hellojfx@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "javafx-presentation",
-      "description": "\u003cp\u003eA presentation made with JavaFX\u003c/p\u003e\n",
-      "scriptRef": "javafx-presentation/JFXPresentation.java",
-      "command": "javafx-presentation@yostane",
-      "fullcommand": "jbang javafx-presentation@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "devoxxuk-2025",
-      "description": "\u003cp\u003eDevoxx UK 2025: scripting on the JVM with JBang. Content is optimized for 720p display.\u003c/p\u003e\n",
-      "scriptRef": "jbang-devoxxuk2025/jbang_devoxxuk2025.java",
-      "command": "devoxxuk-2025@yostane",
-      "fullcommand": "jbang devoxxuk-2025@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/192943590?v\u003d4",
-      "repoOwner": "laYN57192e",
-      "repoName": "FIjoz4R98Y",
-      "alias": "karate",
-      "scriptRef": "io.karatelabs:karate-core:1.5.0:all",
-      "command": "karate@laYN57192e/FIjoz4R98Y",
-      "fullcommand": "jbang karate@laYN57192e/FIjoz4R98Y",
-      "link": "https://github.com/laYN57192e/FIjoz4R98Y/blob/5b7fc535fcb8c7b2ce4072706b8eb62693e99601/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1814558?v\u003d4",
-      "repoOwner": "SemonCat",
-      "repoName": "karate-grpcurl",
-      "alias": "karate-grpcurl",
-      "scriptRef": "karate-grpcurl-fatjar.jar",
-      "command": "karate-grpcurl@SemonCat/karate-grpcurl",
-      "fullcommand": "jbang karate-grpcurl@SemonCat/karate-grpcurl",
-      "link": "https://github.com/SemonCat/karate-grpcurl/blob/cee506e882147ffeec0c40271eccd45117da9637/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "quarkus-ghsa-v3h5-jw6m-6m42",
-      "alias": "revapi-update",
-      "scriptRef": "RevapiUpdate.java",
-      "command": "revapi-update@quarkusio/quarkus-ghsa-v3h5-jw6m-6m42~.jbang",
-      "fullcommand": "jbang revapi-update@quarkusio/quarkus-ghsa-v3h5-jw6m-6m42~.jbang",
-      "link": "https://github.com/quarkusio/quarkus-ghsa-v3h5-jw6m-6m42/blob/996730b8e924f8c96b6f46c97d0fab1c0bf9b9a4/.jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1279749?v\u003d4",
-      "repoOwner": "gsmet",
-      "repoName": "quarkus-renovate",
-      "alias": "revapi-update",
-      "scriptRef": "RevapiUpdate.java",
-      "command": "revapi-update@gsmet/quarkus-renovate~.jbang",
-      "fullcommand": "jbang revapi-update@gsmet/quarkus-renovate~.jbang",
-      "link": "https://github.com/gsmet/quarkus-renovate/blob/8b5aa6bf9175688d52c240c092ef82dd78c21626/.jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/2318030?v\u003d4",
-      "repoOwner": "brunobat",
-      "repoName": "private_quarkus",
-      "alias": "revapi-update",
-      "scriptRef": "RevapiUpdate.java",
-      "command": "revapi-update@brunobat/private_quarkus~.jbang",
-      "fullcommand": "jbang revapi-update@brunobat/private_quarkus~.jbang",
-      "link": "https://github.com/brunobat/private_quarkus/blob/5ad2f1c6681b85b97eb1ce8f0d67163634fe7ced/.jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/38693920?v\u003d4",
-      "repoOwner": "TarekBenSalama",
-      "repoName": "quarkus",
-      "alias": "revapi-update",
-      "scriptRef": "RevapiUpdate.java",
-      "command": "revapi-update@TarekBenSalama/quarkus~.jbang",
-      "fullcommand": "jbang revapi-update@TarekBenSalama/quarkus~.jbang",
-      "link": "https://github.com/TarekBenSalama/quarkus/blob/3f5257be5a82e7376c97b28e7dd43fc9abc03ae9/.jbang/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "jbang-fmt",
-      "description": "\u003cp\u003eA script that formats JBang Java example files for use in the JBang documentation\u003c/p\u003e\n",
-      "scriptRef": "jbang-fmt@jbangdev/jbang-fmt",
-      "command": "jbang-fmt@codacy-open-source-projects-scans/jbang~docs/modules/ROOT/examples",
-      "fullcommand": "jbang jbang-fmt@codacy-open-source-projects-scans/jbang~docs/modules/ROOT/examples",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/docs/modules/ROOT/examples/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/112608403?v\u003d4",
-      "repoOwner": "RnKkOrM0",
-      "repoName": "RNeKl31Y",
-      "alias": "karate",
-      "scriptRef": "io.karatelabs:karate-core:1.5.0:all",
-      "command": "karate@RnKkOrM0/RNeKl31Y",
-      "fullcommand": "jbang karate@RnKkOrM0/RNeKl31Y",
-      "link": "https://github.com/RnKkOrM0/RNeKl31Y/blob/3c52fbb4b9cde12fbc7c2c770e4c86e6053b2f12/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/112548146?v\u003d4",
-      "repoOwner": "0J27VWx",
-      "repoName": "UNi57cV7lgY",
-      "alias": "karate",
-      "scriptRef": "io.karatelabs:karate-core:1.5.0:all",
-      "command": "karate@0J27VWx/UNi57cV7lgY",
-      "fullcommand": "jbang karate@0J27VWx/UNi57cV7lgY",
-      "link": "https://github.com/0J27VWx/UNi57cV7lgY/blob/d0739ae02ad3d2fdc306107569a6b0a5b230dd09/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/114464014?v\u003d4",
-      "repoOwner": "jJLVccUB2i",
-      "repoName": "NWwzXcD5Y",
-      "alias": "karate",
-      "scriptRef": "io.karatelabs:karate-core:1.5.0:all",
-      "command": "karate@jJLVccUB2i/NWwzXcD5Y",
-      "fullcommand": "jbang karate@jJLVccUB2i/NWwzXcD5Y",
-      "link": "https://github.com/jJLVccUB2i/NWwzXcD5Y/blob/d32de0e7dcc68a09f0c164cbae48cf6c4d02fa17/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/87857052?v\u003d4",
-      "repoOwner": "hamidme101",
-      "repoName": "dashboard-api-automation",
-      "alias": "karate",
-      "scriptRef": "io.karatelabs:karate-core:1.5.0:all",
-      "command": "karate@hamidme101/dashboard-api-automation",
-      "fullcommand": "jbang karate@hamidme101/dashboard-api-automation",
-      "link": "https://github.com/hamidme101/dashboard-api-automation/blob/6288a27d7ec54a4fde9f5a9eccdcc2c6f6d04cf5/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/175750835?v\u003d4",
-      "repoOwner": "ParapluOU",
-      "repoName": "formhandle-sdk",
-      "alias": "formhandle",
-      "description": "\u003cp\u003eCLI for FormHandle — form submissions as email\u003c/p\u003e\n",
-      "scriptRef": "src/main/java/dev/formhandle/cli/Main.java",
-      "command": "formhandle@ParapluOU/formhandle-sdk~java",
-      "fullcommand": "jbang formhandle@ParapluOU/formhandle-sdk~java",
-      "link": "https://github.com/ParapluOU/formhandle-sdk/blob/d732b64d0af1f0477d30bfadcb72bbfe7c1da9b1/java/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/62888618?v\u003d4",
-      "repoOwner": "ayagmar",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-forge",
-      "description": "\u003cp\u003eKeyboard-first Quarkus project generator TUI\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/ayagmar/quarkus-forge/releases/download/v0.6.5/quarkus-forge-jvm.jar",
-      "command": "quarkus-forge@ayagmar",
-      "fullcommand": "jbang quarkus-forge@ayagmar",
-      "link": "https://github.com/ayagmar/jbang-catalog/blob/266844b5f558b6a8e550b8c255d5825941c90570/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/62888618?v\u003d4",
-      "repoOwner": "ayagmar",
-      "repoName": "jbang-catalog",
-      "alias": "quarkus-forge-headless",
-      "description": "\u003cp\u003eQuarkus project generator headless CLI (no TUI dependencies)\u003c/p\u003e\n",
-      "scriptRef": "https://github.com/ayagmar/quarkus-forge/releases/download/v0.6.5/quarkus-forge-headless.jar",
-      "command": "quarkus-forge-headless@ayagmar",
-      "fullcommand": "jbang quarkus-forge-headless@ayagmar",
-      "link": "https://github.com/ayagmar/jbang-catalog/blob/266844b5f558b6a8e550b8c255d5825941c90570/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/878933?v\u003d4",
-      "repoOwner": "butelo",
-      "repoName": "pi-java",
-      "alias": "pi-java",
-      "description": "\u003cp\u003eTUI Code Agent in Java\u003c/p\u003e\n",
-      "scriptRef": "src/main/java/com/example/pijava/App.java",
-      "command": "pi-java@butelo/pi-java",
-      "fullcommand": "jbang pi-java@butelo/pi-java",
-      "link": "https://github.com/butelo/pi-java/blob/d8d444059d6bb8c87ea61efac7d1d40804096d18/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1588543?v\u003d4",
-      "repoOwner": "pdudits",
-      "repoName": "jbang-catalog",
-      "alias": "bunana",
-      "scriptRef": "bunana.java",
-      "command": "bunana@pdudits",
-      "fullcommand": "jbang bunana@pdudits",
-      "link": "https://github.com/pdudits/jbang-catalog/blob/208cfca0c538d112def65d6d716b6512455e45a6/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/120025512?v\u003d4",
-      "repoOwner": "ep-infosec",
-      "repoName": "33_apache_sling-whiteboard",
-      "alias": "start",
-      "description": "\u003cp\u003eStart Apache Sling\u003c/p\u003e\n",
-      "scriptRef": "jbang/SlingStarter.java",
-      "command": "start@ep-infosec/33_apache_sling-whiteboard",
-      "fullcommand": "jbang start@ep-infosec/33_apache_sling-whiteboard",
-      "link": "https://github.com/ep-infosec/33_apache_sling-whiteboard/blob/269824630144cc4fc5f78b9f9a43080e9ea245d6/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/120025512?v\u003d4",
-      "repoOwner": "ep-infosec",
-      "repoName": "33_apache_sling-whiteboard",
-      "alias": "repoinitValidator",
-      "description": "\u003cp\u003eValidate a Repoinit script\u003c/p\u003e\n",
-      "scriptRef": "jbang/RepoinitValidator.java",
-      "command": "repoinitValidator@ep-infosec/33_apache_sling-whiteboard",
-      "fullcommand": "jbang repoinitValidator@ep-infosec/33_apache_sling-whiteboard",
-      "link": "https://github.com/ep-infosec/33_apache_sling-whiteboard/blob/269824630144cc4fc5f78b9f9a43080e9ea245d6/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/120025512?v\u003d4",
-      "repoOwner": "ep-infosec",
-      "repoName": "33_apache_sling-whiteboard",
-      "alias": "jvmVersion",
-      "description": "\u003cp\u003eRun with a specific JVM version\u003c/p\u003e\n",
-      "scriptRef": "jbang/jvmVersion.java",
-      "command": "jvmVersion@ep-infosec/33_apache_sling-whiteboard",
-      "fullcommand": "jbang jvmVersion@ep-infosec/33_apache_sling-whiteboard",
-      "link": "https://github.com/ep-infosec/33_apache_sling-whiteboard/blob/269824630144cc4fc5f78b9f9a43080e9ea245d6/jbang-catalog.json"
+      "icon": "https://avatars.githubusercontent.com/u/11964329?v=4",
+      "link": "https://github.com/debezium/jbang-catalog/blob/0c2fe579ea0067942e8b723c9d5dede919de2194/jbang-catalog.json",
+      "aliases": [],
+      "templates": [
+        {
+          "a": "capturing:postgres",
+          "c": "capturing:postgres@debezium",
+          "d": "<p>Debezium Capturing boilerplate for PostgreSQL</p>\n"
+        },
+        {
+          "a": "capturing:mysql",
+          "c": "capturing:mysql@debezium",
+          "d": "<p>Debezium Capturing boilerplate for MySql</p>\n"
+        },
+        {
+          "a": "capturing:mariadb",
+          "c": "capturing:mariadb@debezium",
+          "d": "<p>Debezium Capturing boilerplate for MariaDB</p>\n"
+        },
+        {
+          "a": "capturing:mongodb",
+          "c": "capturing:mongodb@debezium",
+          "d": "<p>Debezium Capturing boilerplate for MongoDB</p>\n"
+        },
+        {
+          "a": "capturing:sqlserver",
+          "c": "capturing:sqlserver@debezium",
+          "d": "<p>Debezium Capturing boilerplate for Microsoft Sql Server</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "nandorholozsnyak",
+      "name": "jbang-cloud",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/11406183?v=4",
+      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json",
+      "aliases": [],
+      "templates": [
+        {
+          "a": "q-aws-lambda",
+          "c": "q-aws-lambda@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template</p>\n"
+        },
+        {
+          "a": "q-aws-lambda-tf",
+          "c": "q-aws-lambda-tf@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template with Terraform template. Use the -Dnative-function flag to have native image based Terraform resources</p>\n"
+        },
+        {
+          "a": "q-aws-lambda-sqs",
+          "c": "q-aws-lambda-sqs@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template with incoming SQS event</p>\n"
+        },
+        {
+          "a": "q-aws-lambda-sqs-tf",
+          "c": "q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template with incoming SQS event</p>\n"
+        },
+        {
+          "a": "q-aws-lambda-s3",
+          "c": "q-aws-lambda-s3@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template with incoming S3 event</p>\n"
+        },
+        {
+          "a": "q-aws-lambda-s3-tf",
+          "c": "q-aws-lambda-s3-tf@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template with incoming S3 event</p>\n"
+        },
+        {
+          "a": "q-aws-lambda-ecs-event-tf",
+          "c": "q-aws-lambda-ecs-event-tf@nandorholozsnyak/jbang-cloud",
+          "d": "<p>Quarkus AWS Lambda template to handle ECS event</p>\n"
+        }
+      ]
+    },
+    {
+      "owner": "kmos",
+      "name": "debezium-catalog",
+      "stars": 0,
+      "icon": "https://avatars.githubusercontent.com/u/8403734?v=4",
+      "link": "https://github.com/kmos/debezium-catalog/blob/46facae6c2987f8f5082d24f327ad97376a82698/jbang-catalog.json",
+      "aliases": [],
+      "templates": [
+        {
+          "a": "capturing",
+          "c": "capturing@kmos/debezium-catalog",
+          "d": "<p>Simple Debezium Capturing script</p>\n"
+        }
+      ]
     }
-  ],
-  "templates": [
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "gpt",
-      "description": "\u003cp\u003eTemplate using ChatGPT (requires --preview and OPENAI_API_KEY)\u003c/p\u003e\n",
-      "command": "gpt@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t gpt@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "gpt.kt",
-      "description": "\u003cp\u003eTemplate using ChatGPT for kotlin (requires --preview and OPENAI_API_KEY)\u003c/p\u003e\n",
-      "command": "gpt.kt@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t gpt.kt@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "gpt.groovy",
-      "description": "\u003cp\u003eTemplate using ChatGPT for groovy (requires --preview and OPENAI_API_KEY)\u003c/p\u003e\n",
-      "command": "gpt.groovy@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t gpt.groovy@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "agent",
-      "description": "\u003cp\u003eAgent template\u003c/p\u003e\n",
-      "command": "agent@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t agent@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "cli",
-      "description": "\u003cp\u003eCLI template\u003c/p\u003e\n",
-      "command": "cli@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t cli@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "hello",
-      "description": "\u003cp\u003eBasic Hello World template\u003c/p\u003e\n",
-      "command": "hello@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t hello@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "hello.kt",
-      "description": "\u003cp\u003eBasic kotlin Hello World template\u003c/p\u003e\n",
-      "command": "hello.kt@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t hello.kt@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "hello.groovy",
-      "description": "\u003cp\u003eBasic groovy Hello World template\u003c/p\u003e\n",
-      "command": "hello.groovy@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t hello.groovy@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "readme.md",
-      "description": "\u003cp\u003eBasic markdown readme template\u003c/p\u003e\n",
-      "command": "readme.md@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t readme.md@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "qcli",
-      "description": "\u003cp\u003eQuarkus CLI template\u003c/p\u003e\n",
-      "command": "qcli@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t qcli@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "qmetrics",
-      "description": "\u003cp\u003eQuarkus Metrics template\u003c/p\u003e\n",
-      "command": "qmetrics@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t qmetrics@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1792,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang",
-      "alias": "qrest",
-      "description": "\u003cp\u003eQuarkus REST template\u003c/p\u003e\n",
-      "command": "qrest@jbangdev/jbang~src/main/resources",
-      "fullcommand": "jbang init -t qrest@jbangdev/jbang~src/main/resources",
-      "link": "https://github.com/jbangdev/jbang/blob/9927a5494083ed76983dfd2d0390d3c22ff48fa6/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 1587,
-      "icon_url": "https://avatars.githubusercontent.com/u/4430336?v\u003d4",
-      "repoOwner": "oracle",
-      "repoName": "graalpython",
-      "alias": "graalpy",
-      "description": "\u003cp\u003eBasic template for Graal Python java file.\u003c/p\u003e\n",
-      "command": "graalpy@oracle/graalpython",
-      "fullcommand": "jbang init -t graalpy@oracle/graalpython",
-      "link": "https://github.com/oracle/graalpython/blob/9ecf016b5dbfb237f7b8425664fbfc6dbaa84a7d/jbang-catalog.json"
-    },
-    {
-      "stars": 1587,
-      "icon_url": "https://avatars.githubusercontent.com/u/4430336?v\u003d4",
-      "repoOwner": "oracle",
-      "repoName": "graalpython",
-      "alias": "graalpy_local_repo",
-      "description": "\u003cp\u003eBasic template for Graal Python java file. Mainly for testing.\u003c/p\u003e\n",
-      "command": "graalpy_local_repo@oracle/graalpython",
-      "fullcommand": "jbang init -t graalpy_local_repo@oracle/graalpython",
-      "link": "https://github.com/oracle/graalpython/blob/9ecf016b5dbfb237f7b8425664fbfc6dbaa84a7d/jbang-catalog.json"
-    },
-    {
-      "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "pg-reproducer",
-      "description": "\u003cp\u003eTemplate for a test with PostgreSQL using Junit 4, Vert.x Unit and Testcontainers\u003c/p\u003e\n",
-      "command": "pg-reproducer@hibernate/hibernate-reactive",
-      "fullcommand": "jbang init -t pg-reproducer@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
-    },
-    {
-      "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "mysql-reproducer",
-      "description": "\u003cp\u003eTemplate for a test with MySQL using Junit 4, Vert.x Unit and Testcontainers\u003c/p\u003e\n",
-      "command": "mysql-reproducer@hibernate/hibernate-reactive",
-      "fullcommand": "jbang init -t mysql-reproducer@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
-    },
-    {
-      "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "mariadb-reproducer",
-      "description": "\u003cp\u003eTemplate for a test with MariaDB using Junit 4, Vert.x Unit and Testcontainers\u003c/p\u003e\n",
-      "command": "mariadb-reproducer@hibernate/hibernate-reactive",
-      "fullcommand": "jbang init -t mariadb-reproducer@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
-    },
-    {
-      "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "db2-reproducer",
-      "description": "\u003cp\u003eTemplate for a test with Db2 using Junit 4, Vert.x Unit and Testcontainers\u003c/p\u003e\n",
-      "command": "db2-reproducer@hibernate/hibernate-reactive",
-      "fullcommand": "jbang init -t db2-reproducer@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
-    },
-    {
-      "stars": 465,
-      "icon_url": "https://avatars.githubusercontent.com/u/348262?v\u003d4",
-      "repoOwner": "hibernate",
-      "repoName": "hibernate-reactive",
-      "alias": "cockroachdb-reproducer",
-      "description": "\u003cp\u003eTemplate for a test with CockroachDB using Junit 4, Vert.x Unit and Testcontainers\u003c/p\u003e\n",
-      "command": "cockroachdb-reproducer@hibernate/hibernate-reactive",
-      "fullcommand": "jbang init -t cockroachdb-reproducer@hibernate/hibernate-reactive",
-      "link": "https://github.com/hibernate/hibernate-reactive/blob/20c36921206a46a4c28633b1e23b84c167075f5d/jbang-catalog.json"
-    },
-    {
-      "stars": 188,
-      "icon_url": "https://avatars.githubusercontent.com/u/69191779?v\u003d4",
-      "repoOwner": "quarkiverse",
-      "repoName": "quarkus-mcp-servers",
-      "alias": "mcp",
-      "command": "mcp@quarkiverse/quarkus-mcp-servers",
-      "fullcommand": "jbang init -t mcp@quarkiverse/quarkus-mcp-servers",
-      "link": "https://github.com/quarkiverse/quarkus-mcp-servers/blob/33113ca2950051a3f12b52c61c66d5a340d3df70/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "github",
-      "description": "\u003cp\u003eSimple cli to querying github\u003c/p\u003e\n",
-      "command": "github@jbangdev",
-      "fullcommand": "jbang init -t github@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "qmcp",
-      "description": "\u003cp\u003eSimple cli to querying github\u003c/p\u003e\n",
-      "command": "qmcp@jbangdev",
-      "fullcommand": "jbang init -t qmcp@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "jitpack",
-      "description": "\u003cp\u003eInitializes a bare-bone jitpack.yml to enable publishing a jbang script as a maven artifact via jitpack.\u003c/p\u003e\n\u003cp\u003eExample: \u003ccode\u003ejbang init -t jitpack@jbangdev myapp.java\u003c/code\u003e and then commit this to github and visit jitpack.io to trigger its build.\u003c/p\u003e\n",
-      "command": "jitpack@jbangdev",
-      "fullcommand": "jbang init -t jitpack@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "renovate",
-      "description": "\u003cp\u003eInitializes a renovate.json to enable automatic management of any .java file //DEPS section.\u003c/p\u003e\n\u003cp\u003eExample: \u003ccode\u003ejbang init -t renovate@jbangdev .github/renovate.json\u003c/code\u003e and then commit this to github and if you installed \u003ca rel\u003d\"nofollow\" href\u003d\"https://github.com/apps/renovate\"\u003ehttps://github.com/apps/renovate\u003c/a\u003e renovate will make issues and PR\u0027s for dependency updates.\u003c/p\u003e\n",
-      "command": "renovate@jbangdev",
-      "fullcommand": "jbang init -t renovate@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 60,
-      "icon_url": "https://avatars.githubusercontent.com/u/60074102?v\u003d4",
-      "repoOwner": "jbangdev",
-      "repoName": "jbang-catalog",
-      "alias": "junit",
-      "description": "\u003cp\u003eBasic template for JUnit tests\u003c/p\u003e\n",
-      "command": "junit@jbangdev",
-      "fullcommand": "jbang init -t junit@jbangdev",
-      "link": "https://github.com/jbangdev/jbang-catalog/blob/01f8ae36d08ee17ff9187709d41a5f04c268e6dc/jbang-catalog.json"
-    },
-    {
-      "stars": 30,
-      "icon_url": "https://avatars.githubusercontent.com/u/5173767?v\u003d4",
-      "repoOwner": "worldline",
-      "repoName": "learning-kotlin",
-      "alias": "jfxkt-legacy",
-      "description": "\u003cp\u003eSingle file JavaFX application\u003c/p\u003e\n",
-      "command": "jfxkt-legacy@worldline/learning-kotlin",
-      "fullcommand": "jbang init -t jfxkt-legacy@worldline/learning-kotlin",
-      "link": "https://github.com/worldline/learning-kotlin/blob/bffc395ae1426a7a0b822e7e9902ae00130b23c3/jbang-catalog.json"
-    },
-    {
-      "stars": 30,
-      "icon_url": "https://avatars.githubusercontent.com/u/5173767?v\u003d4",
-      "repoOwner": "worldline",
-      "repoName": "learning-kotlin",
-      "alias": "jfxkt",
-      "description": "\u003cp\u003eSingle file JavaFX application that defined the UI with code (no fxml)\u003c/p\u003e\n",
-      "command": "jfxkt@worldline/learning-kotlin",
-      "fullcommand": "jbang init -t jfxkt@worldline/learning-kotlin",
-      "link": "https://github.com/worldline/learning-kotlin/blob/bffc395ae1426a7a0b822e7e9902ae00130b23c3/jbang-catalog.json"
-    },
-    {
-      "stars": 9,
-      "icon_url": "https://avatars.githubusercontent.com/u/4430336?v\u003d4",
-      "repoOwner": "oracle",
-      "repoName": "graalpy-extensions",
-      "alias": "graalpy",
-      "description": "\u003cp\u003eBasic template for Graal Python java file.\u003c/p\u003e\n",
-      "command": "graalpy@oracle/graalpy-extensions",
-      "fullcommand": "jbang init -t graalpy@oracle/graalpy-extensions",
-      "link": "https://github.com/oracle/graalpy-extensions/blob/8ce0773fa86fbd4238f1e312137bedda9994f8fc/jbang-catalog.json"
-    },
-    {
-      "stars": 8,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "jbang-catalog",
-      "alias": "githubbot",
-      "description": "\u003cp\u003eExample of making a github app\u003c/p\u003e\n",
-      "command": "githubbot@quarkusio",
-      "fullcommand": "jbang init -t githubbot@quarkusio",
-      "link": "https://github.com/quarkusio/jbang-catalog/blob/7e27f03eb8119a1279d0e04d61bc5f5c1083a3db/jbang-catalog.json"
-    },
-    {
-      "stars": 7,
-      "icon_url": "https://avatars.githubusercontent.com/u/47638783?v\u003d4",
-      "repoOwner": "quarkusio",
-      "repoName": "quarkus-insights",
-      "alias": "ByteSize",
-      "description": "\u003cp\u003eByteSize example from Quarkus Insights #53 about java memory\u003c/p\u003e\n",
-      "command": "ByteSize@quarkusio/quarkus-insights",
-      "fullcommand": "jbang init -t ByteSize@quarkusio/quarkus-insights",
-      "link": "https://github.com/quarkusio/quarkus-insights/blob/12ce1c265a05081dd47448c2dd82e9eb755690b8/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "helloworld",
-      "description": "\u003cp\u003emaxs first template\u003c/p\u003e\n",
-      "command": "helloworld@maxandersen",
-      "fullcommand": "jbang init -t helloworld@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "gcal",
-      "description": "\u003cp\u003eGoogle Calendar API Template\u003c/p\u003e\n",
-      "command": "gcal@maxandersen",
-      "fullcommand": "jbang init -t gcal@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "dashboard",
-      "command": "dashboard@maxandersen",
-      "fullcommand": "jbang init -t dashboard@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 6,
-      "icon_url": "https://avatars.githubusercontent.com/u/54129?v\u003d4",
-      "repoOwner": "maxandersen",
-      "repoName": "jbang-catalog",
-      "alias": "setup-jitpack",
-      "description": "\u003cp\u003eSetup Jitpack for a java/mvn based project\u003c/p\u003e\n",
-      "command": "setup-jitpack@maxandersen",
-      "fullcommand": "jbang init -t setup-jitpack@maxandersen",
-      "link": "https://github.com/maxandersen/jbang-catalog/blob/c51b7898e7b9910f3f90385c0363b3ba7779dedc/jbang-catalog.json"
-    },
-    {
-      "stars": 5,
-      "icon_url": "https://avatars.githubusercontent.com/u/156902772?v\u003d4",
-      "repoOwner": "jbanghub",
-      "repoName": "jbang-catalog",
-      "alias": "jbang-catalog",
-      "description": "\u003cp\u003eTemplate for creating a new JBang catalog hosted on github with automatic renovate updates\u003c/p\u003e\n",
-      "command": "jbang-catalog@jbanghub",
-      "fullcommand": "jbang init -t jbang-catalog@jbanghub",
-      "link": "https://github.com/jbanghub/jbang-catalog/blob/fa0f2f7f0b6fa7973c6295c2c8f42d82a0229e80/jbang-catalog.json"
-    },
-    {
-      "stars": 3,
-      "icon_url": "https://avatars.githubusercontent.com/u/201120?v\u003d4",
-      "repoOwner": "neo4j",
-      "repoName": "jbang-catalog",
-      "alias": "run-neo4j",
-      "description": "\u003cp\u003eBasic Neo4j Driver example\u003c/p\u003e\n",
-      "command": "run-neo4j@neo4j",
-      "fullcommand": "jbang init -t run-neo4j@neo4j",
-      "link": "https://github.com/neo4j/jbang-catalog/blob/9259448738fbd017e8193feb46b293a394fec178/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-spring-boot",
-      "alias": "SpringBoot2",
-      "description": "\u003cp\u003eSpring Boot 2 Java App Template\u003c/p\u003e\n",
-      "command": "SpringBoot2@linux-china/jbang-spring-boot",
-      "fullcommand": "jbang init -t SpringBoot2@linux-china/jbang-spring-boot",
-      "link": "https://github.com/linux-china/jbang-spring-boot/blob/cc36d6a2a8d68868eb8aa2ae5ee0e81f797d0fd1/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-spring-boot",
-      "alias": "SpringBoot3",
-      "description": "\u003cp\u003eSpring Boot 3 Java App Template\u003c/p\u003e\n",
-      "command": "SpringBoot3@linux-china/jbang-spring-boot",
-      "fullcommand": "jbang init -t SpringBoot3@linux-china/jbang-spring-boot",
-      "link": "https://github.com/linux-china/jbang-spring-boot/blob/cc36d6a2a8d68868eb8aa2ae5ee0e81f797d0fd1/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-spring-boot",
-      "alias": "SpringBoot2Kt",
-      "description": "\u003cp\u003eSpring Boot 2 Kotlin App Template\u003c/p\u003e\n",
-      "command": "SpringBoot2Kt@linux-china/jbang-spring-boot",
-      "fullcommand": "jbang init -t SpringBoot2Kt@linux-china/jbang-spring-boot",
-      "link": "https://github.com/linux-china/jbang-spring-boot/blob/cc36d6a2a8d68868eb8aa2ae5ee0e81f797d0fd1/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-spring-boot",
-      "alias": "SpringBoot3Kt",
-      "description": "\u003cp\u003eSpring Boot 3 Kotlin App Template\u003c/p\u003e\n",
-      "command": "SpringBoot3Kt@linux-china/jbang-spring-boot",
-      "fullcommand": "jbang init -t SpringBoot3Kt@linux-china/jbang-spring-boot",
-      "link": "https://github.com/linux-china/jbang-spring-boot/blob/cc36d6a2a8d68868eb8aa2ae5ee0e81f797d0fd1/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/11964329?v\u003d4",
-      "repoOwner": "debezium",
-      "repoName": "jbang-catalog",
-      "alias": "capturing:postgres",
-      "description": "\u003cp\u003eDebezium Capturing boilerplate for PostgreSQL\u003c/p\u003e\n",
-      "command": "capturing:postgres@debezium",
-      "fullcommand": "jbang init -t capturing:postgres@debezium",
-      "link": "https://github.com/debezium/jbang-catalog/blob/0c2fe579ea0067942e8b723c9d5dede919de2194/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/11964329?v\u003d4",
-      "repoOwner": "debezium",
-      "repoName": "jbang-catalog",
-      "alias": "capturing:mysql",
-      "description": "\u003cp\u003eDebezium Capturing boilerplate for MySql\u003c/p\u003e\n",
-      "command": "capturing:mysql@debezium",
-      "fullcommand": "jbang init -t capturing:mysql@debezium",
-      "link": "https://github.com/debezium/jbang-catalog/blob/0c2fe579ea0067942e8b723c9d5dede919de2194/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/11964329?v\u003d4",
-      "repoOwner": "debezium",
-      "repoName": "jbang-catalog",
-      "alias": "capturing:mariadb",
-      "description": "\u003cp\u003eDebezium Capturing boilerplate for MariaDB\u003c/p\u003e\n",
-      "command": "capturing:mariadb@debezium",
-      "fullcommand": "jbang init -t capturing:mariadb@debezium",
-      "link": "https://github.com/debezium/jbang-catalog/blob/0c2fe579ea0067942e8b723c9d5dede919de2194/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/11964329?v\u003d4",
-      "repoOwner": "debezium",
-      "repoName": "jbang-catalog",
-      "alias": "capturing:mongodb",
-      "description": "\u003cp\u003eDebezium Capturing boilerplate for MongoDB\u003c/p\u003e\n",
-      "command": "capturing:mongodb@debezium",
-      "fullcommand": "jbang init -t capturing:mongodb@debezium",
-      "link": "https://github.com/debezium/jbang-catalog/blob/0c2fe579ea0067942e8b723c9d5dede919de2194/jbang-catalog.json"
-    },
-    {
-      "stars": 2,
-      "icon_url": "https://avatars.githubusercontent.com/u/11964329?v\u003d4",
-      "repoOwner": "debezium",
-      "repoName": "jbang-catalog",
-      "alias": "capturing:sqlserver",
-      "description": "\u003cp\u003eDebezium Capturing boilerplate for Microsoft Sql Server\u003c/p\u003e\n",
-      "command": "capturing:sqlserver@debezium",
-      "fullcommand": "jbang init -t capturing:sqlserver@debezium",
-      "link": "https://github.com/debezium/jbang-catalog/blob/0c2fe579ea0067942e8b723c9d5dede919de2194/jbang-catalog.json"
-    },
-    {
-      "stars": 1,
-      "icon_url": "https://avatars.githubusercontent.com/u/46711?v\u003d4",
-      "repoOwner": "linux-china",
-      "repoName": "jbang-alibaba-spring-cloud",
-      "alias": "RocketmqConsumer",
-      "description": "\u003cp\u003eBasic template for RocketMQ Consumer\u003c/p\u003e\n",
-      "command": "RocketmqConsumer@linux-china/jbang-alibaba-spring-cloud",
-      "fullcommand": "jbang init -t RocketmqConsumer@linux-china/jbang-alibaba-spring-cloud",
-      "link": "https://github.com/linux-china/jbang-alibaba-spring-cloud/blob/f2ada0151ed8ff71400697df152aec1e3c2d8458/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "adventofcode",
-      "alias": "kt",
-      "description": "\u003cp\u003eKotlin Template\u003c/p\u003e\n",
-      "command": "kt@yostane/adventofcode",
-      "fullcommand": "jbang init -t kt@yostane/adventofcode",
-      "link": "https://github.com/yostane/adventofcode/blob/df00369dcb0ad3765d8c7c7537d28723b7aed468/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-catalog-doc-generator",
-      "alias": "q-aws-lambda-tf",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template with Terraform template. Use the -Dnative-function flag to have native image based Terraform resources\u003c/p\u003e\n",
-      "command": "q-aws-lambda-tf@nandorholozsnyak/jbang-catalog-doc-generator",
-      "fullcommand": "jbang init -t q-aws-lambda-tf@nandorholozsnyak/jbang-catalog-doc-generator",
-      "link": "https://github.com/nandorholozsnyak/jbang-catalog-doc-generator/blob/5b0a0d3627b30fe46c51d7f1ef1dba50a5c8dd34/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template\u003c/p\u003e\n",
-      "command": "q-aws-lambda@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda-tf",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template with Terraform template. Use the -Dnative-function flag to have native image based Terraform resources\u003c/p\u003e\n",
-      "command": "q-aws-lambda-tf@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda-tf@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda-sqs",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template with incoming SQS event\u003c/p\u003e\n",
-      "command": "q-aws-lambda-sqs@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda-sqs@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda-sqs-tf",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template with incoming SQS event\u003c/p\u003e\n",
-      "command": "q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda-s3",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template with incoming S3 event\u003c/p\u003e\n",
-      "command": "q-aws-lambda-s3@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda-s3@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda-s3-tf",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template with incoming S3 event\u003c/p\u003e\n",
-      "command": "q-aws-lambda-s3-tf@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda-s3-tf@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/11406183?v\u003d4",
-      "repoOwner": "nandorholozsnyak",
-      "repoName": "jbang-cloud",
-      "alias": "q-aws-lambda-ecs-event-tf",
-      "description": "\u003cp\u003eQuarkus AWS Lambda template to handle ECS event\u003c/p\u003e\n",
-      "command": "q-aws-lambda-ecs-event-tf@nandorholozsnyak/jbang-cloud",
-      "fullcommand": "jbang init -t q-aws-lambda-ecs-event-tf@nandorholozsnyak/jbang-cloud",
-      "link": "https://github.com/nandorholozsnyak/jbang-cloud/blob/db9ec860df88a2055069acaeccd0ea02cbfaa765/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "agent",
-      "description": "\u003cp\u003eAgent template\u003c/p\u003e\n",
-      "command": "agent@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t agent@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "cli",
-      "description": "\u003cp\u003eCLI template\u003c/p\u003e\n",
-      "command": "cli@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t cli@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "hello",
-      "description": "\u003cp\u003eBasic Hello World template\u003c/p\u003e\n",
-      "command": "hello@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t hello@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "hello.kt",
-      "description": "\u003cp\u003eBasic kotlin Hello World template\u003c/p\u003e\n",
-      "command": "hello.kt@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t hello.kt@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "qcli",
-      "description": "\u003cp\u003eQuarkus CLI template\u003c/p\u003e\n",
-      "command": "qcli@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t qcli@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "qmetrics",
-      "description": "\u003cp\u003eQuarkus Metrics template\u003c/p\u003e\n",
-      "command": "qmetrics@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t qmetrics@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/88204064?v\u003d4",
-      "repoOwner": "aswiniqaconsultants",
-      "repoName": "jbangdev",
-      "alias": "qrest",
-      "description": "\u003cp\u003eQuarkus REST template\u003c/p\u003e\n",
-      "command": "qrest@aswiniqaconsultants/jbangdev~src/main/resources",
-      "fullcommand": "jbang init -t qrest@aswiniqaconsultants/jbangdev~src/main/resources",
-      "link": "https://github.com/aswiniqaconsultants/jbangdev/blob/fab2f812876055da40b11bf0a175329a7b3ac277/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "test",
-      "command": "test@codacy-open-source-projects-scans/jbang~itests",
-      "fullcommand": "jbang init -t test@codacy-open-source-projects-scans/jbang~itests",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/itests/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/5173767?v\u003d4",
-      "repoOwner": "worldline",
-      "repoName": "jbang-catalog",
-      "alias": "jfxkt-legacy",
-      "description": "\u003cp\u003eSingle file JavaFX application template\u003c/p\u003e\n",
-      "command": "jfxkt-legacy@worldline",
-      "fullcommand": "jbang init -t jfxkt-legacy@worldline",
-      "link": "https://github.com/worldline/jbang-catalog/blob/d91d3ff764252280c598ac48363434fe8eca0851/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/5173767?v\u003d4",
-      "repoOwner": "worldline",
-      "repoName": "jbang-catalog",
-      "alias": "jfxkt",
-      "description": "\u003cp\u003eSingle file JavaFX application template. View are defined by code (no fxml)\u003c/p\u003e\n",
-      "command": "jfxkt@worldline",
-      "fullcommand": "jbang init -t jfxkt@worldline",
-      "link": "https://github.com/worldline/jbang-catalog/blob/d91d3ff764252280c598ac48363434fe8eca0851/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/91672412?v\u003d4",
-      "repoOwner": "valyc0",
-      "repoName": "quarkus-mcp-servers-java-docker",
-      "alias": "mcp",
-      "command": "mcp@valyc0/quarkus-mcp-servers-java-docker",
-      "fullcommand": "jbang init -t mcp@valyc0/quarkus-mcp-servers-java-docker",
-      "link": "https://github.com/valyc0/quarkus-mcp-servers-java-docker/blob/90a377ca56d3f810a036565dbcbd0fee024c0e0a/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/8403734?v\u003d4",
-      "repoOwner": "kmos",
-      "repoName": "debezium-catalog",
-      "alias": "capturing",
-      "description": "\u003cp\u003eSimple Debezium Capturing script\u003c/p\u003e\n",
-      "command": "capturing@kmos/debezium-catalog",
-      "fullcommand": "jbang init -t capturing@kmos/debezium-catalog",
-      "link": "https://github.com/kmos/debezium-catalog/blob/46facae6c2987f8f5082d24f327ad97376a82698/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "implicit-main",
-      "description": "\u003cp\u003eJava 24 file wiht Implicitly Declared Classes and Instance Main Method\u003c/p\u003e\n",
-      "command": "implicit-main@yostane",
-      "fullcommand": "jbang init -t implicit-main@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "compact-main",
-      "description": "\u003cp\u003eJava 25+ file wiht that uses a compact main class\u003c/p\u003e\n",
-      "command": "compact-main@yostane",
-      "fullcommand": "jbang init -t compact-main@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "ktor-rest",
-      "description": "\u003cp\u003eKtor Rest API server with JSON serialization\u003c/p\u003e\n",
-      "command": "ktor-rest@yostane",
-      "fullcommand": "jbang init -t ktor-rest@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "javafx",
-      "description": "\u003cp\u003eA starter JavaFX app\u003c/p\u003e\n",
-      "command": "javafx@yostane",
-      "fullcommand": "jbang init -t javafx@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/1958676?v\u003d4",
-      "repoOwner": "yostane",
-      "repoName": "jbang-catalog",
-      "alias": "javafx-presentation",
-      "description": "\u003cp\u003eA presentation made with JavaFX\u003c/p\u003e\n",
-      "command": "javafx-presentation@yostane",
-      "fullcommand": "jbang init -t javafx-presentation@yostane",
-      "link": "https://github.com/yostane/jbang-catalog/blob/4582a78e5d03dc371be0d08b1c4ab7e55b65e26e/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "gpt",
-      "description": "\u003cp\u003eTemplate using ChatGPT (requires --preview and OPENAI_API_KEY)\u003c/p\u003e\n",
-      "command": "gpt@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t gpt@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "gpt.kt",
-      "description": "\u003cp\u003eTemplate using ChatGPT for kotlin (requires --preview and OPENAI_API_KEY)\u003c/p\u003e\n",
-      "command": "gpt.kt@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t gpt.kt@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "gpt.groovy",
-      "description": "\u003cp\u003eTemplate using ChatGPT for groovy (requires --preview and OPENAI_API_KEY)\u003c/p\u003e\n",
-      "command": "gpt.groovy@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t gpt.groovy@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "agent",
-      "description": "\u003cp\u003eAgent template\u003c/p\u003e\n",
-      "command": "agent@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t agent@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "cli",
-      "description": "\u003cp\u003eCLI template\u003c/p\u003e\n",
-      "command": "cli@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t cli@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "hello",
-      "description": "\u003cp\u003eBasic Hello World template\u003c/p\u003e\n",
-      "command": "hello@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t hello@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "hello.kt",
-      "description": "\u003cp\u003eBasic kotlin Hello World template\u003c/p\u003e\n",
-      "command": "hello.kt@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t hello.kt@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "hello.groovy",
-      "description": "\u003cp\u003eBasic groovy Hello World template\u003c/p\u003e\n",
-      "command": "hello.groovy@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t hello.groovy@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "readme.md",
-      "description": "\u003cp\u003eBasic markdown readme template\u003c/p\u003e\n",
-      "command": "readme.md@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t readme.md@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "qcli",
-      "description": "\u003cp\u003eQuarkus CLI template\u003c/p\u003e\n",
-      "command": "qcli@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t qcli@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "qmetrics",
-      "description": "\u003cp\u003eQuarkus Metrics template\u003c/p\u003e\n",
-      "command": "qmetrics@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t qmetrics@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    },
-    {
-      "stars": 0,
-      "icon_url": "https://avatars.githubusercontent.com/u/131972263?v\u003d4",
-      "repoOwner": "codacy-open-source-projects-scans",
-      "repoName": "jbang",
-      "alias": "qrest",
-      "description": "\u003cp\u003eQuarkus REST template\u003c/p\u003e\n",
-      "command": "qrest@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "fullcommand": "jbang init -t qrest@codacy-open-source-projects-scans/jbang~src/main/resources",
-      "link": "https://github.com/codacy-open-source-projects-scans/jbang/blob/afabde7640593c15d2ddad0758a0adbcda8a5c2b/src/main/resources/jbang-catalog.json"
-    }
-  ],
-  "templateCount": 84
+  ]
 }


### PR DESCRIPTION
Group data by catalog (repo) instead of flat alias lists with repeated repo info. Each catalog entry contains repo metadata (owner, name, stars, icon, link) with aliases and templates as children.

**Size reduction:**
- 532KB → 314KB pretty-printed (41% smaller)
- 445KB → 236KB minified (47% smaller)
- 55KB → 50KB gzipped (9% smaller over the wire)

**Structure (before):**
```json
{ "aliases": [{ "stars": 11335, "icon_url": "...", "repoOwner": "apple", "repoName": "pkl", ... }, ...] }
```

**Structure (after):**
```json
{ "catalogs": [{ "owner": "apple", "name": "pkl", "stars": 11335, "icon": "...", "aliases": [{"a": "pkl", "c": "pkl@apple/pkl", ...}], "templates": [] }] }
```

Updated `.github/appstore.java` generator and `content/appstore.html` frontend.