### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/appstore-update.yml
+++ b/.github/workflows/appstore-update.yml
@@ -9,8 +9,8 @@ jobs:
   appstore-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
       - run: jbang statsquery2.java --token ${{ secrets.CLOUDFLARE_TOKEN }} --account ${{ secrets.CLOUDFLARE_ACCOUNT }}
         env:
           GITHUB_TOKEN: ${{ secrets.APPSTORE_GH_TOKEN != '' && secrets.APPSTORE_GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
           git push
       - name: Update website
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1
         with:
           workflow: github-pages
           token: ${{ secrets.JEKYLL_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 5000
           fetch-tags: false
@@ -27,7 +27,7 @@ jobs:
         run: echo ${{ github.event.number }} > ./target/roq/pr-id.txt
 
       - name: Publishing directory for PR preview
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: site
           path: ./target/roq

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Website
         uses: ./.github/actions/build-website
@@ -42,4 +42,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
     - name: Download PR Artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
       with:
         run-id: ${{ github.event.workflow_run.id }}
         name: site
@@ -48,7 +48,7 @@ jobs:
         PR_ID: ${{  steps.pr.outputs.id }}
 
     - name: Update PR status comment on success
-      uses: quarkusio/action-helpers@main
+      uses: quarkusio/action-helpers@b53791b65e22e8d7e5d7f84b8f546be8fb3e8f6d # main
       with:
         action: maintain-one-comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
 
         body-marker: <!-- Preview status comment marker -->
     - name: Update PR status comment on failure
-      uses: quarkusio/action-helpers@main
+      uses: quarkusio/action-helpers@b53791b65e22e8d7e5d7f84b8f546be8fb3e8f6d # main
       if: ${{ failure() }}
       with:
         action: maintain-one-comment

--- a/.github/workflows/preview_teardown.yml
+++ b/.github/workflows/preview_teardown.yml
@@ -12,7 +12,7 @@ jobs:
         id: deploy
         run: npx surge teardown https://jbangdev-preview-pr-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
       - name: Update PR status comment
-        uses: quarkusio/action-helpers@main
+        uses: quarkusio/action-helpers@b53791b65e22e8d7e5d7f84b8f546be8fb3e8f6d # main
         if: env.NOT_TORNDOWN != 'true'
         with:
           action: maintain-one-comment


### PR DESCRIPTION
Pin all action references to full-length commit SHAs for supply chain security.

This is required for enabling the org-level policy:
**Require actions to be pinned to a full-length commit SHA**

Original version tags are preserved as comments for readability.
Consider adding Dependabot for GitHub Actions to keep pins updated:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```