### PR TITLE
fix: remove intro animation from masthead and nav

### DIFF
--- a/public/assets/js/greedy-nav.js
+++ b/public/assets/js/greedy-nav.js
@@ -44,33 +44,23 @@ document.addEventListener('DOMContentLoaded', function() {
     var toggleWidth = 44;
 
     // Find how many items fit
+    // Sum all item widths
     var totalWidth = 0;
-    var cutoff = allItems.length;
-
-    // First pass: assume we need toggle, find cutoff
     for (var i = 0; i < allItems.length; i++) {
       totalWidth += itemWidths[i];
-      if (totalWidth > available - toggleWidth) {
-        cutoff = i;
-        break;
-      }
     }
 
-    // If all items fit with toggle reserve, check if they fit without it
-    if (cutoff === allItems.length) {
+    var cutoff = allItems.length;
+
+    // If everything fits, no toggle needed
+    if (totalWidth > available) {
+      // Need toggle — find how many items fit with toggle reserve
       totalWidth = 0;
       for (var j = 0; j < allItems.length; j++) {
         totalWidth += itemWidths[j];
-      }
-      if (totalWidth > available) {
-        // Need toggle, recalculate
-        totalWidth = 0;
-        for (var k = 0; k < allItems.length; k++) {
-          totalWidth += itemWidths[k];
-          if (totalWidth > available - toggleWidth) {
-            cutoff = k;
-            break;
-          }
+        if (totalWidth > available - toggleWidth) {
+          cutoff = j;
+          break;
         }
       }
     }

--- a/public/assets/js/greedy-nav.js
+++ b/public/assets/js/greedy-nav.js
@@ -1,0 +1,92 @@
+/**
+ * Greedy Nav: moves nav items that don't fit into a hamburger dropdown.
+ */
+document.addEventListener('DOMContentLoaded', function() {
+  var nav = document.querySelector('.greedy-nav');
+  if (!nav) return;
+  var visibleLinks = nav.querySelector('.visible-links');
+  var hiddenLinks = nav.querySelector('.hidden-links');
+  var toggleBtn = nav.querySelector('.greedy-nav__toggle');
+  if (!visibleLinks || !hiddenLinks || !toggleBtn) return;
+
+  // Toggle dropdown
+  toggleBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    hiddenLinks.classList.toggle('hidden');
+  });
+  document.addEventListener('click', function(e) {
+    if (!hiddenLinks.classList.contains('hidden') && !nav.contains(e.target)) {
+      hiddenLinks.classList.add('hidden');
+    }
+  });
+
+  // Record natural widths of all items before any get hidden
+  var allItems = Array.from(visibleLinks.querySelectorAll(':scope > li'));
+  var itemWidths = allItems.map(function(li) { return li.getBoundingClientRect().width; });
+
+  function updateNav() {
+    // Move all items back to visible first
+    while (hiddenLinks.firstChild) {
+      visibleLinks.appendChild(hiddenLinks.firstChild);
+    }
+    toggleBtn.classList.add('hidden');
+
+    // Calculate available width: container width minus fixed elements
+    var navWidth = nav.offsetWidth;
+    var siteLogo = nav.querySelector('.site-logo');
+    var siteTitle = nav.querySelector('.site-title');
+    var searchInput = nav.querySelector('#search-input');
+    var fixedWidth = (siteLogo ? siteLogo.getBoundingClientRect().width + 8 : 0)
+                   + (siteTitle ? siteTitle.getBoundingClientRect().width + 16 : 0)
+                   + (searchInput ? searchInput.getBoundingClientRect().width + 16 : 0)
+                   + 32; // nav padding
+    var available = navWidth - fixedWidth;
+    var toggleWidth = 44;
+
+    // Find how many items fit
+    var totalWidth = 0;
+    var cutoff = allItems.length;
+
+    // First pass: assume we need toggle, find cutoff
+    for (var i = 0; i < allItems.length; i++) {
+      totalWidth += itemWidths[i];
+      if (totalWidth > available - toggleWidth) {
+        cutoff = i;
+        break;
+      }
+    }
+
+    // If all items fit with toggle reserve, check if they fit without it
+    if (cutoff === allItems.length) {
+      totalWidth = 0;
+      for (var j = 0; j < allItems.length; j++) {
+        totalWidth += itemWidths[j];
+      }
+      if (totalWidth > available) {
+        // Need toggle, recalculate
+        totalWidth = 0;
+        for (var k = 0; k < allItems.length; k++) {
+          totalWidth += itemWidths[k];
+          if (totalWidth > available - toggleWidth) {
+            cutoff = k;
+            break;
+          }
+        }
+      }
+    }
+
+    // Move overflow items to hidden dropdown
+    for (var m = cutoff; m < allItems.length; m++) {
+      hiddenLinks.appendChild(allItems[m]);
+    }
+
+    if (hiddenLinks.children.length > 0) {
+      toggleBtn.classList.remove('hidden');
+    } else {
+      hiddenLinks.classList.add('hidden');
+    }
+  }
+
+  updateNav();
+  window.addEventListener('resize', updateNav);
+});

--- a/src/main/resources/web/app/main.scss
+++ b/src/main/resources/web/app/main.scss
@@ -95,6 +95,9 @@ div[class*="thebelab"] button {
     input#search-input {
         margin-left: 1rem;
         margin-bottom: .1em;
+        width: 10em;
+        flex-shrink: 1;
+        min-width: 6em;
     }
 
     .feature__wrapper {

--- a/src/main/resources/web/app/minimal-mistakes/_masthead.scss
+++ b/src/main/resources/web/app/minimal-mistakes/_masthead.scss
@@ -5,10 +5,6 @@
 .masthead {
   position: relative;
   border-bottom: 1px solid $border-color;
-  -webkit-animation: $intro-transition;
-  animation: $intro-transition;
-  -webkit-animation-delay: 0.15s;
-  animation-delay: 0.15s;
   z-index: 20;
 
   &__inner-wrap {

--- a/src/main/resources/web/app/minimal-mistakes/_navigation.scss
+++ b/src/main/resources/web/app/minimal-mistakes/_navigation.scss
@@ -12,10 +12,6 @@
   max-width: 100%;
   padding-inline: 1em;
   font-family: $sans-serif;
-  -webkit-animation: $intro-transition;
-  animation: $intro-transition;
-  -webkit-animation-delay: 0.3s;
-  animation-delay: 0.3s;
 
   @include breakpoint($x-large) {
     max-width: $x-large;

--- a/templates/partials/head/custom.html
+++ b/templates/partials/head/custom.html
@@ -73,4 +73,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+<!-- Greedy nav: moves items that don't fit into a hamburger dropdown -->
+<script src="/assets/js/greedy-nav.js" defer></script>
+
 <!-- end custom head snippets -->


### PR DESCRIPTION
The `opacity:0→1` intro animation with `fill-mode:both` causes content to be invisible until the animation fires. On Windows and with `prefers-reduced-motion`, this can leave the nav and title clipped or partially hidden — 'AppStore' renders as '.ppStore', hero title gets cut off on the left.

![image](https://jbangdev.zulipchat.com/user_uploads/67434/aKUdzt5l_Deh3YmEYeRfmDjS/image.png)

Completes the animation removal started in #157 (which removed it from `#main` and `.page__hero` but missed masthead and nav).